### PR TITLE
luci-app-frp: align UI with TOML configuration

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -1,140 +1,1364 @@
 'use strict';
 'require view';
-'require ui';
 'require form';
 'require rpc';
 'require tools.widgets as widgets';
 
-//	[Widget, Option, Title, Description, {Param: 'Value'}],
+/*
+ * Important:
+ *
+ * This LuCI page writes UCI options into /etc/config/frpc.
+ * UCI option names must not contain ".".
+ *
+ * Therefore we keep UCI-safe option names here, then let init/generator script
+ * convert them to frp TOML keys, for example:
+ *
+ *   server_addr          -> serverAddr
+ *   server_port          -> serverPort
+ *   protocol             -> transport.protocol
+ *   wire_protocol        -> transport.wireProtocol
+ *   tls_enable           -> transport.tls.enable
+ *   token                -> auth.token
+ *   admin_addr           -> webServer.addr
+ *   use_encryption       -> transport.useEncryption
+ *   use_compression      -> transport.useCompression
+ *   sk                   -> secretKey
+ *
+ * Do NOT use option names like "transport.protocol" in LuCI form options.
+ */
+
+/*
+ * Debug-only TOML mapping. Keep these TOML: hints in the JS source for
+ * troubleshooting generated configs, but do not show them in LuCI form text
+ * and do not wrap them in _().
+ *
+ * common.client_id -> TOML: clientID
+ * common.user -> TOML: user
+ * common.server_addr -> TOML: serverAddr
+ * common.server_port -> TOML: serverPort
+ * common.nat_hole_stun_server -> TOML: natHoleStunServer
+ * common.login_fail_exit -> TOML: loginFailExit
+ * common.dns_server -> TOML: dnsServer
+ * common.start -> TOML: start
+ * common.udp_packet_size -> TOML: udpPacketSize
+ * common.includes -> TOML: includes
+ * common.authentication_method -> TOML: auth.method
+ * common.token -> TOML: auth.token
+ * common.auth_additional_scopes -> TOML: auth.additionalScopes
+ * common.token_source_type -> TOML: auth.tokenSource.type
+ * common.token_source_file_path -> TOML: auth.tokenSource.file.path
+ * common.token_source_exec_command -> TOML: auth.tokenSource.exec.command
+ * common.token_source_exec_args -> TOML: auth.tokenSource.exec.args
+ * common.token_source_exec_env -> TOML: auth.tokenSource.exec.env
+ * common.oidc_client_id -> TOML: auth.oidc.clientID
+ * common.oidc_client_secret -> TOML: auth.oidc.clientSecret
+ * common.oidc_audience -> TOML: auth.oidc.audience
+ * common.oidc_scope -> TOML: auth.oidc.scope
+ * common.oidc_token_endpoint_url -> TOML: auth.oidc.tokenEndpointURL
+ * common.oidc_additional_endpoint_params -> TOML: auth.oidc.additionalEndpointParams
+ * common.oidc_trusted_ca_file -> TOML: auth.oidc.trustedCaFile
+ * common.oidc_insecure_skip_verify -> TOML: auth.oidc.insecureSkipVerify
+ * common.oidc_proxy_url -> TOML: auth.oidc.proxyURL
+ * common.dial_server_timeout -> TOML: transport.dialServerTimeout
+ * common.dial_server_keepalive -> TOML: transport.dialServerKeepalive
+ * common.http_proxy -> TOML: transport.proxyURL
+ * common.pool_count -> TOML: transport.poolCount
+ * common.tcp_mux -> TOML: transport.tcpMux
+ * common.tcp_mux_keepalive_interval -> TOML: transport.tcpMuxKeepaliveInterval
+ * common.protocol -> TOML: transport.protocol
+ * common.wire_protocol -> TOML: transport.wireProtocol
+ * common.connect_server_local_ip -> TOML: transport.connectServerLocalIP
+ * common.heartbeat_interval -> TOML: transport.heartbeatInterval
+ * common.heartbeat_timeout -> TOML: transport.heartbeatTimeout
+ * common.tls_enable -> TOML: transport.tls.enable
+ * common.tls_cert_file -> TOML: transport.tls.certFile
+ * common.tls_key_file -> TOML: transport.tls.keyFile
+ * common.tls_trusted_ca_file -> TOML: transport.tls.trustedCaFile
+ * common.tls_server_name -> TOML: transport.tls.serverName
+ * common.disable_custom_tls_first_byte -> TOML: transport.tls.disableCustomTLSFirstByte
+ * common.quic_keepalive_period -> TOML: transport.quic.keepalivePeriod
+ * common.quic_max_idle_timeout -> TOML: transport.quic.maxIdleTimeout
+ * common.quic_max_incoming_streams -> TOML: transport.quic.maxIncomingStreams
+ * common.admin_addr -> TOML: webServer.addr
+ * common.admin_port -> TOML: webServer.port
+ * common.admin_user -> TOML: webServer.user
+ * common.admin_pwd -> TOML: webServer.password
+ * common.admin_tls_cert_file -> TOML: webServer.tls.certFile
+ * common.admin_tls_key_file -> TOML: webServer.tls.keyFile
+ * common.assets_dir -> TOML: webServer.assetsDir
+ * common.pprof_enable -> TOML: webServer.pprofEnable
+ * common.feature_gates -> TOML: featureGates
+ * common.virtual_net_address -> TOML: virtualNet.address
+ * common.store_path -> TOML: store.path
+ * common.metadatas -> TOML: metadatas
+ * common.log_file -> TOML: log.to
+ * common.log_level -> TOML: log.level
+ * common.log_max_days -> TOML: log.maxDays
+ * common.disable_log_color -> TOML: log.disablePrintColor
+ * conf.name -> TOML: proxies[].name / visitors[].name
+ * conf.type -> TOML: proxies[].type / visitors[].type
+ * conf.enabled -> TOML: proxies[].enabled / visitors[].enabled
+ * conf.local_ip -> TOML: proxies[].localIP
+ * conf.local_port -> TOML: proxies[].localPort
+ * conf.remote_port -> TOML: proxies[].remotePort
+ * conf.custom_domains -> TOML: proxies[].customDomains
+ * conf.subdomain -> TOML: proxies[].subdomain
+ * conf.locations -> TOML: proxies[].locations
+ * conf.http_user -> TOML: proxies[].httpUser
+ * conf.http_pwd -> TOML: proxies[].httpPassword
+ * conf.route_by_http_user -> TOML: proxies[].routeByHTTPUser
+ * conf.host_header_rewrite -> TOML: proxies[].hostHeaderRewrite
+ * conf.request_headers -> TOML: proxies[].requestHeaders.set
+ * conf.response_headers -> TOML: proxies[].responseHeaders.set
+ * conf.multiplexer -> TOML: proxies[].multiplexer
+ * conf.group -> TOML: proxies[].loadBalancer.group
+ * conf.group_key -> TOML: proxies[].loadBalancer.groupKey
+ * conf.health_check_type -> TOML: proxies[].healthCheck.type
+ * conf.health_check_url -> TOML: proxies[].healthCheck.path
+ * conf.health_check_headers -> TOML: proxies[].healthCheck.httpHeaders
+ * conf.sk -> TOML: proxies[].secretKey / visitors[].secretKey
+ * conf.allow_users -> TOML: proxies[].allowUsers
+ * conf.server_user -> TOML: visitors[].serverUser
+ * conf.server_name -> TOML: visitors[].serverName
+ * conf.bind_addr -> TOML: visitors[].bindAddr
+ * conf.bind_port -> TOML: visitors[].bindPort
+ * conf.visitor_protocol -> TOML: visitors[].protocol
+ * conf.keep_tunnel_open -> TOML: visitors[].keepTunnelOpen
+ * conf.fallback_to -> TOML: visitors[].fallbackTo
+ * conf.plugin -> TOML: proxies[].plugin.type / visitors[].plugin.type
+ */
+
 const startupConf = [
-	[form.Flag, 'stdout', _('Log stdout')],
-	[form.Flag, 'stderr', _('Log stderr')],
+	[form.Flag, 'stdout', _('Log stdout'), null,
+	{
+		enabled: '1',
+		disabled: '0',
+		default: '1',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Flag, 'stderr', _('Log stderr'), null,
+	{
+		enabled: '1',
+		disabled: '0',
+		default: '1',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
 	[widgets.UserSelect, 'user', _('Run daemon as user')],
 	[widgets.GroupSelect, 'group', _('Run daemon as group')],
-	[form.Flag, 'respawn', _('Respawn when crashed')],
-	[form.DynamicList, 'env', _('Environment variable'), _('OS environments pass to frp for config file template, see %s.'.format('<a href="https://github.com/fatedier/frp#configuration-file-template">frp README</a>')), {placeholder: 'ENV_NAME=value'}],
-	[form.DynamicList, 'conf_inc', _('Additional configs'), _('Config files include in temporary config file'), {placeholder: '/etc/frp/frpc.d/frpc_full.ini'}]
+
+	[form.Flag, 'respawn', _('Respawn when crashed'), null,
+	{
+		enabled: '1',
+		disabled: '0',
+		default: '1',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.DynamicList, 'env', _('Environment variable'),
+	_('OS environments passed to frp for config file template, see %s.').format('<a href="https://github.com/fatedier/frp#configuration-file-template">frp README</a>'),
+	{
+		placeholder: 'ENV_NAME=value',
+		validate: function (section_id, value) {
+			return validateEnv(value);
+		}
+	}],
+
+	[form.DynamicList, 'conf_inc', _('Additional configs'),
+	_('Extra root-level configuration fragments included before generated proxy and visitor sections. Use frp includes or per-proxy raw settings for proxy/visitor tables.'),
+	{
+		datatype: 'file',
+		placeholder: '/etc/frp/frpc.d/frpc_extra.toml'
+	}]
 ];
 
-const commonConf = [
-	[form.Value, 'server_addr', _('Server address'), _('ServerAddr specifies the address of the server to connect to.<br />By default, this value is "127.0.0.1".'), {datatype: 'host'}],
-	[form.Value, 'server_port', _('Server port'), _('ServerPort specifies the port to connect to the server on.<br />By default, this value is 7000.'), {datatype: 'port'}],
-	[form.Value, 'http_proxy', _('HTTP proxy'), _('HttpProxy specifies a proxy address to connect to the server through. If this value is "", the server will be connected to directly.<br />By default, this value is read from the "http_proxy" environment variable.')],
-	[form.Value, 'log_file', _('Log file'), _('LogFile specifies a file where logs will be written to. This value will only be used if LogWay is set appropriately.<br />By default, this value is "console".')],
-	[form.ListValue, 'log_level', _('Log level'), _('LogLevel specifies the minimum log level. Valid values are "trace", "debug", "info", "warn", and "error".<br />By default, this value is "info".'), {values: ['trace', 'debug', 'info', 'warn', 'error']}],
-	[form.Value, 'log_max_days', _('Log max days'), _('LogMaxDays specifies the maximum number of days to store log information before deletion. This is only used if LogWay == "file".<br />By default, this value is 0.'), {datatype: 'uinteger'}],
-	[form.Flag, 'disable_log_color', _('Disable log color'), _('DisableLogColor disables log colors when LogWay == "console" when set to true.'), {datatype: 'bool', default: 'false'}],
-	[form.Value, 'token', _('Token'), _('Token specifies the authorization token used to create keys to be sent to the server. The server must have a matching token for authorization to succeed. <br />By default, this value is "".')],
-	[form.Value, 'admin_addr', _('Admin address'), _('AdminAddr specifies the address that the admin server binds to.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
-	[form.Value, 'admin_port', _('Admin port'), _('AdminPort specifies the port for the admin server to listen on. If this value is 0, the admin server will not be started.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'admin_user', _('Admin user'), _('AdminUser specifies the username that the admin server will use for login.<br />By default, this value is "admin".')],
-	[form.Value, 'admin_pwd', _('Admin password'), _('AdminPwd specifies the password that the admin server will use for login.<br />By default, this value is "admin".'), {password: true}],
-	[form.Value, 'assets_dir', _('Assets dir'), _('AssetsDir specifies the local directory that the admin server will load resources from. If this value is "", assets will be loaded from the bundled executable using statik.<br />By default, this value is "".')],
-	[form.Flag, 'tcp_mux', _('TCP mux'), _('TcpMux toggles TCP stream multiplexing. This allows multiple requests from a client to share a single TCP connection. If this value is true, the server must have TCP multiplexing enabled as well.<br />By default, this value is true.'), {datatype: 'bool', default: 'true'}],
-	[form.Value, 'user', _('User'), _('User specifies a prefix for proxy names to distinguish them from other clients. If this value is not "", proxy names will automatically be changed to "{user}.{proxy_name}".<br />By default, this value is "".')],
-	[form.Flag, 'login_fail_exit', _('Exit when login fail'), _('LoginFailExit controls whether or not the client should exit after a failed login attempt. If false, the client will retry until a login attempt succeeds.<br />By default, this value is true.'), {datatype: 'bool', default: 'true'}],
-	[form.ListValue, 'protocol', _('Protocol'), _('Protocol specifies the protocol to use when interacting with the server. Valid values are "tcp", "kcp", "quic" and "websocket".<br />By default, this value is "tcp".'), {values: ['tcp', 'kcp', 'quic', 'websocket']}],
-	[form.Flag, 'tls_enable', _('TLS'), _('TLS Enable specifies whether or not TLS should be used when communicating with the server.'), {datatype: 'bool'}],
-	[form.Value, 'heartbeat_interval', _('Heartbeat interval'), _('HeartBeatInterval specifies at what interval heartbeats are sent to the server, in seconds. It is not recommended to change this value.<br />By default, this value is 30.'), {datatype: 'uinteger'}],
-	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'), _('HeartBeatTimeout specifies the maximum allowed heartbeat response delay before the connection is terminated, in seconds. It is not recommended to change this value.<br />By default, this value is 90.'), {datatype: 'uinteger'}],
-	[form.DynamicList, '_', _('Additional settings'), _('This list can be used to specify some additional parameters which have not been included in this LuCI.'), {placeholder: 'Key-A=Value-A'}]
+const commonBaseConf = [
+	[form.Value, 'client_id', _('Client ID'),
+	_('Optional unique identifier for this frpc instance.')],
+
+	[form.Value, 'server_addr', _('Server address'),
+	_('Address of the frps server.'),
+	{ datatype: 'host', rmempty: false, placeholder: '127.0.0.1' }],
+
+	[form.Value, 'server_port', _('Server port'),
+	_('Port of the frps server. Default is 7000.'),
+	{ datatype: 'port', rmempty: false, placeholder: '7000' }],
+
+	[form.Value, 'user', _('Proxy name prefix'),
+	_('Prefix for proxy names. If set, proxy names become {user}.{proxy}.')],
+
+	[form.Value, 'nat_hole_stun_server', _('NAT hole STUN server'),
+	_('STUN server used for NAT traversal.'),
+	{ placeholder: 'stun.easyvoip.com:3478' }],
+
+	[form.Flag, 'login_fail_exit', _('Exit when login fails'),
+	_('Exit frpc when the first login fails.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'dns_server', _('DNS server'),
+	_('Custom DNS server used by frpc.'),
+	{ datatype: 'ipaddr', placeholder: '8.8.8.8' }],
+
+	[form.DynamicList, 'start', _('Start proxies / visitors'),
+	_('Only start specified proxies or visitors. Empty means start all.'),
+	{ placeholder: 'ssh' }],
+
+	[form.Value, 'udp_packet_size', _('UDP packet size'),
+	_('UDP packet size in bytes. Should match frps. Default is 1500.'),
+	{ datatype: 'uinteger', placeholder: '1500' }],
+
+	[form.DynamicList, 'includes', _('Include config files'),
+	_('Additional config files included by frpc.'),
+	{ placeholder: './confd/*.toml' }]
+];
+
+const commonAuthConf = [
+	[form.ListValue, 'authentication_method', _('Authentication method'),
+	_('Authentication method.'),
+	{ values: [['token', 'token'], ['oidc', 'oidc']], default: 'token' }],
+
+	[form.Value, 'token', _('Token'),
+	_('Token used for authentication.'),
+	{
+		depends: { authentication_method: 'token' },
+		password: true,
+		validate: function (section_id, value) {
+			const tokenSourceType = this.section.getOption('token_source_type');
+
+			if (value && tokenSourceType && tokenSourceType.formvalue(section_id))
+				return _('Token and token source are mutually exclusive.');
+
+			return true;
+		}
+	}],
+
+	[form.MultiValue, 'auth_additional_scopes', _('Additional auth scopes'),
+	_('Additional scopes to include authentication information.'),
+	{ values: ['HeartBeats', 'NewWorkConns'] }],
+
+	[form.ListValue, 'token_source_type', _('Token source type'),
+	_('Load token from an external source. File reads the token from a local file; exec runs a command and requires frp unsafe permission. Mutually exclusive with auth.token.'),
+	{
+		depends: { authentication_method: 'token' },
+		values: [['', _('Disabled')], ['file', 'file'], ['exec', 'exec']],
+		rmempty: true,
+		validate: function (section_id, value) {
+			const token = this.section.getOption('token');
+
+			if (value && token && token.formvalue(section_id))
+				return _('Token and token source are mutually exclusive.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'token_source_file_path', _('Token source file'),
+	_('Path of token file.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'file'
+		},
+		datatype: 'file',
+		rmempty: false,
+		validate: function (section_id, value) {
+			const tokenSourceType = this.section.getOption('token_source_type');
+
+			if (
+				tokenSourceType &&
+				tokenSourceType.formvalue(section_id) === 'file' &&
+				!String(value || '').trim()
+			)
+				return _('Token source file path is required when token source type is file.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'token_source_exec_command', _('Token source command'),
+	_('Command used to obtain the token. The init script adds --allow-unsafe=TokenSourceExec when this source type is used.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'exec'
+		},
+		datatype: 'file',
+		rmempty: false,
+		validate: function (section_id, value) {
+			const tokenSourceType = this.section.getOption('token_source_type');
+
+			if (
+				tokenSourceType &&
+				tokenSourceType.formvalue(section_id) === 'exec' &&
+				!String(value || '').trim()
+			)
+				return _('Token source command is required when token source type is exec.');
+
+			return true;
+		}
+	}],
+
+	[form.DynamicList, 'token_source_exec_args', _('Token source command arguments'),
+	_('Command arguments passed to token source exec.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'exec'
+		},
+		placeholder: '--format'
+	}],
+
+	[form.DynamicList, 'token_source_exec_env', _('Token source environment'),
+	_('Environment variables passed to token source exec. Use KEY=value.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'exec'
+		},
+		placeholder: 'TOKEN_SERVICE=production',
+		validate: function (section_id, value) {
+			return validateEnv(value);
+		}
+	}],
+
+	[form.Value, 'oidc_client_id', _('OIDC client ID'),
+	_('Configuration key: auth.oidc.clientID.'),
+	{ depends: { authentication_method: 'oidc' } }],
+
+	[form.Value, 'oidc_client_secret', _('OIDC client secret'),
+	_('Configuration key: auth.oidc.clientSecret.'),
+	{ depends: { authentication_method: 'oidc' }, password: true }],
+
+	[form.Value, 'oidc_audience', _('OIDC audience'),
+	_('Configuration key: auth.oidc.audience.'),
+	{ depends: { authentication_method: 'oidc' } }],
+
+	[form.Value, 'oidc_scope', _('OIDC scope'),
+	_('Configuration key: auth.oidc.scope.'),
+	{ depends: { authentication_method: 'oidc' } }],
+
+	[form.Value, 'oidc_token_endpoint_url', _('OIDC token endpoint URL'),
+	_('Configuration key: auth.oidc.tokenEndpointURL.'),
+	{ depends: { authentication_method: 'oidc' }, datatype: 'url' }],
+
+	[form.DynamicList, 'oidc_additional_endpoint_params', _('OIDC additional endpoint params'),
+	_('Additional OIDC token endpoint params. Use key=value.'),
+	{
+		depends: { authentication_method: 'oidc' },
+		placeholder: 'audience=https://dev.auth.com/api/v2/',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}],
+
+	[form.Value, 'oidc_trusted_ca_file', _('OIDC trusted CA file'),
+	_('Custom CA certificate file for OIDC endpoint.'),
+	{ depends: { authentication_method: 'oidc' }, datatype: 'file' }],
+
+	[form.Flag, 'oidc_insecure_skip_verify', _('OIDC insecure skip verify'),
+	_('Skip TLS verification for OIDC endpoint. Not recommended for production.'),
+	{ depends: { authentication_method: 'oidc' }, datatype: 'bool', default: 'false' }],
+
+	[form.Value, 'oidc_proxy_url', _('OIDC proxy URL'),
+	_('Proxy URL for OIDC token endpoint.'),
+	{ depends: { authentication_method: 'oidc' }, datatype: 'url', placeholder: 'http://proxy.example.com:8080' }]
+];
+
+const commonLogConf = [
+	[form.Value, 'log_file', _('Log output'),
+	_('Log output path or console.'),
+	{ placeholder: 'console' }],
+
+	[form.ListValue, 'log_level', _('Log level'),
+	_('Configuration key: log.level.'),
+	{ values: ['trace', 'debug', 'info', 'warn', 'error'], default: 'info' }],
+
+	[form.Value, 'log_max_days', _('Log max days'),
+	_('Maximum number of days to keep logs.'),
+	{ datatype: 'uinteger', placeholder: '3' }],
+
+	[form.Flag, 'disable_log_color', _('Disable log color'),
+	_('Disable log colors when log output is console.'),
+	{ datatype: 'bool', default: 'false' }]
+];
+
+const commonWebConf = [
+	[form.Value, 'admin_addr', _('Web server address'),
+	_('Web server bind address.'),
+	{ datatype: 'host', placeholder: '127.0.0.1' }],
+
+	[form.Value, 'admin_port', _('Web server port'),
+	_('Web server port. Leave empty or set to 0 to disable the web server.'),
+	{ validate: validatePortOrZero, placeholder: '7400' }],
+
+	[form.Value, 'admin_user', _('Web server user'),
+	_('Web server username.'),
+	{ placeholder: 'admin' }],
+
+	[form.Value, 'admin_pwd', _('Web server password'),
+	_('Web server password.'),
+	{ password: true, placeholder: 'change_me_to_a_strong_password' }],
+
+	[form.Flag, 'admin_tls_enable', _('Enable web HTTPS'),
+	_('Enable HTTPS for the frpc web server. This switch controls whether webServer.tls.certFile and webServer.tls.keyFile are emitted.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'false',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'admin_tls_cert_file', _('TLS certificate path'),
+	_('Path to the certificate file used by the HTTPS web server.'),
+	{
+		datatype: 'file',
+		placeholder: '/etc/ssl/acme/example.com.fullchain.crt',
+		retain: true,
+		validate: function (section_id, value) {
+			if (
+				adminWebEnabled(this.section, section_id) &&
+				adminHttpsEnabled(this.section, section_id) &&
+				!String(value || '').trim()
+			)
+				return _('TLS certificate path is required when web HTTPS is enabled.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'admin_tls_key_file', _('TLS private key path'),
+	_('Path to the private key file used by the HTTPS web server.'),
+	{
+		datatype: 'file',
+		placeholder: '/etc/ssl/acme/example.com.key',
+		retain: true,
+		validate: function (section_id, value) {
+			if (
+				adminWebEnabled(this.section, section_id) &&
+				adminHttpsEnabled(this.section, section_id) &&
+				!String(value || '').trim()
+			)
+				return _('TLS private key path is required when web HTTPS is enabled.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'assets_dir', _('Assets dir'),
+	_('Web server assets directory.'),
+	{ datatype: 'directory' }],
+
+	[form.Flag, 'pprof_enable', _('Enable pprof'),
+	_('Enable Go pprof handlers in web server.'),
+	{
+		datatype: 'bool',
+		enabled: 'true',
+		disabled: 'false',
+		default: 'false',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}]
+];
+
+const commonTransportConf = [
+	[form.Value, 'dial_server_timeout', _('Dial server timeout'),
+	_('Timeout in seconds for connecting to frps.'),
+	{ datatype: 'uinteger', placeholder: '10' }],
+
+	[form.Value, 'dial_server_keepalive', _('Dial server keepalive'),
+	_('TCP keepalive interval in seconds. Negative value disables keepalive.'),
+	{ datatype: 'integer', placeholder: '7200' }],
+
+	[form.Value, 'http_proxy', _('Proxy URL'),
+	_('Proxy URL used to connect to frps. Supports http, socks5 and ntlm.'),
+	{ placeholder: 'http://user:passwd@192.168.1.128:8080' }],
+
+	[form.Value, 'pool_count', _('Connection pool count'),
+	_('Connections established in advance.'),
+	{ datatype: 'uinteger', placeholder: '1' }],
+
+	[form.Flag, 'tcp_mux', _('TCP mux'),
+	_('Enable TCP stream multiplexing.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'tcp_mux_keepalive_interval', _('TCP mux keepalive interval'),
+	_('Keepalive interval for TCP mux.'),
+	{ datatype: 'uinteger', placeholder: '30' }],
+
+	[form.ListValue, 'protocol', _('Transport protocol'),
+	_('Transport protocol used to connect to frps.'),
+	{ values: ['tcp', 'kcp', 'quic', 'websocket', 'wss'], default: 'tcp' }],
+
+	[form.ListValue, 'wire_protocol', _('Wire protocol'),
+	_('frp internal wire protocol. v2 requires frps support and must be enabled explicitly.'),
+	{ values: ['v1', 'v2'], default: 'v1' }],
+
+	[form.Value, 'connect_server_local_ip', _('Connect server local IP'),
+	_('Local IP bound when connecting to frps. Only valid for tcp, websocket or wss.'),
+	{
+		datatype: 'ipaddr',
+		depends: [{ protocol: 'tcp' }, { protocol: 'websocket' }, { protocol: 'wss' }],
+		placeholder: '0.0.0.0'
+	}],
+
+	[form.Value, 'heartbeat_interval', _('Heartbeat interval'),
+	_('Heartbeat interval in seconds.'),
+	{ datatype: 'integer', placeholder: '30' }],
+
+	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'),
+	_('Heartbeat timeout in seconds.'),
+	{ datatype: 'integer', placeholder: '90' }]
+];
+
+const commonTlsQuicConf = [
+	[form.Flag, 'tls_enable', _('TLS'),
+	_('Enable TLS when communicating with frps. Since frp v0.50.0, default is true.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'tls_cert_file', _('TLS certificate path'),
+	_('Path to the TLS certificate file.'),
+	{ datatype: 'file', placeholder: '/etc/ssl/frp/client.crt' }],
+
+	[form.Value, 'tls_key_file', _('TLS private key path'),
+	_('Path to the TLS private key file.'),
+	{ datatype: 'file', placeholder: '/etc/ssl/frp/client.key' }],
+
+	[form.Value, 'tls_trusted_ca_file', _('TLS trusted CA path'),
+	_('Path to the trusted CA certificate file.'),
+	{ datatype: 'file', placeholder: '/etc/ssl/frp/ca.crt' }],
+
+	[form.Value, 'tls_server_name', _('TLS server name'),
+	_('Server name used for TLS verification.'),
+	{ placeholder: 'example.com' }],
+
+	[form.Flag, 'disable_custom_tls_first_byte', _('Disable custom TLS first byte'),
+	_('Since frp v0.50.0, default is true.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'quic_keepalive_period', _('QUIC keepalive period'),
+	_('Configuration key: transport.quic.keepalivePeriod.'),
+	{ datatype: 'uinteger', depends: { protocol: 'quic' }, placeholder: '10' }],
+
+	[form.Value, 'quic_max_idle_timeout', _('QUIC max idle timeout'),
+	_('Configuration key: transport.quic.maxIdleTimeout.'),
+	{ datatype: 'uinteger', depends: { protocol: 'quic' }, placeholder: '30' }],
+
+	[form.Value, 'quic_max_incoming_streams', _('QUIC max incoming streams'),
+	_('Configuration key: transport.quic.maxIncomingStreams.'),
+	{ datatype: 'uinteger', depends: { protocol: 'quic' }, placeholder: '100000' }]
+];
+
+const commonAdvancedConf = [
+	[form.DynamicList, 'feature_gates', _('Feature gates'),
+	_('Experimental feature gates. Use key=value, for example VirtualNet=true.'),
+	{
+		placeholder: 'VirtualNet=true',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}],
+
+	[form.Value, 'virtual_net_address', _('VirtualNet address'),
+	_('Virtual network address. Requires VirtualNet feature gate.'),
+	{ placeholder: '100.86.1.1/24' }],
+
+	[form.Value, 'store_path', _('Store file path'),
+	_('Persist runtime proxy and visitor configuration for Web UI or API management.'),
+	{ datatype: 'file', placeholder: '/etc/frp/frpc_store.json' }],
+
+	[form.DynamicList, 'metadatas', _('Client metadata'),
+	_('Additional client metadata. Use key=value.'),
+	{
+		placeholder: 'var1=abc',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}]
+];
+
+const proxyOnlyDepends = [
+	{ type: 'tcp' },
+	{ type: 'udp' },
+	{ type: 'http' },
+	{ type: 'https' },
+	{ type: 'tcpmux' },
+	{ type: 'stcp', role: 'server' },
+	{ type: 'xtcp', role: 'server' },
+	{ type: 'sudp', role: 'server' }
+];
+
+const healthCheckDepends = [
+	{ type: 'tcp' },
+	{ type: 'http' },
+	{ type: 'https' },
+	{ type: 'tcpmux' }
 ];
 
 const baseProxyConf = [
-	[form.Value, 'name', _('Proxy name'), undefined, {rmempty: false, optional: false}],
-	[form.ListValue, 'type', _('Proxy type'), _('ProxyType specifies the type of this proxy. Valid values include "tcp", "udp", "http", "https", "stcp" and "xtcp".<br />By default, this value is "tcp".'), {values: ['tcp', 'udp', 'http', 'https', 'stcp', 'xtcp']}],
-	[form.Flag, 'use_encryption', _('Encryption'), _('UseEncryption controls whether or not communication with the server will be encrypted. Encryption is done using the tokens supplied in the server and client configuration.<br />By default, this value is false.'), {datatype: 'bool'}],
-	[form.Flag, 'use_compression', _('Compression'), _('UseCompression controls whether or not communication with the server will be compressed.<br />By default, this value is false.'), {datatype: 'bool'}],
-	[form.Value, 'local_ip', _('Local IP'), _('LocalIp specifies the IP address or host name to proxy to.'), {datatype: 'host'}],
-	[form.Value, 'local_port', _('Local port'), _('LocalPort specifies the port to proxy to.'), {datatype: 'port'}],
+	[form.Value, 'name', _('Proxy name'), undefined,
+	{ rmempty: false, optional: false }],
+
+	[form.ListValue, 'type', _('Proxy type'),
+	_('Proxy type.'),
+	{ values: ['tcp', 'udp', 'http', 'https', 'stcp', 'xtcp', 'sudp', 'tcpmux'], default: 'tcp' }],
+
+	[form.Flag, 'enabled', _('Enabled'),
+	_('Enable or disable this proxy.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'local_ip', _('Local IP'),
+	_('Local service IP or host.'),
+	{ datatype: 'host', depends: proxyOnlyDepends }],
+
+	[form.Value, 'local_port', _('Local port'),
+	_('Local service port.'),
+	{ datatype: 'port', depends: proxyOnlyDepends }],
+
+	[form.Value, 'remote_port', _('Remote port'),
+	_('Remote port listened by frps. If 0, frps assigns a random port.'),
+	{
+		validate: validatePortOrZero,
+		depends: [{ type: 'tcp' }, { type: 'udp' }],
+		textvalue: function (section_id) {
+			const v = this.cfgvalue(section_id);
+			return v && v !== '0' ? v : '#';
+		}
+	}]
 ];
 
-const bindInfoConf = [
-	[form.Value, 'remote_port', _('Remote port'), _('If remote_port is 0, frps will assign a random port for you'), {datatype: 'port'}]
+const proxyTransportConf = [
+	[form.Value, 'bandwidth_limit', _('Bandwidth limit'),
+	_('Bandwidth limit, for example 1MB.'),
+	{ placeholder: '1MB', depends: proxyOnlyDepends }],
+
+	[form.ListValue, 'bandwidth_limit_mode', _('Bandwidth limit mode'),
+	_('Where to limit bandwidth.'),
+	{ values: ['client', 'server'], default: 'client', depends: proxyOnlyDepends }],
+
+	[form.Flag, 'use_encryption', _('Encryption'),
+	_('Encrypt proxy traffic.'),
+	{ datatype: 'bool', default: 'false' }],
+
+	[form.Flag, 'use_compression', _('Compression'),
+	_('Compress proxy traffic.'),
+	{ datatype: 'bool', default: 'false' }],
+
+	[form.ListValue, 'proxy_protocol_version', _('Proxy protocol version'),
+	_('Use proxy protocol to transfer connection info to local service.'),
+	{ values: [['', _('Disabled')], ['v1', 'v1'], ['v2', 'v2']], rmempty: true, depends: proxyOnlyDepends }]
 ];
 
 const domainConf = [
-	[form.Value, 'custom_domains', _('Custom domains')],
-	[form.Value, 'subdomain', _('Subdomain')],
+	[form.DynamicList, 'custom_domains', _('Custom domains'),
+	_('Configuration key: proxies[].customDomains.'),
+	{ placeholder: 'web01.yourdomain.com' }],
+
+	[form.Value, 'subdomain', _('Subdomain'),
+	_('Configuration key: proxies[].subdomain.')]
 ];
 
 const httpProxyConf = [
-	[form.Value, 'locations', _('Locations')],
-	[form.Value, 'http_user', _('HTTP user')],
-	[form.Value, 'http_pwd', _('HTTP password')],
-	[form.Value, 'host_header_rewrite', _('Host header rewrite')],
-	// [form.Value, 'headers', _('Headers')], // FIXME
+	[form.DynamicList, 'locations', _('Locations'),
+	_('Only valid for HTTP proxy.'),
+	{
+		placeholder: '/',
+		validate: function (section_id, value) {
+			return validateHttpPath(value);
+		}
+	}],
+
+	[form.Value, 'host_header_rewrite', _('Host header rewrite'),
+	_('Rewrite Host header.')],
+
+	[form.DynamicList, 'request_headers', _('Request headers'),
+	_('Set request headers. Use Header=Value.'),
+	{
+		placeholder: 'x-from-where=frp',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}],
+
+	[form.DynamicList, 'response_headers', _('Response headers'),
+	_('Set response headers. Use Header=Value.'),
+	{
+		placeholder: 'foo=bar',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}]
 ];
 
-const stcpProxyConf = [
-	[form.ListValue, 'role', _('Role'), undefined, {values: ['server', 'visitor']}],
-	[form.Value, 'server_name', _('Server name'), undefined, {depends: [{role: 'visitor'}]}],
-	[form.Value, 'bind_addr', _('Bind addr'), undefined, {depends: [{role: 'visitor'}]}],
-	[form.Value, 'bind_port', _('Bind port'), undefined, {depends: [{role: 'visitor'}]}],
-	[form.Value, 'sk', _('Sk')],
+const httpAuthConf = [
+	[form.Value, 'http_user', _('HTTP user'),
+	_('HTTP or TCPMUX basic auth username.')],
+
+	[form.Value, 'http_pwd', _('HTTP password'),
+	_('HTTP or TCPMUX basic auth password.'),
+	{ password: true }]
+];
+
+const routeByHTTPUserConf = [
+	[form.Value, 'route_by_http_user', _('Route by HTTP user'),
+	_('Route HTTP or TCPMUX requests by HTTP basic auth user.')]
+];
+
+const tcpmuxConf = [
+	[form.ListValue, 'multiplexer', _('Multiplexer'),
+	_('TCP multiplexer.'),
+	{ values: ['httpconnect'], depends: { type: 'tcpmux' }, default: 'httpconnect' }]
+];
+
+const loadBalancerConf = [
+	[form.Value, 'group', _('Load balancer group'),
+	_('Configuration key: proxies[].loadBalancer.group.'),
+	{ depends: proxyOnlyDepends }],
+
+	[form.Value, 'group_key', _('Load balancer group key'),
+	_('Configuration key: proxies[].loadBalancer.groupKey.'),
+	{
+		password: true,
+		depends: proxyOnlyDepends,
+		validate: function (section_id, value) {
+			const group = this.section.getOption('group');
+
+			if (String(value || '').trim() && group && !String(group.formvalue(section_id) || '').trim())
+				return _('Load balancer group is required when group key is set.');
+
+			return true;
+		}
+	}]
+];
+
+const healthCheckConf = [
+	[form.ListValue, 'health_check_type', _('Health check type'),
+	_('Health check type.'),
+	{ values: [['', _('Disabled')], ['tcp', 'tcp'], ['http', 'http']], rmempty: true, depends: healthCheckDepends }],
+
+	[form.Value, 'health_check_timeout_s', _('Health check timeout'),
+	_('Health check timeout in seconds.'),
+	{ datatype: 'uinteger', depends: [{ health_check_type: 'tcp' }, { health_check_type: 'http' }], placeholder: '3' }],
+
+	[form.Value, 'health_check_max_failed', _('Health check max failed'),
+	_('Remove proxy from frps after continuous failures.'),
+	{ datatype: 'uinteger', depends: [{ health_check_type: 'tcp' }, { health_check_type: 'http' }], placeholder: '3' }],
+
+	[form.Value, 'health_check_interval_s', _('Health check interval'),
+	_('Health check interval in seconds.'),
+	{ datatype: 'uinteger', depends: [{ health_check_type: 'tcp' }, { health_check_type: 'http' }], placeholder: '10' }],
+
+	[form.Value, 'health_check_url', _('Health check path'),
+	_('HTTP health check path.'),
+	{
+		depends: { health_check_type: 'http' },
+		placeholder: '/status',
+		validate: function (section_id, value) {
+			const healthCheckType = this.section.getOption('health_check_type');
+
+			if (
+				healthCheckType &&
+				healthCheckType.formvalue(section_id) === 'http' &&
+				!String(value || '').trim()
+			)
+				return _('Health check path is required when health check type is http.');
+
+			return validateHttpPath(value);
+		}
+	}],
+
+	[form.DynamicList, 'health_check_headers', _('Health check headers'),
+	_('HTTP health check headers. Use Header=Value.'),
+	{
+		depends: { health_check_type: 'http' },
+		placeholder: 'x-from-where=frp',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}]
+];
+
+const stcpXtcpConf = [
+	[form.ListValue, 'role', _('Role'),
+	_('Compatibility field for UCI. Server sections are emitted as proxy entries; visitor sections are emitted as visitor entries.'),
+	{ values: ['server', 'visitor'], default: 'server' }],
+
+	[form.Value, 'sk', _('Secret key'),
+	_('Secret key used by STCP/XTCP/SUDP proxies and visitors.'),
+	{ password: true }],
+
+	[form.DynamicList, 'allow_users', _('Allow users'),
+	_('Only visitors from specified users can connect. Use * to allow all users.'),
+	{ depends: { role: 'server' }, placeholder: '*' }],
+
+	[form.Value, 'server_user', _('Server user'),
+	_('Server user for visitor.'),
+	{ depends: { role: 'visitor' } }],
+
+	[form.Value, 'server_name', _('Server name'),
+	_('Server proxy name to visit.'),
+	{
+		depends: { role: 'visitor' },
+		validate: function (section_id, value) {
+			const role = this.section.getOption('role');
+
+			if (role && role.formvalue(section_id) === 'visitor' && !String(value || '').trim())
+				return _('Server name is required for visitors.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'bind_addr', _('Bind address'),
+	_('Local bind address for visitor.'),
+	{ depends: { role: 'visitor' }, datatype: 'ipaddr', placeholder: '127.0.0.1' }],
+
+	[form.Value, 'bind_port', _('Bind port'),
+	_('Local bind port for visitor. Use a negative value to avoid binding.'),
+	{
+		depends: { role: 'visitor' },
+		validate: function (section_id, value) {
+			const role = this.section.getOption('role');
+
+			if (role && role.formvalue(section_id) === 'visitor' && !String(value || '').trim())
+				return _('Bind port is required for visitors.');
+
+			return validateVisitorBindPort(section_id, value);
+		}
+	}],
+
+	[form.ListValue, 'visitor_protocol', _('XTCP protocol'),
+	_('XTCP visitor tunnel protocol.'),
+	{ depends: { role: 'visitor', type: 'xtcp' }, values: ['quic', 'kcp'], default: 'quic' }],
+
+	[form.Flag, 'keep_tunnel_open', _('Keep tunnel open'),
+	_('Keep XTCP tunnel open.'),
+	{ depends: { role: 'visitor', type: 'xtcp' }, datatype: 'bool', default: 'false' }],
+
+	[form.Value, 'max_retries_an_hour', _('Max retries per hour'),
+	_('Effective when XTCP keep tunnel open is enabled.'),
+	{ depends: { role: 'visitor', type: 'xtcp' }, datatype: 'uinteger', placeholder: '8' }],
+
+	[form.Value, 'min_retry_interval', _('Min retry interval'),
+	_('Minimum XTCP retry interval.'),
+	{ depends: { role: 'visitor', type: 'xtcp' }, datatype: 'uinteger', placeholder: '90' }],
+
+	[form.Value, 'fallback_to', _('Fallback to'),
+	_('Fallback visitor name for XTCP.'),
+	{ depends: { role: 'visitor', type: 'xtcp' } }],
+
+	[form.Value, 'fallback_timeout_ms', _('Fallback timeout ms'),
+	_('Fallback timeout in milliseconds for XTCP.'),
+	{ depends: { role: 'visitor', type: 'xtcp' }, datatype: 'uinteger', placeholder: '500' }],
+
+	[form.Flag, 'nat_disable_assisted_addrs', _('Disable NAT assisted addresses'),
+	_('Disable local interface assisted addresses for XTCP NAT traversal.'),
+	{ depends: { type: 'xtcp' }, datatype: 'bool', default: 'false' }]
 ];
 
 const pluginConf = [
-	[form.ListValue, 'plugin', _('Plugin'), undefined, {values: ['', 'http_proxy', 'socks5', 'unix_domain_socket'], rmempty: true}],
-	[form.Value, 'plugin_http_user', _('HTTP user'), undefined, {depends: {plugin: 'http_proxy'}}],
-	[form.Value, 'plugin_http_passwd', _('HTTP password'), undefined, {depends: {plugin: 'http_proxy'}}],
-	[form.Value, 'plugin_user', _('SOCKS5 user'), undefined, {depends: {plugin: 'socks5'}}],
-	[form.Value, 'plugin_passwd', _('SOCKS5 password'), undefined, {depends: {plugin: 'socks5'}}],
-	[form.Value, 'plugin_unix_path', _('Unix domain socket path'), undefined, {depends: {plugin: 'unix_domain_socket'}, optional: false, rmempty: false,
-		datatype: 'file', placeholder: '/var/run/docker.sock', default: '/var/run/docker.sock'}],
+	[form.ListValue, 'plugin', _('Plugin'),
+	_('Plugin type.'),
+	{
+		values: [
+			['', _('Disabled')],
+			['http_proxy', 'http_proxy'],
+			['socks5', 'socks5'],
+			['unix_domain_socket', 'unix_domain_socket'],
+			['static_file', 'static_file'],
+			['https2http', 'https2http'],
+			['https2https', 'https2https'],
+			['http2https', 'http2https'],
+			['http2http', 'http2http'],
+			['tls2raw', 'tls2raw'],
+			['virtual_net', 'virtual_net']
+		],
+		rmempty: true,
+		validate: function (section_id, value) {
+			return validatePlugin(this.section, section_id, value);
+		}
+	}],
+
+	[form.Value, 'plugin_http_user', _('HTTP user'),
+	_('Configuration key: plugin.httpUser.'),
+	{ depends: [{ plugin: 'http_proxy' }, { plugin: 'static_file' }] }],
+
+	[form.Value, 'plugin_http_passwd', _('HTTP password'),
+	_('Configuration key: plugin.httpPassword.'),
+	{ depends: [{ plugin: 'http_proxy' }, { plugin: 'static_file' }], password: true }],
+
+	[form.Value, 'plugin_user', _('SOCKS5 user'),
+	_('Configuration key: plugin.username.'),
+	{ depends: { plugin: 'socks5' } }],
+
+	[form.Value, 'plugin_passwd', _('SOCKS5 password'),
+	_('Configuration key: plugin.password.'),
+	{ depends: { plugin: 'socks5' }, password: true }],
+
+	[form.Value, 'plugin_unix_path', _('Unix domain socket path'),
+	_('Configuration key: plugin.unixPath.'),
+	{
+		depends: { plugin: 'unix_domain_socket' },
+		optional: false,
+		rmempty: false,
+		datatype: 'file',
+		placeholder: '/var/run/docker.sock',
+		default: '/var/run/docker.sock'
+	}],
+
+	[form.Value, 'plugin_local_path', _('Static file local path'),
+	_('Configuration key: plugin.localPath.'),
+	{ depends: { plugin: 'static_file' }, datatype: 'directory', placeholder: '/var/www/blog' }],
+
+	[form.Value, 'plugin_strip_prefix', _('Static file strip prefix'),
+	_('Configuration key: plugin.stripPrefix.'),
+	{ depends: { plugin: 'static_file' }, placeholder: 'static' }],
+
+	[form.Value, 'plugin_local_addr', _('Plugin local address'),
+	_('Local backend address used by bridge plugins. For https2http, https2https and tls2raw, this is the local service address reached after frp terminates external TLS; for http2https/http2http, it is the local upstream address.'),
+	{
+		depends: [
+			{ plugin: 'https2http' },
+			{ plugin: 'https2https' },
+			{ plugin: 'http2https' },
+			{ plugin: 'http2http' },
+			{ plugin: 'tls2raw' }
+		],
+		placeholder: '127.0.0.1:80'
+	}],
+
+	[form.Value, 'plugin_crt_path', _('Plugin certificate path'),
+	_('Configuration key: plugin.crtPath.'),
+	{
+		depends: [
+			{ plugin: 'https2http' },
+			{ plugin: 'https2https' },
+			{ plugin: 'tls2raw' }
+		],
+		datatype: 'file',
+		placeholder: './server.crt'
+	}],
+
+	[form.Value, 'plugin_key_path', _('Plugin key path'),
+	_('Configuration key: plugin.keyPath.'),
+	{
+		depends: [
+			{ plugin: 'https2http' },
+			{ plugin: 'https2https' },
+			{ plugin: 'tls2raw' }
+		],
+		datatype: 'file',
+		placeholder: './server.key'
+	}],
+
+	[form.Value, 'plugin_host_header_rewrite', _('Plugin host header rewrite'),
+	_('Configuration key: plugin.hostHeaderRewrite.'),
+	{
+		depends: [
+			{ plugin: 'https2http' },
+			{ plugin: 'https2https' },
+			{ plugin: 'http2https' },
+			{ plugin: 'http2http' }
+		],
+		placeholder: '127.0.0.1'
+	}],
+
+	[form.Flag, 'plugin_enable_http2', _('Plugin HTTP/2'),
+	_('Enable HTTP/2 for HTTPS bridge plugins.'),
+	{
+		depends: [
+			{ plugin: 'https2http' },
+			{ plugin: 'https2https' }
+		],
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.DynamicList, 'plugin_request_headers', _('Plugin request headers'),
+	_('Use Header=Value.'),
+	{
+		depends: [
+			{ plugin: 'https2http' },
+			{ plugin: 'https2https' },
+			{ plugin: 'http2https' },
+			{ plugin: 'http2http' }
+		],
+		placeholder: 'x-from-where=frp',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}],
+
+	[form.Value, 'plugin_destination_ip', _('VirtualNet destination IP'),
+	_('For virtual_net visitor plugin.'),
+	{
+		depends: { plugin: 'virtual_net', role: 'visitor' },
+		datatype: 'ipaddr',
+		placeholder: '100.86.0.1',
+		validate: function (section_id, value) {
+			return validateVirtualNetDestination(this.section, section_id, value);
+		}
+	}]
 ];
 
+const metadataConf = [
+	[form.DynamicList, 'metadatas', _('Proxy metadatas'),
+	_('Additional proxy metadata. Use key=value.'),
+	{
+		depends: proxyOnlyDepends,
+		placeholder: 'var1=abc',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}],
+
+	[form.DynamicList, 'annotations', _('Annotations'),
+	_('Annotations displayed on frps dashboard. Use key=value.'),
+	{
+		depends: proxyOnlyDepends,
+		placeholder: 'key1=value1',
+		validate: function (section_id, value) {
+			return validateKeyValue(value);
+		}
+	}]
+];
+
+function writeFlagDisabled(section_id) {
+	return this.write(section_id, this.disabled || 'false');
+}
+
+function removeIfPresent(section_id) {
+	const this_cfg = this.uciconfig || this.section.uciconfig || this.map.config;
+	const this_sid = this.ucisection || section_id;
+	const this_opt = this.ucioption || this.option;
+
+	for (let i = 0; i < this.section.children.length; i++) {
+		const sibling = this.section.children[i];
+
+		if (sibling === this || sibling.ucioption == null)
+			continue;
+
+		const sibling_cfg = sibling.uciconfig || sibling.section.uciconfig || sibling.map.config;
+		const sibling_sid = sibling.ucisection || section_id;
+		const sibling_opt = sibling.ucioption || sibling.option;
+
+		if (this_cfg != sibling_cfg || this_sid != sibling_sid || this_opt != sibling_opt)
+			continue;
+
+		if (typeof sibling.isActive === 'function' && sibling.isActive(section_id))
+			return Promise.resolve();
+	}
+
+	if (this.map.data.get(this_cfg, this_sid, this_opt) == null)
+		return Promise.resolve();
+
+	return this.map.data.unset(this_cfg, this_sid, this_opt);
+}
+
+function isUciDeleteNotFoundError(err) {
+	const message = err && err.message ? err.message : String(err);
+
+	return /uci\/delete/.test(message) && /ubus code 4/.test(message);
+}
+
+function guardUciDeleteNotFound(data, config) {
+	data._frpIgnoreMissingDeleteConfigs ??= {};
+	data._frpIgnoreMissingDeleteConfigs[config] = true;
+
+	if (data._frpIgnoreMissingDeleteInstalled)
+		return;
+
+	const callDelete = data.callDelete;
+
+	data.callDelete = function(conf, sid, options) {
+		const guarded = this._frpIgnoreMissingDeleteConfigs && this._frpIgnoreMissingDeleteConfigs[conf];
+
+		return callDelete.apply(this, arguments).catch(L.bind(function(err) {
+			if (!guarded || !isUciDeleteNotFoundError(err))
+				return Promise.reject(err);
+
+			if (!Array.isArray(options) || options.length <= 1)
+				return null;
+
+			return Promise.all(options.map(L.bind(function(opt) {
+				return callDelete.call(this, conf, sid, [ opt ]).catch(function(e) {
+					return isUciDeleteNotFoundError(e) ? null : Promise.reject(e);
+				});
+			}, this)));
+		}, this));
+	};
+
+	data._frpIgnoreMissingDeleteInstalled = true;
+}
+
+function adminWebEnabled(section, section_id) {
+	const port = section.getOption('admin_port');
+	const value = port ? port.formvalue(section_id) : null;
+
+	return !!(value && value !== '0');
+}
+
+function adminHttpsEnabled(section, section_id) {
+	const enable = section.getOption('admin_tls_enable');
+
+	return !!(enable && enable.formvalue(section_id) === 'true');
+}
+
+function validatePortOrZero(section_id, value) {
+	if (!value)
+		return true;
+
+	value = String(value).trim();
+
+	if (!/^\d+$/.test(value))
+		return _('Port must be a number between 0 and 65535.');
+
+	const port = Number(value);
+	if (port < 0 || port > 65535)
+		return _('Port must be between 0 and 65535.');
+
+	return true;
+}
+
+function validateVisitorBindPort(section_id, value) {
+	if (!value)
+		return true;
+
+	value = String(value).trim();
+
+	if (/^-\d+$/.test(value) && Number(value) < 0)
+		return true;
+
+	if (!/^\d+$/.test(value))
+		return _('Port must be negative or a number between 1 and 65535.');
+
+	const port = Number(value);
+	if (port < 1 || port > 65535)
+		return _('Port must be negative or between 1 and 65535.');
+
+	return true;
+}
+
+function validateEnv(value) {
+	if (!value)
+		return true;
+
+	if (/\r|\n/.test(String(value)) || !/^[A-Za-z_][A-Za-z0-9_]*=.*$/.test(String(value)))
+		return _('Environment variable must use KEY=value format.');
+
+	return true;
+}
+
+function validateHttpPath(value) {
+	if (!value)
+		return true;
+
+	if (/\r|\n/.test(String(value)) || String(value).charAt(0) !== '/')
+		return _('HTTP path must start with /.');
+
+	return true;
+}
+
+function validateKeyValue(value) {
+	if (!value)
+		return true;
+
+	if (/[\r\n]/.test(String(value)) || !/^[^=\s][^=]*=.*$/.test(String(value)))
+		return _('Please use KEY=value format.');
+
+	return true;
+}
+
+function validatePlugin(section, section_id, value) {
+	const role = section.getOption('role');
+	const roleValue = role ? role.formvalue(section_id) : null;
+
+	if (roleValue === 'visitor' && value && value !== 'virtual_net')
+		return _('Only the virtual_net plugin is valid for visitors.');
+
+	return true;
+}
+
+function validateVirtualNetDestination(section, section_id, value) {
+	const plugin = section.getOption('plugin');
+	const role = section.getOption('role');
+
+	if (
+		plugin && plugin.formvalue(section_id) === 'virtual_net' &&
+		role && role.formvalue(section_id) === 'visitor' &&
+		!String(value || '').trim()
+	)
+		return _('VirtualNet destination IP is required for virtual_net visitors.');
+
+	return true;
+}
+
+function normalizeDepends(depends) {
+	if (depends == null)
+		return [];
+
+	return Array.isArray(depends) ? depends : [ depends ];
+}
+
+function mergeDepends(existing, next) {
+	const current = normalizeDepends(existing);
+	const incoming = normalizeDepends(next);
+
+	if (current.length === 0)
+		return incoming;
+
+	if (incoming.length === 0)
+		return current;
+
+	const merged = [];
+
+	for (let oldDep of current) {
+		for (let newDep of incoming) {
+			const dep = {};
+			let conflict = false;
+
+			for (let key in oldDep)
+				dep[key] = oldDep[key];
+
+			for (let key in newDep) {
+				if (Object.prototype.hasOwnProperty.call(dep, key) && dep[key] !== newDep[key]) {
+					conflict = true;
+					break;
+				}
+
+				dep[key] = newDep[key];
+			}
+
+			if (!conflict)
+				merged.push(dep);
+		}
+	}
+
+	return merged;
+}
+
 function setParams(o, params) {
-	if (!params) return;
+	if (!params)
+		return;
+
 	for (let key in params) {
 		let val = params[key];
+
 		if (key === 'values') {
 			for (let v of val) {
 				let args = v;
+
 				if (!Array.isArray(args))
 					args = [args];
+
 				o.value.apply(o, args);
 			}
 		} else if (key === 'depends') {
-			if (!Array.isArray(val))
-				val = [val];
-
-			const deps = [];
-			for (let v of val) {
-				const d = {};
-				for (let vkey in v)
-					d[vkey] = v[vkey];
-				for (let od of (o.deps || [])) {
-					for (let dkey in od) {
-						d[dkey] = od[dkey];
-					}
-				}
-				deps.push(d);
-			}
-			o.deps = deps;
+			o.deps = mergeDepends(o.deps, val);
 		} else {
 			o[key] = params[key];
 		}
 	}
+
 	if (params['datatype'] === 'bool') {
 		o.enabled = 'true';
 		o.disabled = 'false';
 	}
 }
 
+
 function defTabOpts(s, t, opts, params) {
 	for (let opt of opts) {
 		const o = s.taboption(t, opt[0], opt[1], opt[2], opt[3]);
+
 		setParams(o, opt[4]);
 		setParams(o, params);
+
+		/*
+		 * Per-option optional must win over tab-wide optional.
+		 * This is important for form.Flag with default='true',
+		 * otherwise LuCI may treat checked state as default and call remove().
+		 */
+		if (opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'optional'))
+			o.optional = opt[4].optional;
+
+		if (
+			!(opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'remove')) &&
+			!(params && Object.prototype.hasOwnProperty.call(params, 'remove'))
+		)
+			o.remove = removeIfPresent;
 	}
 }
 
 function defOpts(s, opts, params) {
 	for (let opt of opts) {
 		const o = s.option(opt[0], opt[1], opt[2], opt[3]);
+
 		setParams(o, opt[4]);
 		setParams(o, params);
+
+		if (opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'optional'))
+			o.optional = opt[4].optional;
+
+		if (
+			!(opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'remove')) &&
+			!(params && Object.prototype.hasOwnProperty.call(params, 'remove'))
+		)
+			o.remove = removeIfPresent;
 	}
 }
 
@@ -147,25 +1371,26 @@ const callServiceList = rpc.declare({
 
 function getServiceStatus() {
 	return L.resolveDefault(callServiceList('frpc'), {}).then(function (res) {
-		let isRunning = false;
-		try {
-			isRunning = res['frpc']['instances']['instance1']['running'];
-		} catch (e) { }
-		return isRunning;
+		const instances = res.frpc && res.frpc.instances;
+
+		if (!instances)
+			return false;
+
+		for (let name in instances) {
+			if (instances[name] && instances[name].running)
+				return true;
+		}
+
+		return false;
 	});
 }
 
 function renderStatus(isRunning) {
-	let renderHTML = "";
-	const spanTemp = '<em><span style="color:%s"><strong>%s %s</strong></span></em>';
+	const color = isRunning ? 'green' : 'red';
+	const status = isRunning ? _('RUNNING') : _('NOT RUNNING');
 
-	if (isRunning) {
-		renderHTML += String.format(spanTemp, 'green', _("frp Client"), _("RUNNING"));
-	} else {
-		renderHTML += String.format(spanTemp, 'red', _("frp Client"), _("NOT RUNNING"));
-	}
-
-	return renderHTML;
+	return String.format('<em><span style="color:%s"><strong>%s %s</strong></span></em>',
+		color, _('frp Client'), status);
 }
 
 return view.extend({
@@ -173,32 +1398,46 @@ return view.extend({
 		let m, s, o;
 
 		m = new form.Map('frpc', _('frp Client'));
+		guardUciDeleteNotFound(m.data, 'frpc');
 
 		s = m.section(form.NamedSection, '_status');
 		s.anonymous = true;
 		s.render = function (section_id) {
 			L.Poll.add(function () {
-				return L.resolveDefault(getServiceStatus()).then(function(res) {
-					const view = document.getElementById("service_status");
-					view.innerHTML = renderStatus(res);
+				return L.resolveDefault(getServiceStatus()).then(function (res) {
+					const view = document.getElementById('service_status');
+
+					if (view)
+						view.innerHTML = renderStatus(res);
 				});
 			});
 
 			return E('div', { class: 'cbi-map' },
-				E('fieldset', { class: 'cbi-section'}, [
-					E('p', { id: 'service_status' },
-						_('Collecting data ...'))
+				E('fieldset', { class: 'cbi-section' }, [
+					E('p', { id: 'service_status' }, _('Collecting data ...'))
 				])
 			);
-		}
+		};
 
 		s = m.section(form.NamedSection, 'common', 'conf');
 		s.dynamic = true;
 
 		s.tab('common', _('Common Settings'));
+		s.tab('auth', _('Authentication'));
+		s.tab('transport', _('Transport Settings'));
+		s.tab('tls_quic', _('TLS / QUIC'));
+		s.tab('web', _('Web Server'));
+		s.tab('advanced', _('Advanced'));
+		s.tab('log', _('Log Settings'));
 		s.tab('init', _('Startup Settings'));
 
-		defTabOpts(s, 'common', commonConf, {optional: true});
+		defTabOpts(s, 'common', commonBaseConf, { optional: true });
+		defTabOpts(s, 'auth', commonAuthConf, { optional: true });
+		defTabOpts(s, 'transport', commonTransportConf, { optional: true });
+		defTabOpts(s, 'tls_quic', commonTlsQuicConf, { optional: true });
+		defTabOpts(s, 'web', commonWebConf, { optional: true });
+		defTabOpts(s, 'advanced', commonAdvancedConf, { optional: true });
+		defTabOpts(s, 'log', commonLogConf, { optional: true });
 
 		o = s.taboption('init', form.SectionValue, 'init', form.TypedSection, 'init', _('Startup Settings'));
 		s = o.subsection;
@@ -207,47 +1446,85 @@ return view.extend({
 
 		defOpts(s, startupConf);
 
-		s = m.section(form.GridSection, 'conf', _('Proxy Settings'));
+		s = m.section(form.GridSection, 'conf', _('Proxy / Visitor Settings'));
 		s.anonymous = true;
 		s.addremove = true;
 		s.sortable = true;
-		s.addbtntitle = _('Add new proxy...');
+		s.nodescriptions = true;
+		s.addbtntitle = _('Add new proxy or visitor...');
 
-		s.filter = function(s) { return s !== 'common'; };
-
-		s.tab('general', _('General Settings'));
-		s.tab('http', _('HTTP Settings'));
-		s.tab('plugin', _('Plugin Settings'));
-
-		s.option(form.Value, 'name', _('Proxy name')).modalonly = false;
-		s.option(form.Value, 'type', _('Proxy type')).modalonly = false;
-		s.option(form.Value, 'local_ip', _('Local IP')).modalonly = false;
-		s.option(form.Value, 'local_port', _('Local port')).modalonly = false;
-		o = s.option(form.Value, 'remote_port', _('Remote port'));
-		o.modalonly = false;
-		o.depends('type', 'tcp');
-		o.depends('type', 'udp');
-		o.cfgvalue = function() {
-			const  v = this.super('cfgvalue', arguments);
-			return v&&v!='0'?v:'#';
+		s.filter = function (section_id) {
+			return section_id !== 'common';
 		};
 
-		defTabOpts(s, 'general', baseProxyConf, {modalonly: true});
+		s.tab('general', _('General Settings'));
+		s.tab('transport', _('Transport'));
+		s.tab('http', _('HTTP / Domain'));
+		s.tab('plugin', _('Plugin'));
+		s.tab('stcp_xtcp', _('STCP / XTCP / SUDP'));
+		s.tab('health', _('Health Check'));
+		s.tab('lb', _('Load Balancer'));
+		s.tab('metadata', _('Metadata'));
 
-		// TCP and UDP
-		defTabOpts(s, 'general', bindInfoConf, {optional: true, modalonly: true, depends: [{type: 'tcp'}, {type: 'udp'}]});
+		defTabOpts(s, 'general', baseProxyConf, { modalonly: null });
+		defTabOpts(s, 'transport', proxyTransportConf, { optional: true, modalonly: true });
 
-		// HTTP and HTTPS
-		defTabOpts(s, 'http', domainConf, {optional: true, modalonly: true, depends: [{type: 'http'}, {type: 'https'}]});
+		defTabOpts(s, 'http', domainConf, {
+			optional: true,
+			modalonly: true,
+			depends: [{ type: 'http' }, { type: 'https' }, { type: 'tcpmux' }]
+		});
 
-		// HTTP
-		defTabOpts(s, 'http', httpProxyConf, {optional: true, modalonly: true, depends: {type: 'http'}});
+		defTabOpts(s, 'http', httpProxyConf, {
+			optional: true,
+			modalonly: true,
+			depends: { type: 'http' }
+		});
 
-		// STCP and XTCP
-		defTabOpts(s, 'general', stcpProxyConf, {modalonly: true, depends: [{type: 'stcp'}, {type: 'xtcp'}]});
+		defTabOpts(s, 'http', httpAuthConf, {
+			optional: true,
+			modalonly: true,
+			depends: [{ type: 'http' }, { type: 'tcpmux' }]
+		});
 
-		// Plugin
-		defTabOpts(s, 'plugin', pluginConf, {modalonly: true});
+		defTabOpts(s, 'http', routeByHTTPUserConf, {
+			optional: true,
+			modalonly: true,
+			depends: [{ type: 'http' }, { type: 'tcpmux' }]
+		});
+
+		defTabOpts(s, 'http', tcpmuxConf, {
+			optional: true,
+			modalonly: true,
+			depends: { type: 'tcpmux' }
+		});
+
+		defTabOpts(s, 'plugin', pluginConf, {
+			optional: true,
+			modalonly: true
+		});
+
+		defTabOpts(s, 'stcp_xtcp', stcpXtcpConf, {
+			optional: true,
+			modalonly: true,
+			depends: [{ type: 'stcp' }, { type: 'xtcp' }, { type: 'sudp' }]
+		});
+
+		defTabOpts(s, 'health', healthCheckConf, {
+			optional: true,
+			modalonly: true,
+			depends: healthCheckDepends
+		});
+
+		defTabOpts(s, 'lb', loadBalancerConf, {
+			optional: true,
+			modalonly: true
+		});
+
+		defTabOpts(s, 'metadata', metadataConf, {
+			optional: true,
+			modalonly: true
+		});
 
 		return m.render();
 	}

--- a/applications/luci-app-frpc/po/ar/frpc.po
+++ b/applications/luci-app-frpc/po/ar/frpc.po
@@ -11,121 +11,404 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "الاعدادات الإضافية"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "المصادقة"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "يتم جمع البيانات..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "معطل"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "مفعَّل"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "التعمية"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "الاعدادات العامة"
 
@@ -133,319 +416,810 @@ msgstr "الاعدادات العامة"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "مستوى التسجيل"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "البروتوكول"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "قيد التشغيل"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "عنوان الخادم"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "اسم الخادم"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "مستخدم"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/az/frpc.po
+++ b/applications/luci-app-frpc/po/az/frpc.po
@@ -7,121 +7,404 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -129,319 +412,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/be/frpc.po
+++ b/applications/luci-app-frpc/po/be/frpc.po
@@ -8,121 +8,404 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Уключана"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -130,319 +413,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/bg/frpc.po
+++ b/applications/luci-app-frpc/po/bg/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Добавяне на ново прокси..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Допълнителни настройки"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Допълнителни настройки"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Присвоен порт"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Събиране на данни ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Общи Настройки"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Потребителски домейни"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Забранен"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Включено"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Криптиране"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Общи настройки"
 
@@ -132,319 +415,810 @@ msgstr "Общи настройки"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP Настройки"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Ако remote_port е 0, frps ще Ви назначи случаен порт"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Локалнен IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Локален порт"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp указва IP адреса или хостнейм към който да пренасочва (proxy)."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort указва порт-а към който да пренасочва (proxy)."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Ниво на записи"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "НЕ СЕ ИЗПЪЛНЯВА"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Протокол"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "РАБОТИ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/bn_BD/frpc.po
+++ b/applications/luci-app-frpc/po/bn_BD/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "অতিরিক্ত কনফিগারেশন"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "অতিরিক্ত সেটিংস"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "অ্যাসেট ডিরেক্টরি"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "অ্যাড্রেস বাইন্ড করুন"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "বাইন্ড পোর্ট"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "তথ্য সংগ্রহ করা হচ্ছে ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "কনফিগ ফাইলগুলি অস্থায়ী কনফিগ ফাইলের অন্তর্ভুক্ত"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "রঙ্গিন লগ নিষ্ক্রিয় করুন"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "নিষ্ক্রিয়"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "সক্রিয়"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "এনভায়রনমেন্ট ভ্যারিয়েবল"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "সাধারণ সেটিংস"
 
@@ -132,330 +415,810 @@ msgstr "সাধারণ সেটিংস"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "হার্টবিট টাইমআউট"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "লগ লেভেল"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
+msgstr "সর্বোচ্চ দিন লগ করুন"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "stderr লগ করুন"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "stdout লগ করুন"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "চলমান না"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "প্রোটোকল"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "চলমান"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "ক্র্যাশ করলে পুনরুজ্জীবিত করুন"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "গ্রুপ হিসাবে ডেমন চালান"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "ব্যবহারকারী হিসাবে ডেমন চালান"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "টিসিপি মাক্স"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"LuCI তে অন্তর্ভুক্ত হয়নি এমন কিছু অতিরিক্ত প্যারামিটার নির্দিষ্ট করতে এই তালিকাটি "
-"ব্যবহৃত হবে।"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "টোকেন"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr ""
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "কনফিগারেশন ফাইল টেমপ্লেটের জন্য ওএস এনভায়রনমেন্ট frp- এ চলে যায়, এখানে দেখুন "
-#~ "<a href=\"https://github.com/fatedier/frp#configuration-file-"
-#~ "template\">frp README</a>"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/ca/frpc.po
+++ b/applications/luci-app-frpc/po/ca/frpc.po
@@ -11,121 +11,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Afegeix un nou servidor intermediari..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configuracions addicionals"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avançat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autenticació"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Adreça de vinculació"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Inhabilitat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Activat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Encriptatge"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Paràmetres generals"
 
@@ -133,319 +416,810 @@ msgstr "Paràmetres generals"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
-msgstr ""
+msgstr "Nivell de registre"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocol"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Executa el servei com a grup"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
-msgstr ""
+msgstr "Executa el dimoni com l'usuari"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
+msgstr "Port del servidor"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/cs/frpc.po
+++ b/applications/luci-app-frpc/po/cs/frpc.po
@@ -10,137 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Přidat novou proxy…"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Další nastavení"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Další nastavení"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Adresa správce"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Heslo správce"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Port pro správu"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Uživatel-správce"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr určuje adresu, na kterou se správní server naváže.<br />Ve "
-"výchozím stavu je tato hodnota „0.0.0.0“ (všechny)."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort určuje port, na kterém má správní server očekávat spojení. Pokud "
-"je hodnota 0 (nula), správní server nebude spouštěn.<br />Výchozí je právě "
-"toto chování (0)."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd určuje heslo, které správní server použije pro přihlášení.<br />Ve "
-"výchozím stavu je tato hodnota „admin“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser určuje uživatelské jméno, které správní server využije pro "
-"přihlášení.<br />Ve výchozím stavu je tato hodnota „admin“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Složka obsahu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir určuje lokální složku, ze které správní server načte prostředky. "
-"Pokud je tato hodnota „“, prostředky budou načítány z přibaleného "
-"spustitelného souboru pomocí statik.<br />Ve výchozím stavu je tato hodnota "
-"„“."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Ověřování se"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "Adresa, na kterou navázat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Port, na který navázat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Shromažďování dat …"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Společná nastavení"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Komprese"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
-"Které soubory s nastaveními zahrnout do dočasného souboru s nastaveními"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Uživatelsky určené domény"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Neobarvovat záznam událostí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"Pokud nastaveno na true (ano) DisableLogColor vypíná obarvování záznamu "
-"událostí, když je LogWay == \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Povoleno"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Šifrování"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Proměnná prostředí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Při nezdaru přihlášení ukončit"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
@@ -148,406 +415,810 @@ msgstr "Obecná nastavení"
 msgid "Grant access to LuCI app frpc"
 msgstr "Udělit přístup k LuCI aplikaci frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Nastavení pro HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP heslo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "HTTP uživatel"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval určuje v jakém intervalu jsou heartbeats zasílány na "
-"server (v sekundách). Není doporučeno tuto hodnotu měnit.<br />Ve výchozím "
-"stavu je 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout určuje nejdelší umožněnou prodlevu heartbeat odezvy, po "
-"jejímž překročení bude spojení ukončeno (v sekundách). Není doporučeno tuto "
-"hodnotu měnit.<br />Ve výchozím stavu je 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Interval kontroly stavu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Časový limit kontroly stavu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Přepsání hlavičky hostitel"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy určuje adresu proxy, přes kterou se k serveru připojovat. Pokud je "
-"tato hodnota „“, k serveru se bude připojováno napřímo.<br />Ve výchozím "
-"stavu je tato hodnota přečtena z proměnné prostředí „http_proxy“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Pokud je remote_port 0, frps vám přiřadí náhodný port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Lokální IP adresa"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Lokální port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"Localip určuje IP adresu nebo název hostitele na kterou provádět proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort určuje port na který provádět proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Umístění"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Soubor se záznamem událostí"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Nastavení zaznamenávání událostí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Stupeň podrobnosti záznamu událostí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Zaznamenávat nejvýše dnů"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Zaznamenávat standardní chybový výstup"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Zaznamenávat standardní výstup"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile určuje soubor, do kterého budou zapisovány záznamy událostí. Tato "
-"hodnota bude použita pouze pokud je LogWay příslušně nastaveno.<br />Ve "
-"výchozím stavu je tato hodnota „console“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel určuje nejnižší stupeň podrobnosti záznamu událostí. Platnými "
-"hodnotami jsou „trace“, „debug“ (ladění), „info“, “warn“ (varování) a "
-"„error“ (chyba).<br />Ve výchozím stavu je tato hodnota „info“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays určuje nejvyšší počet dnů, po který ukládat informace záznamu "
-"událostí, než budou smazány. Toto je použito pouze pokud LogWay == \"file\"."
-"<br />Ve výchozím stavu je tato hodnota 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit řídí zda po neúspěšném pokusu o přihlášení má či nemá klient "
-"skončit. Pokud ne, klient to bude zkoušet pořád dál, dokud se pokus o "
-"přihlášení nezdaří.<br />Ve výchozím stavu je tato hodnota true (ano)."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NESPUŠTĚNÉ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"Předávání proměnných prostředí OS k předání do frp pro šablonu souboru s "
-"nastaveními – viz %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Nastavení pro zásuvný modul"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokol"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"„Protokol“ určuje protokol, který použít při interakci se serverem. Platnými "
-"hodnotami jsou „tcp“, „kcp“, „quic“ a „websocket“.<br />Ve výchozím stavu je "
-"tato hodnota „tcp“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Nastavení proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Název proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Typ proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType určuje typ této proxy. Mezi platné hodnoty patří „tcp“, „udp“, "
-"„http“, „https“, „stcp“ a „xtcp“.<br />Ve výchozím stavu je tato hodnota "
-"„tcp“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "SPUŠTĚNÉ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Vzdálený port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "V případě pádu spustit znovu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Role"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Spustit proces služby s oprávněními skupiny"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Spustit proces služby pod uživatelskými oprávněními"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "SOCKS5 heslo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5 uživatel"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Adresa serveru"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Název serveru"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Port na serveru"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr určuje adresu serveru, ke kterému se připojovat.<br />Ve výchozím "
-"stavu je tato hodnota „127.0.0.1“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort určuje port, na kterém se na serveru připojit.<br />Ve výchozím "
-"stavu je tato hodnota 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Nastavení spouštění"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Dílčí doména"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"„Zapnout TLS“ určuje zda má či nemá být TLS použito při komunikaci se "
-"serverem."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux vypíná/zapíná směšování TCP proudů. Toto umožňuje, aby vícero "
-"požadavků z klienta sdílelo jedno TCP spojení. Pokud zapnuto je třeba, aby "
-"server měl TCP směšování také zapnuto.<br />Ve výchozím stavu je tato "
-"hodnota platí."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Tento seznam je možné použít pro zadání nějakých dalších parametrů, které "
-"nejsou zde v LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token určuje pověřovací token použitý pro vytvoření klíčů, které poslat na "
-"server. Aby uspělo je třeba, aby server měl odpovídající token. <br />Ve "
-"výchozím stavu je tato hodnota „“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Popis umístění soketu unixové domény"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression řídí zda komunikace se serverem bude či nebude komprimována."
-"<br />Ve výchozím stavu je tato hodnota neplatí."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption řídí zda šifrovat komunikace se serverem nebo ne. Šifrování se "
-"děje pomocí tokenů poskytnutých v nastavení serveru a klienta.<br />Ve "
-"výchozím stavu je tato hodnota false (ne)."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Uživatel"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Uživatel určuje předponu pro proxy názvy kvůli jejich rozlišení od ostatních "
-"klientů. Pokud hodnota není „“, proxy názvy budou automaticky změněny na "
-"„{user}.{proxy_name}“.<br />Ve výchozím stavu je tato hodnota „“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "frp klient"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Prostředí operačního systému, které předat frp pro šablonu souboru s "
-#~ "nastaveními – viz <a href=\"https://github.com/fatedier/frp#configuration-"
-#~ "file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protokol určuje který použít při interakci se serverem. Platnými "
-#~ "hodnotami jsou „tcp“, „kcp“ a „websocket“.<br />Ve výchozím stavu je tato "
-#~ "hodnota „tcp“."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType určuje typ této proxy. Platnými hodnotami jsou „tcp“, „udp“, "
-#~ "„http“, „https“, „stcp“, a „xtcp“.<br />Ve výchozím stavu je tato hodnota "
-#~ "„tcp“."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable určuje zda má či nemá být při komunikaci se serverem používáno "
-#~ "TLS."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/da/frpc.po
+++ b/applications/luci-app-frpc/po/da/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Yderligere konfigurationer"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avanceret"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Godkendelse"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Bind port"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Aktiveret"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Generelle indstillinger"
 
@@ -132,319 +415,810 @@ msgstr "Generelle indstillinger"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Log niveau"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "KØRE IKKE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokol"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "KØRE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rolle"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Kør dæmon som gruppe"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Kør dæmon som bruger"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Serveradresse"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
+msgstr "Servernavn"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
+msgstr "Server port"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/de/frpc.po
+++ b/applications/luci-app-frpc/po/de/frpc.po
@@ -10,136 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Neuen Proxy hinzufügen..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Zusätzliche Konfiguration"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Weitere Einstellungen"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Admin-Adresse"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Admin-Kennwort"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Admin-Port"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Admin-Nutzer"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort spezifiziert den Port auf dem der Admin-Server lauschen soll. "
-"Falls der Wert 0 ist, wird kein Admin-Server gestartet.<br />Standardwert "
-"ist 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd spezifiziert das Kennwort, dass der Admin-Server zum Login abfragt."
-"<br />Standardkennwort ist \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Erweitert"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser spezifiziert den Benutzername, den der Admin-Server fürs Login "
-"verwenden soll.<br />Standardnutzer ist \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Asset-Verzeichnis"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Authentifizierung"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"AssetsDir spezifiziert das lokale Verzeichnis, aus dem der Admin-Server "
-"seine Ressourcen lädt. Falls der Wert \"\" beträgt, werden Ressource aus der "
-"mitgelieferten ausführbaren Datei mittels statik geladen.<br />Standardwert "
-"ist \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "Adresse binden"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Bind-Adresse"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Apps, die Geräteattestierung verwenden"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Sammeln von Daten ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Komprimierung"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Konfigurationsdateien die in temporärer Konfiguration enthalten sind"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Benutzerdefinierte Domänen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Deaktiviere farbiges Log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor deaktiviert farbiges Log wenn LogWay == \"console\" "
-"aktiviert ist."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Umgebungsvariable"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Beende Programm bei Loginfehler"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -147,404 +415,810 @@ msgstr "Allgemeine Einstellungen"
 msgid "Grant access to LuCI app frpc"
 msgstr "Zugriff auf LuCI-App frpc gewähren"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP-Einstellungen"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP-Passwort"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP-Proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "HTTP-User"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval spezifiziert den Zeitabstand zwischen dem Senden von "
-"Heartbeats an den Server in Sekunden. Es wird nicht empfohlen, diesen Wert "
-"zu ändern.<br />Standardwert hierfür ist 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout spezifiziert die maximal erlaubte Heartbeat-Antwort-"
-"Verzögerung in Sekunden, bevor die Verbindung gekappt wird. Es wird nicht "
-"empfohlen, diesen Wert zu ändern.<br />Standardwert hierfür ist 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Heartbeat-Intervall"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Heartbeat-Timeout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Host-Header umschreiben"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy spezifiziert über welche Proxy-Adresse zum Server verbunden werden "
-"soll. Falls dieser Wert \"\" ist, wird direkt zum Server verbunden.<br /"
-">Standardwert hierfür wird aus der \"http_proxy\"-Umgebungsvariable gelesen."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Wenn remote_port 0 ist, weist frps Ihnen einen zufälligen Port zu"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Lokale IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Lokaler Port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp gibt die IP-Adresse oder den Hostnamen für den Proxy an."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort spezifiziert den Port des Proxys."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Standorte"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Protokolldatei"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Protokolleinstellungen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Protokollierungslevel"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Maximale Tage protokollieren"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Stderr protokollieren"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Stdout protokollieren"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile gibt eine Datei an, in die Protokolle geschrieben werden. Dieser "
-"Wert wird nur verwendet, wenn LogWay entsprechend eingestellt ist.<br />In "
-"der Voreinstellung ist dieser Wert \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel spezifiziert den minimalen Log-Level. Gültige Werte sind \"trace\", "
-"\"debug\", \"info\", \"warn\" und \"error\".<br />Standardwert hierfür ist "
-"\"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays gibt die maximale Anzahl von Tagen an, für die "
-"Protokollinformationen vor dem Löschen gespeichert werden sollen. Dies wird "
-"nur verwendet, wenn LogWay == „file“ ist.<br/>Standardmäßig ist dieser Wert "
-"0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit legt fest, ob sich ein Client nach einem fehlgeschlagenen "
-"Loginversuch beenden soll. Falls es auf falsch steht, wir es der client so "
-"oft versuchen, bis es erfolgreich war.<br />Standardwert hierfür ist wahr."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "LÄUFT NICHT"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
-msgstr "OS-Umgebungen für config Dateivorlage an frp übergeben, siehe %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Plugin"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Plugin-Einstellungen"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokoll"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Protokoll gibt das Protokoll an, das bei der Interaktion mit dem Server "
-"verwendet werden soll. Gültige Werte sind \"tcp\", \"kcp\", \"quic\" und "
-"\"websocket\".<br /> Standardmäßig ist dieser Wert \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Proxy-Einstellungen"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Name des Proxies"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Proxy-Typ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType gibt den Typ dieses Proxys an. Gültige Werte sind „tcp“, „udp“, „"
-"http“, „https“, „stcp“ und „xtcp“.<br/>Standardmäßig ist dieser Wert „tcp“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "LÄUFT"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Entfernter Port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Starte nach Crash neu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rolle"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Daemon als Gruppe ausführen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Daemon als Gruppe ausführen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "SOCKS5-Passwort"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5-Benutzer"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Server-Adresse"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Servername"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Server-Port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr spezifiziert die Adresse des Servers zu dem Verbunden werden soll."
-"<br />Standardwert hierfür ist \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort spezifiziert den Port des Servers zu dem verbunden werden soll."
-"<br />Standardwert hierfür ist 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Startup-Einstellungen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Unterdomäne"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP-mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"TLS Enable gibt an, ob TLS bei der Kommunikation mit dem Server verwendet "
-"werden soll oder nicht."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux regelt ob TCP-Stream-Multiplexing genutzt werden soll. Dies erlaubt "
-"mehrere Requests eines Clients über eine TCP-Verbindung. Falls dieser Wert "
-"auf wahr steht, muss der Server ebenfalls TCP-Multiplexing aktiviert haben."
-"<br />Standardwert hierfür ist wahr."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"In dieser Liste können zusätzliche Parameter angegeben werden, die in diesem "
-"LuCI nicht enthalten sind."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token spezifiziert das Autorisierungs-Token, das für die Erzeugung von "
-"Schlüsseln die an den Server gesendet werden genutzt wird. Der Server muss "
-"ein gleichlautendes Token zur Autorisierung eingestellt haben.<br /"
-">Standardwert hierfür ist \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Unix-Domänensocketpfad"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression legt fest, ob die Datenverbindung mit dem Server komprimiert "
-"werden soll.<br />Standardwert hierfür ist falsch."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption legt fest, ob die Datenverbindung mit dem Server verschlüsselt "
-"werden soll. Die Verschlüsselung erfolgt mittels der eingestellten Token auf "
-"Server- und Clientseite.<br />Standardwert hierfür ist falsch."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Benutzer"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"User spezifiziert den Präfix für Proxy-Namen zur Unterscheidung von anderen "
-"Clients. Falls dieser Wert \"\" beträgt, werden Proxy-Namen automatisch zu "
-"\"{user} {proxy_name} \" umgeschrieben.<br />Standardwert hierfür ist \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
-msgstr "frp Client"
+msgstr ""
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Betriebssystemumgebungsvariablen welche an frp für das Konfig-Datei-"
-#~ "Template weitergereicht werden, siehe <a href=\"https://github.com/"
-#~ "fatedier/frp#configuration-file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocol spezifiziert das Protokoll welches zur Interaktion mit dem "
-#~ "Server verwendet werden soll. Gültige Werte sind \"tcp\", \"kcp\" und "
-#~ "\"websocket\".<br />Standardwert hierfür ist \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType spezifiziert den Typ des Proxyservers. Gültige Werte beinhalten "
-#~ "\"tcp\", \"udp\", \"https\", \"stcp\" und \"xtcp\".<br />Standardwert "
-#~ "hierfür ist \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable spezifiziert ob TLS bei der Kommunikation mit dem Server "
-#~ "verwendet werden soll."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/el/frpc.po
+++ b/applications/luci-app-frpc/po/el/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "προχωρημένο"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Εξουσιοδότηση"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Διεύθυνση στην οποία ακούει η υπηρεσία"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Απενεργοποιημένο"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Ενεργοποιήθηκε"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Κρυπτογράφηση"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Γενικές ρυθμίσεις"
 
@@ -132,319 +415,810 @@ msgstr "Γενικές ρυθμίσεις"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Επίπεδο καταγραφής"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Πρωτόκολλο"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "ΕΚΤΕΛΕΙΤΕ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Χρήστης"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/eo/frpc.po
+++ b/applications/luci-app-frpc/po/eo/frpc.po
@@ -7,121 +7,404 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -129,319 +412,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/es/frpc.po
+++ b/applications/luci-app-frpc/po/es/frpc.po
@@ -13,138 +13,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Añadir nuevo proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configuraciones adicionales"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Configuración adicional"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Dirección del administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Contraseña de administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Puerto del administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Usuario de administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr especifica la dirección a la que se une el servidor de "
-"administración.<br />De manera predeterminada, este valor es «0.0.0.0»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort especifica el puerto para que el servidor de administración "
-"escuche. Si este valor es 0, el servidor de administración no se iniciará."
-"<br />De manera predeterminada, este valor es 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd especifica la contraseña que el servidor de administración usará "
-"para iniciar sesión.<br />De manera predeterminada, este valor es «admin»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser especifica el nombre de usuario que el administrador del servidor "
-"usará para iniciar sesión.<br /> Por defecto, este valor es «admin»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Directorio de activos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"AssetsDir especifica el directorio local desde el que el servidor de "
-"administración cargará los recursos. Si este valor es \"\", los activos se "
-"cargarán desde el ejecutable incluido usando statik.<br />Por defecto, este "
-"valor es \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "Dir. de enlace"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Dirección de enlace"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Puerto de enlace"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Recopilando datos..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Configuración común"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Compresión"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
-"Los archivos de configuración incluyen en el archivo de configuración "
-"temporal"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Dominios personalizados"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Desactivar color de registro"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor desactiva los colores de registro cuando LogWay == "
-"\"console\" cuando se establece en verdadero."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Activado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Cifrado"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Variable ambiental"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Salir cuando falla el inicio de sesión"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Configuración general"
 
@@ -152,410 +418,810 @@ msgstr "Configuración general"
 msgid "Grant access to LuCI app frpc"
 msgstr "Conceder acceso a la aplicación frpc de LuCI"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Configuración HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Contraseña HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Proxy HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Usuario HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval especifica en qué intervalo se envían los latidos al "
-"servidor, en segundos. No se recomienda cambiar este valor.<br />Por "
-"defecto, este valor es 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout especifica el retraso de respuesta de latido máximo "
-"permitido antes de que finalice la conexión, en segundos. No se recomienda "
-"cambiar este valor.<br />Por defecto, este valor es 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Intervalo de latidos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Tiempo de espera de latidos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Reescritura de encabezado de host"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy especifica una dirección proxy para conectarse al servidor. Si "
-"este valor es \"\", el servidor se conectará directamente.<br />De manera "
-"predeterminada, este valor se lee desde la variable de entorno «http_proxy»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Si el puerto remoto es 0, frps te asignará un puerto"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Puerto local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"LocalIp especifica la dirección IP o el nombre de host al que se utilizará "
-"el proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort especifica el puerto al que se aplicará el proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Localizaciones"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Archivo de registro"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Ajustes de registro"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Nivel de registro"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Máx. días de registro"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Registro de stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Registro de stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile especifica un archivo en el que se escribirán los registros. Este "
-"valor solo se utilizará si LogWay se configura correctamente.<br />De forma "
-"predeterminada, este valor es «console»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel especifica el nivel mínimo de registro. Los valores válidos son «"
-"trace», «debug», «info», «warn» y «error».<br />Por defecto, este valor es «"
-"info»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays especifica el número máximo de días para almacenar información de "
-"registro antes de la eliminación. Esto solo se usa si LogWay == «archivo"
-"».<br />De forma predeterminada, este valor es 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit controla si el cliente debe salir o no después de un intento "
-"fallido de inicio de sesión. Si es falso, el cliente volverá a intentarlo "
-"hasta que un intento de inicio de sesión tenga éxito.<br />Por defecto, este "
-"valor es verdadero."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NO SE ESTÁ EJECUTANDO"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"Los entornos del sistema operativo pasan a frp para la plantilla del archivo "
-"de configuración, consulte %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Complemento"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Configuración del complemento"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocolo"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"El protocolo especifica el protocolo que se usará al interactuar con el "
-"servidor. Los valores válidos son «tcp», «kcp», «quic» y «websocket».<br />"
-"Por defecto, este valor es «tcp»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Configuración del proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Nombre del proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Tipo del proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType especifica el tipo de este proxy. Los valores válidos son «tcp», «"
-"udp», «http», «https», «stcp» y «xtcp».<br />De forma predeterminada, este "
-"valor es «tcp»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "EJECUTÁNDOSE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Puerto remoto"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Reaparecer cuando se estrelló"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rol"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Ejecutar demonio como grupo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Ejecutar demonio como usuario"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Contraseña para SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "Usuario de SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Dirección del servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nombre del servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Puerto del servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr especifica la dirección del servidor al que conectarse.<br />Por "
-"defecto, este valor es «127.0.0.1»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort especifica el puerto para conectarse al servidor.<br />Por "
-"defecto, este valor es 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Configuración de inicio"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Subdominio"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "Multiplexación TCP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"Activar TLS especifica si se debe utilizar o no TLS al comunicarse con el "
-"servidor."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux alterna la multiplexación de flujo TCP. Esto permite que múltiples "
-"solicitudes de un cliente compartan una sola conexión TCP. Si este valor es "
-"verdadero, el servidor también debe tener activada la multiplexación "
-"TCP.<br />De manera predeterminada, este valor es verdadero."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Esta lista se puede utilizar para especificar algunos parámetros adicionales "
-"que no se han incluido en este LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token especifica el token de autorización utilizado para crear claves para "
-"enviar al servidor. El servidor debe tener un token coincidente para que la "
-"autorización tenga éxito.<br />Por defecto, este valor es \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Ruta del socket del dominio Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression controla si la comunicación con el servidor se comprimirá o "
-"no.<br />Por defecto, este valor es falso."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption controla si la comunicación con el servidor se cifrará o no. "
-"El cifrado se realiza utilizando los tokens suministrados en la "
-"configuración del servidor y del cliente.<br />De manera predeterminada, "
-"este valor es falso."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Usuario"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"El usuario especifica un prefijo para los nombres de proxy para "
-"distinguirlos de otros clientes. Si este valor no es \"\", los nombres de "
-"proxy se cambiarán automáticamente a «{user}.{Proxy_name}».<br />De manera "
-"predeterminada, este valor es \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "Cliente frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Los entornos de SO pasan a frp para la plantilla del archivo de "
-#~ "configuración, véase <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp LEAME</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocolo especifica el protocolo que se utilizará al interactuar con el "
-#~ "servidor. Los valores válidos son \"tcp\", \"kcp\" y \"websocket\".<br /"
-#~ ">De manera predeterminada, este valor es \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType especifica el tipo de este proxy. Los valores válidos incluyen "
-#~ "\"tcp\", \"udp\", \"http\", \"https\", \"stcp\" y \"xtcp\".<br />Por "
-#~ "defecto, este valor es \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable especifica si TLS debe usarse o no cuando se comunica con el "
-#~ "servidor."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/et/frpc.po
+++ b/applications/luci-app-frpc/po/et/frpc.po
@@ -7,121 +7,404 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -129,319 +412,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/fa/frpc.po
+++ b/applications/luci-app-frpc/po/fa/frpc.po
@@ -1,387 +1,382 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-02-08 18:10+0000\n"
 "Project-Id-Version: luci-app-frpc\n"
-"Last-Translator: 大王叫我来巡山 "
-"<hamburger2048@users.noreply.hosted.weblate.org>\n"
-"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
-"projects/openwrt/luciapplicationsfrpc/zh_Hans/>\n"
-"Language: zh_Hans\n"
+"PO-Revision-Date: 2025-12-20 14:35+0000\n"
+"Last-Translator: Ashkan Azoun <ashk4n@gmail.com>\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsfrpc/fa/>\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.16-dev\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 5.15.1\n"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
 msgid "Add new proxy or visitor..."
-msgstr "添加新的代理或访问者..."
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
 msgid "Additional OIDC token endpoint params. Use key=value."
-msgstr "附加 OIDC 令牌端点参数。使用 key=value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
 msgid "Additional auth scopes"
-msgstr "额外认证范围"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
 msgid "Additional client metadata. Use key=value."
-msgstr "附加客户端元数据。使用 key=value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
 msgid "Additional config files included by frpc."
-msgstr "frpc 包含的附加配置文件。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
-msgstr "额外配置"
+msgstr "پیکربندی‌های اضافی"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
 msgid "Additional proxy metadata. Use key=value."
-msgstr "附加代理元数据。使用 key=value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
 msgid "Additional scopes to include authentication information."
-msgstr "包含认证信息的附加作用域。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
 msgid "Address of the frps server."
-msgstr "frps 服务器地址。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
 msgid "Advanced"
-msgstr "高级"
+msgstr "پیشرفته"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
 msgid "Allow users"
-msgstr "允许用户"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
 msgid "Annotations"
-msgstr "注解"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
 msgid "Annotations displayed on frps dashboard. Use key=value."
-msgstr "显示在 frps 仪表盘上的注解。使用 key=value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
-msgstr "资源目录"
+msgstr "شاخهٔ دارایی‌ها"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
 msgid "Authentication"
-msgstr "认证"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
 msgid "Authentication method"
-msgstr "认证方式"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
 msgid "Authentication method."
-msgstr "认证方式。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
 msgid "Bandwidth limit"
-msgstr "带宽限制"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
 msgid "Bandwidth limit mode"
-msgstr "带宽限制模式"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
 msgid "Bandwidth limit, for example 1MB."
-msgstr "带宽限制，例如 1MB。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
 msgid "Bind address"
-msgstr "绑定地址"
+msgstr "نشانی اتصال"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
-msgstr "绑定端口"
+msgstr "درگاه اتصال"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
 msgid "Bind port is required for visitors."
-msgstr "访问者必须填写绑定端口。"
+msgstr ""
 
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
 msgid "Client"
-msgstr "客户端"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
 msgid "Client ID"
-msgstr "客户端 ID"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
 msgid "Client metadata"
-msgstr "客户端元数据"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
-msgstr "正在收集数据…"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
 msgid "Command arguments passed to token source exec."
-msgstr "传递给令牌来源执行命令的参数。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
 msgid ""
 "Command used to obtain the token. The init script adds --allow-"
 "unsafe=TokenSourceExec when this source type is used."
 msgstr ""
-"用于获取令牌的命令。使用此来源类型时，init 脚本会添加 --allow-"
-"unsafe=TokenSourceExec。"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
-msgstr "常规设置"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
 msgid ""
 "Compatibility field for UCI. Server sections are emitted as proxy entries; "
 "visitor sections are emitted as visitor entries."
-msgstr "UCI 兼容字段。服务端段会生成为代理条目；访问者段会生成为访问者条目。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
 msgid "Compress proxy traffic."
-msgstr "压缩代理流量。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
-msgstr "压缩"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
 msgid "Configuration key: auth.oidc.audience."
-msgstr "配置键：auth.oidc.audience。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
 msgid "Configuration key: auth.oidc.clientID."
-msgstr "配置键：auth.oidc.clientID。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
 msgid "Configuration key: auth.oidc.clientSecret."
-msgstr "配置键：auth.oidc.clientSecret。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
 msgid "Configuration key: auth.oidc.scope."
-msgstr "配置键：auth.oidc.scope。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
 msgid "Configuration key: auth.oidc.tokenEndpointURL."
-msgstr "配置键：auth.oidc.tokenEndpointURL。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
 msgid "Configuration key: log.level."
-msgstr "配置键：log.level。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
 msgid "Configuration key: plugin.crtPath."
-msgstr "配置键：plugin.crtPath。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
 msgid "Configuration key: plugin.hostHeaderRewrite."
-msgstr "配置键：plugin.hostHeaderRewrite。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
 msgid "Configuration key: plugin.httpPassword."
-msgstr "配置键：plugin.httpPassword。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
 msgid "Configuration key: plugin.httpUser."
-msgstr "配置键：plugin.httpUser。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
 msgid "Configuration key: plugin.keyPath."
-msgstr "配置键：plugin.keyPath。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
 msgid "Configuration key: plugin.localPath."
-msgstr "配置键：plugin.localPath。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
 msgid "Configuration key: plugin.password."
-msgstr "配置键：plugin.password。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
 msgid "Configuration key: plugin.stripPrefix."
-msgstr "配置键：plugin.stripPrefix。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
 msgid "Configuration key: plugin.unixPath."
-msgstr "配置键：plugin.unixPath。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
 msgid "Configuration key: plugin.username."
-msgstr "配置键：plugin.username。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
 msgid "Configuration key: proxies[].customDomains."
-msgstr "配置键：proxies[].customDomains。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
 msgid "Configuration key: proxies[].loadBalancer.group."
-msgstr "配置键：proxies[].loadBalancer.group。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
 msgid "Configuration key: proxies[].loadBalancer.groupKey."
-msgstr "配置键：proxies[].loadBalancer.groupKey。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
 msgid "Configuration key: proxies[].subdomain."
-msgstr "配置键：proxies[].subdomain。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
 msgid "Configuration key: transport.quic.keepalivePeriod."
-msgstr "配置键：transport.quic.keepalivePeriod。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
 msgid "Configuration key: transport.quic.maxIdleTimeout."
-msgstr "配置键：transport.quic.maxIdleTimeout。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
 msgid "Configuration key: transport.quic.maxIncomingStreams."
-msgstr "配置键：transport.quic.maxIncomingStreams。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
 msgid "Connect server local IP"
-msgstr "连接服务器本地 IP"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
 msgid "Connection pool count"
-msgstr "连接池数量"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
 msgid "Connections established in advance."
-msgstr "预先建立的连接数。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
 msgid "Custom CA certificate file for OIDC endpoint."
-msgstr "OIDC 端点的自定义 CA 证书文件。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
 msgid "Custom DNS server used by frpc."
-msgstr "frpc 使用的自定义 DNS 服务器。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
-msgstr "自定义域"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
 msgid "DNS server"
-msgstr "DNS 服务器"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
 msgid "Dial server keepalive"
-msgstr "拨号服务器保活"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
 msgid "Dial server timeout"
-msgstr "拨号服务器超时"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
 msgid "Disable NAT assisted addresses"
-msgstr "禁用 NAT 辅助地址"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
 msgid "Disable custom TLS first byte"
-msgstr "禁用自定义 TLS 首字节"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
 msgid "Disable local interface assisted addresses for XTCP NAT traversal."
-msgstr "禁用用于 XTCP NAT 穿透的本地接口辅助地址。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
-msgstr "禁用日志的颜色"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
 msgid "Disable log colors when log output is console."
-msgstr "当日志输出到控制台时禁用日志颜色。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
 msgid "Disabled"
-msgstr "已禁用"
+msgstr "غیرفعال"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
 msgid "Effective when XTCP keep tunnel open is enabled."
-msgstr "启用 XTCP 保持隧道打开时生效。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
 msgid "Enable Go pprof handlers in web server."
-msgstr "在 Web 服务器中启用 Go pprof 处理器。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
 msgid "Enable HTTP/2 for HTTPS bridge plugins."
-msgstr "为 HTTPS 桥接插件启用 HTTP/2。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
 msgid ""
 "Enable HTTPS for the frpc web server. This switch controls whether "
 "webServer.tls.certFile and webServer.tls.keyFile are emitted."
 msgstr ""
-"为 frpc Web 服务器启用 HTTPS。此开关控制是否生成 webServer.tls.certFile 和 "
-"webServer.tls.keyFile。"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
 msgid "Enable TCP stream multiplexing."
-msgstr "启用 TCP 流多路复用。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
 msgid ""
 "Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
-msgstr "与 frps 通信时启用 TLS。自 frp v0.50.0 起默认为 true。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
 msgid "Enable or disable this proxy."
-msgstr "启用或禁用此代理。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
 msgid "Enable pprof"
-msgstr "启用 pprof"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
 msgid "Enable web HTTPS"
-msgstr "启用 Web HTTPS"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
 msgid "Enabled"
-msgstr "已启用"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
 msgid "Encrypt proxy traffic."
-msgstr "加密代理流量。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
-msgstr "加密"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
-msgstr "环境变量"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
 msgid "Environment variable must use KEY=value format."
-msgstr "环境变量必须使用 KEY=value 格式。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
 msgid "Environment variables passed to token source exec. Use KEY=value."
-msgstr "传递给令牌来源执行命令的环境变量。使用 KEY=value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
 msgid "Exit frpc when the first login fails."
-msgstr "首次登录失败时退出 frpc。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
 msgid "Exit when login fails"
-msgstr "登录失败时退出"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
 msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
-msgstr "实验性功能开关。使用 key=value，例如 VirtualNet=true。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
 msgid ""
@@ -389,170 +384,168 @@ msgid ""
 "visitor sections. Use frp includes or per-proxy raw settings for proxy/"
 "visitor tables."
 msgstr ""
-"在生成的代理和访问者段之前包含额外的根级配置片段。代理/访问者表请使用 frp "
-"includes 或每个代理的原始设置。"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
 msgid "Fallback timeout in milliseconds for XTCP."
-msgstr "XTCP 回退超时时间，单位为毫秒。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
 msgid "Fallback timeout ms"
-msgstr "回退超时毫秒数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
 msgid "Fallback to"
-msgstr "回退到"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
 msgid "Fallback visitor name for XTCP."
-msgstr "XTCP 回退访问者名称。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
 msgid "Feature gates"
-msgstr "功能开关"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
 msgid "For virtual_net visitor plugin."
-msgstr "用于 virtual_net 访问者插件。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
-msgstr "常规设置"
+msgstr ""
 
 #: applications/luci-app-frpc/root/usr/share/rpcd/acl.d/luci-app-frpc.json:3
 msgid "Grant access to LuCI app frpc"
-msgstr "授予访问 LuCI 应用 frpc 的权限"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
 msgid "HTTP / Domain"
-msgstr "HTTP / 域名"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
 msgid "HTTP health check headers. Use Header=Value."
-msgstr "HTTP 健康检查请求头。使用 Header=Value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
 msgid "HTTP health check path."
-msgstr "HTTP 健康检查路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
 msgid "HTTP or TCPMUX basic auth password."
-msgstr "HTTP 或 TCPMUX 基本认证密码。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
 msgid "HTTP or TCPMUX basic auth username."
-msgstr "HTTP 或 TCPMUX 基本认证用户名。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
-msgstr "HTTP 密码"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
 msgid "HTTP path must start with /."
-msgstr "HTTP 路径必须以 / 开头。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
-msgstr "HTTP 用户"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
 msgid "Health Check"
-msgstr "健康检查"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
 msgid "Health check headers"
-msgstr "健康检查请求头"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
 msgid "Health check interval"
-msgstr "健康检查间隔"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
 msgid "Health check interval in seconds."
-msgstr "健康检查间隔，单位为秒。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
 msgid "Health check max failed"
-msgstr "健康检查最大失败次数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
 msgid "Health check path"
-msgstr "健康检查路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
 msgid "Health check path is required when health check type is http."
-msgstr "健康检查类型为 http 时必须填写健康检查路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
 msgid "Health check timeout"
-msgstr "健康检查超时"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
 msgid "Health check timeout in seconds."
-msgstr "健康检查超时时间，单位为秒。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
 msgid "Health check type"
-msgstr "健康检查类型"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
 msgid "Health check type."
-msgstr "健康检查类型。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
-msgstr "心跳包间隔时间"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
 msgid "Heartbeat interval in seconds."
-msgstr "心跳间隔，单位为秒。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
-msgstr "心跳包超时"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
 msgid "Heartbeat timeout in seconds."
-msgstr "心跳超时时间，单位为秒。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
-msgstr "主机头重写"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
 msgid "Include config files"
-msgstr "包含配置文件"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
 msgid "Keep XTCP tunnel open."
-msgstr "保持 XTCP 隧道打开。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
 msgid "Keep tunnel open"
-msgstr "保持隧道打开"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
 msgid "Keepalive interval for TCP mux."
-msgstr "TCP 多路复用保活间隔。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
 msgid "Load Balancer"
-msgstr "负载均衡"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
 msgid "Load balancer group"
-msgstr "负载均衡组"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
 msgid "Load balancer group is required when group key is set."
-msgstr "设置负载均衡组密钥时必须填写负载均衡组。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
 msgid "Load balancer group key"
-msgstr "负载均衡组密钥"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
@@ -560,17 +553,15 @@ msgid ""
 "exec runs a command and requires frp unsafe permission. Mutually exclusive "
 "with auth.token."
 msgstr ""
-"从外部来源加载令牌。file 从本地文件读取令牌；exec 运行命令并需要 frp unsafe "
-"权限。与 auth.token 互斥。"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
-msgstr "本地 IP"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
 msgid ""
 "Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
-msgstr "连接 frps 时绑定的本地 IP。仅对 tcp、websocket 或 wss 有效。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
 msgid ""
@@ -578,661 +569,658 @@ msgid ""
 "and tls2raw, this is the local service address reached after frp terminates "
 "external TLS; for http2https/http2http, it is the local upstream address."
 msgstr ""
-"桥接插件使用的本地后端地址。对于 https2http、https2https 和 tls2raw，这是 "
-"frp 终止外部 TLS 后访问的本地服务地址；对于 http2https/http2http，这是本地上"
-"游地址。"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
 msgid "Local bind address for visitor."
-msgstr "访问者本地绑定地址。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
 msgid "Local bind port for visitor. Use a negative value to avoid binding."
-msgstr "访问者本地绑定端口。使用负值可避免绑定。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
-msgstr "本地端口"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
 msgid "Local service IP or host."
-msgstr "本地服务 IP 或主机名。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
 msgid "Local service port."
-msgstr "本地服务端口。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
-msgstr "位置"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
 msgid "Log Settings"
-msgstr "日志设置"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
-msgstr "日志级别"
+msgstr "سطح دسترسی لاگ"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
-msgstr "日志最大天数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
 msgid "Log output"
-msgstr "日志输出"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
 msgid "Log output path or console."
-msgstr "日志输出路径或 console。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
-msgstr "错误日志"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
-msgstr "普通日志"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
 msgid "Max retries per hour"
-msgstr "每小时最大重试次数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
 msgid "Maximum number of days to keep logs."
-msgstr "保留日志的最大天数。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
 msgid "Metadata"
-msgstr "元数据"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
 msgid "Min retry interval"
-msgstr "最小重试间隔"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
 msgid "Minimum XTCP retry interval."
-msgstr "XTCP 最小重试间隔。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
 msgid "Multiplexer"
-msgstr "多路复用器"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
 msgid "NAT hole STUN server"
-msgstr "NAT 打洞 STUN 服务器"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
-msgstr "未在运行"
+msgstr "اجرا نمی‌شود"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
 msgid "OIDC additional endpoint params"
-msgstr "OIDC 额外端点参数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
 msgid "OIDC audience"
-msgstr "OIDC 受众"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
 msgid "OIDC client ID"
-msgstr "OIDC 客户端 ID"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
 msgid "OIDC client secret"
-msgstr "OIDC 客户端密钥"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
 msgid "OIDC insecure skip verify"
-msgstr "OIDC 不安全跳过验证"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
 msgid "OIDC proxy URL"
-msgstr "OIDC 代理 URL"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
 msgid "OIDC scope"
-msgstr "OIDC 范围"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
 msgid "OIDC token endpoint URL"
-msgstr "OIDC 令牌端点 URL"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
 msgid "OIDC trusted CA file"
-msgstr "OIDC 受信任 CA 文件"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
 msgid "OS environments passed to frp for config file template, see %s."
-msgstr "传递给 frp 配置文件模板的 OS 环境变量，请参见 %s。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
 msgid "Only start specified proxies or visitors. Empty means start all."
-msgstr "仅启动指定的代理或访问者。留空表示启动全部。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
 msgid "Only the virtual_net plugin is valid for visitors."
-msgstr "访问者仅支持 virtual_net 插件。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
 msgid "Only valid for HTTP proxy."
-msgstr "仅对 HTTP 代理有效。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
 msgid ""
 "Only visitors from specified users can connect. Use * to allow all users."
-msgstr "仅允许指定用户的访问者连接。使用 * 允许所有用户。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
 msgid "Optional unique identifier for this frpc instance."
-msgstr "此 frpc 实例的可选唯一标识符。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
 msgid "Path of token file."
-msgstr "令牌来源文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
 msgid "Path to the TLS certificate file."
-msgstr "TLS 证书文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
 msgid "Path to the TLS private key file."
-msgstr "TLS 私钥文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
 msgid "Path to the certificate file used by the HTTPS web server."
-msgstr "HTTPS Web 服务器使用的证书文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
 msgid "Path to the private key file used by the HTTPS web server."
-msgstr "HTTPS Web 服务器使用的私钥文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
 msgid "Path to the trusted CA certificate file."
-msgstr "受信任 CA 证书文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
 msgid ""
 "Persist runtime proxy and visitor configuration for Web UI or API management."
-msgstr "持久化运行时代理和访问者配置，用于 Web UI 或 API 管理。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
 msgid "Please use KEY=value format."
-msgstr "请使用 KEY=value 格式。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
-msgstr "插件"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
 msgid "Plugin HTTP/2"
-msgstr "插件 HTTP/2"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
 msgid "Plugin certificate path"
-msgstr "插件证书路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
 msgid "Plugin host header rewrite"
-msgstr "插件 Host 头重写"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
 msgid "Plugin key path"
-msgstr "插件密钥路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
 msgid "Plugin local address"
-msgstr "插件本地地址"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
 msgid "Plugin request headers"
-msgstr "插件请求头"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
 msgid "Plugin type."
-msgstr "插件类型。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
 msgid "Port must be a number between 0 and 65535."
-msgstr "端口必须是 0 到 65535 之间的数字。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
 msgid "Port must be between 0 and 65535."
-msgstr "端口必须介于 0 到 65535 之间。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
 msgid "Port must be negative or a number between 1 and 65535."
-msgstr "端口必须为负数，或为 1 到 65535 之间的数字。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
 msgid "Port must be negative or between 1 and 65535."
-msgstr "端口必须为负数，或介于 1 到 65535 之间。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
 msgid "Port of the frps server. Default is 7000."
-msgstr "frps 服务器端口。默认值为 7000。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
 msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
-msgstr "代理名称前缀。如果设置，代理名称将变为 {user}.{proxy}。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
 msgid "Proxy / Visitor Settings"
-msgstr "代理 / 访问者设置"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
 msgid "Proxy URL"
-msgstr "代理 URL"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
 msgid "Proxy URL for OIDC token endpoint."
-msgstr "OIDC 令牌端点的代理 URL。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
 msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
-msgstr "用于连接 frps 的代理 URL。支持 http、socks5 和 ntlm。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
 msgid "Proxy metadatas"
-msgstr "代理元数据"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
-msgstr "代理名称"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
 msgid "Proxy name prefix"
-msgstr "代理名称前缀"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
 msgid "Proxy protocol version"
-msgstr "代理协议版本"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
-msgstr "代理类型"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
 msgid "Proxy type."
-msgstr "代理类型。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
 msgid "QUIC keepalive period"
-msgstr "QUIC 保活周期"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
 msgid "QUIC max idle timeout"
-msgstr "QUIC 最大空闲超时"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
 msgid "QUIC max incoming streams"
-msgstr "QUIC 最大传入流数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
-msgstr "运行中"
+msgstr "در حال اجرا"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
-msgstr "远程端口"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
 msgid "Remote port listened by frps. If 0, frps assigns a random port."
-msgstr "frps 监听的远程端口。若为 0，frps 会分配随机端口。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
 msgid "Remove proxy from frps after continuous failures."
-msgstr "连续失败后从 frps 移除此代理。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
 msgid "Request headers"
-msgstr "请求头"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
-msgstr "崩溃时重启"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
 msgid "Response headers"
-msgstr "响应头"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
 msgid "Rewrite Host header."
-msgstr "重写 Host 头。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
-msgstr "角色"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
 msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
-msgstr "按 HTTP 基本认证用户路由 HTTP 或 TCPMUX 请求。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
 msgid "Route by HTTP user"
-msgstr "按 HTTP 用户路由"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
-msgstr "以此组权限运行"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
-msgstr "以此用户权限运行"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
-msgstr "SOCKS5 密码"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
-msgstr "SOCKS5 用户"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
 msgid "STCP / XTCP / SUDP"
-msgstr "STCP / XTCP / SUDP"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
 msgid "STUN server used for NAT traversal."
-msgstr "用于 NAT 穿透的 STUN 服务器。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
 msgid "Secret key"
-msgstr "密钥"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
 msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
-msgstr "STCP/XTCP/SUDP 代理和访问者使用的密钥。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
-msgstr "服务器地址"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
-msgstr "服务器名称"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
 msgid "Server name is required for visitors."
-msgstr "访问者必须填写服务器名称。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
 msgid "Server name used for TLS verification."
-msgstr "用于 TLS 验证的服务器名称。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
-msgstr "服务器端口"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
 msgid "Server proxy name to visit."
-msgstr "要访问的服务器代理名称。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
 msgid "Server user"
-msgstr "服务器用户"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
 msgid "Server user for visitor."
-msgstr "访问者对应的服务器用户。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
 msgid "Set request headers. Use Header=Value."
-msgstr "设置请求头。使用 Header=Value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
 msgid "Set response headers. Use Header=Value."
-msgstr "设置响应头。使用 Header=Value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
 msgid "Since frp v0.50.0, default is true."
-msgstr "自 frp v0.50.0 起默认为 true。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
 "Skip TLS verification for OIDC endpoint. Not recommended for production."
-msgstr "跳过 OIDC 端点的 TLS 验证。不建议在生产环境使用。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
 msgid "Start proxies / visitors"
-msgstr "启动代理 / 访问者"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
-msgstr "启动设置"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
 msgid "Static file local path"
-msgstr "静态文件本地路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
 msgid "Static file strip prefix"
-msgstr "静态文件剥离前缀"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
 msgid "Store file path"
-msgstr "存储文件路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
-msgstr "子域名"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
 msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
-msgstr "TCP 保活间隔，单位为秒。负值表示禁用保活。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
 msgid "TCP multiplexer."
-msgstr "TCP 多路复用器。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
-msgstr "TCP 多路复用"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
 msgid "TCP mux keepalive interval"
-msgstr "TCP mux 保活间隔"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
-msgstr "TLS"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
 msgid "TLS / QUIC"
-msgstr "TLS / QUIC"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
 msgid "TLS certificate path"
-msgstr "TLS 证书路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
 msgid "TLS certificate path is required when web HTTPS is enabled."
-msgstr "启用 Web HTTPS 时必须填写 TLS 证书路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
 msgid "TLS private key path"
-msgstr "TLS 私钥路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
 msgid "TLS private key path is required when web HTTPS is enabled."
-msgstr "启用 Web HTTPS 时必须填写 TLS 私钥路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
 msgid "TLS server name"
-msgstr "TLS 服务器名称"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
 msgid "TLS trusted CA path"
-msgstr "TLS 受信任 CA 路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
 msgid "Timeout in seconds for connecting to frps."
-msgstr "连接 frps 的超时时间，单位为秒。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
-msgstr "令牌"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
 msgid "Token and token source are mutually exclusive."
-msgstr "令牌和令牌来源互斥。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
 msgid "Token source command"
-msgstr "令牌来源命令"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
 msgid "Token source command arguments"
-msgstr "令牌来源命令参数"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
 msgid "Token source command is required when token source type is exec."
-msgstr "令牌来源类型为 exec 时必须填写令牌来源命令。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
 msgid "Token source environment"
-msgstr "令牌来源环境变量"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
 msgid "Token source file"
-msgstr "令牌来源文件"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
 msgid "Token source file path is required when token source type is file."
-msgstr "令牌来源类型为文件时必须填写令牌来源文件路径。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
 msgid "Token source type"
-msgstr "令牌来源类型"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
 msgid "Token used for authentication."
-msgstr "用于认证的令牌。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
 msgid "Transport"
-msgstr "传输"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
 msgid "Transport Settings"
-msgstr "传输设置"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
 msgid "Transport protocol"
-msgstr "传输协议"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
 msgid "Transport protocol used to connect to frps."
-msgstr "用于连接 frps 的传输协议。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
 msgid "UDP packet size"
-msgstr "UDP 数据包大小"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
 msgid "UDP packet size in bytes. Should match frps. Default is 1500."
-msgstr "UDP 数据包大小，单位为字节。应与 frps 匹配。默认值为 1500。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
-msgstr "Unix 域套接字路径"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
 msgid "Use Header=Value."
-msgstr "使用 Header=Value。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
 msgid "Use proxy protocol to transfer connection info to local service."
-msgstr "使用 proxy protocol 向本地服务传递连接信息。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
 msgid "Virtual network address. Requires VirtualNet feature gate."
-msgstr "虚拟网络地址。需要 VirtualNet 功能开关。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
 msgid "VirtualNet address"
-msgstr "VirtualNet 地址"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
 msgid "VirtualNet destination IP"
-msgstr "VirtualNet 目标 IP"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
 msgid "VirtualNet destination IP is required for virtual_net visitors."
-msgstr "virtual_net 访问者必须填写 VirtualNet 目标 IP。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
 msgid "Web Server"
-msgstr "Web 服务器"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
 msgid "Web server address"
-msgstr "Web 服务器地址"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
 msgid "Web server assets directory."
-msgstr "Web 服务器资源目录。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
 msgid "Web server bind address."
-msgstr "Web 服务器绑定地址。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
 msgid "Web server password"
-msgstr "Web 服务器密码"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
 msgid "Web server password."
-msgstr "Web 服务器密码。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
 msgid "Web server port"
-msgstr "Web 服务器端口"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
 msgid "Web server port. Leave empty or set to 0 to disable the web server."
-msgstr "Web 服务器端口。留空或设为 0 表示禁用 Web 服务器。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
 msgid "Web server user"
-msgstr "Web 服务器用户"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
 msgid "Web server username."
-msgstr "Web 服务器用户名。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
 msgid "Where to limit bandwidth."
-msgstr "带宽限制位置。"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
 msgid "Wire protocol"
-msgstr "线路协议"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
 msgid "XTCP protocol"
-msgstr "XTCP 协议"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
 msgid "XTCP visitor tunnel protocol."
-msgstr "XTCP 访问者隧道协议。"
+msgstr ""
 
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
 msgid "frp"
-msgstr "frp"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
-msgstr "frp 客户端"
+msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
 msgid ""
 "frp internal wire protocol. v2 requires frps support and must be enabled "
 "explicitly."
-msgstr "frp 内部线路协议。v2 需要 frps 支持，并且必须显式启用。"
+msgstr ""

--- a/applications/luci-app-frpc/po/fi/frpc.po
+++ b/applications/luci-app-frpc/po/fi/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Lisäasetukset"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Todennus"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Sido osoite"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Sido portti"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Pois käytöstä"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Otettu käyttöön"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Salaus"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Yleiset asetukset"
 
@@ -132,319 +415,810 @@ msgstr "Yleiset asetukset"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Lokitaso"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "EI KÄYNNISSÄ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokolla"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "KÄYNNISSÄ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Palvelimen osoite"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
+msgstr "Palvelimen nimi"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Palvelinportti"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Käyttäjä"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/fr/frpc.po
+++ b/applications/luci-app-frpc/po/fr/frpc.po
@@ -10,138 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Ajouter un proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configurations supplémentaires"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Paramètres supplémentaires"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Adresse administrateur"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "mot de passe d'administrateur"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Port administrateur"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Utilisateur administrateur"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr spécifie l'adresse à laquelle le serveur d'administration se lie."
-"<br />Par défaut, cette valeur est \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort spécifie le port d'écoute du serveur d'administration. Si cette "
-"valeur est 0, le serveur d'administration ne sera pas démarré.<br />Par "
-"défaut, cette valeur est 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd spécifie le mot de passe que le serveur d'administration utilisera "
-"pour la connexion.<br />Par défaut, cette valeur est \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avancé"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser spécifie le nom d'utilisateur que le serveur d'administration "
-"utilisera pour la connexion.<br />Par défaut, cette valeur est \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Répertoire des actifs"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir spécifie le répertoire local à partir duquel le serveur "
-"d'administration chargera les ressources. Si cette valeur est \"\", les "
-"actifs seront chargés à partir de l'exécutable fourni à l'aide de statik."
-"<br />Par défaut, cette valeur est \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Authentification"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Lier l'adresse"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Port de liaison"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Récolte de données..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Paramètres communs"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid "Compression"
-msgstr "Compression"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
 msgstr ""
-"Les fichiers de configuration incluent dans le fichier de configuration "
-"temporaire"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
+msgid "Compression"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Domaines personnalisés"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Désactiver la couleur du journal"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor désactive les couleurs du journal lorsque LogWay == "
-"\"console\" lorsqu'il est défini sur true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Activé"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Chiffrement"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Variable d'environnement"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Quitter lorsque la connexion échoue"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Réglages généraux"
 
@@ -149,400 +415,810 @@ msgstr "Réglages généraux"
 msgid "Grant access to LuCI app frpc"
 msgstr "Accorder l'accès à l'application LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Paramètres HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Mot de passe HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Http proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Utilisateur HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval spécifie à quel intervalle les pulsations sont envoyées au "
-"serveur, en secondes. Il n'est pas recommandé de modifier cette valeur.<br /"
-">Par défaut, cette valeur est 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout spécifie le délai maximal de réponse de pulsation autorisé "
-"avant la fin de la connexion, en secondes. Il n'est pas recommandé de "
-"modifier cette valeur.<br />Par défaut, cette valeur est 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Intervalle des battements cardiaques"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Délai d'expiration du rythme cardiaque"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Réécriture de l'en-tête de l'hôte"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy spécifie une adresse proxy pour se connecter au serveur via. Si "
-"cette valeur est \"\", le serveur sera directement connecté.<br />Par "
-"défaut, cette valeur est lue à partir de la variable d'environnement "
-"\"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Si remote_port vaut 0, frps vous attribuera un port aléatoire"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP locale"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
-msgstr "Local port"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp spécifie l'adresse IP ou le nom d'hôte vers lequel proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort spécifie le port vers lequel proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Emplacements"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Fichier journal"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Niveau de journalisation"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Journal max jours"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Log stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Log stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile spécifie un fichier dans lequel les journaux seront écrits. Cette "
-"valeur ne sera utilisée que si LogWay est défini de manière appropriée.<br /"
-">Par défaut, cette valeur est \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel spécifie le niveau de journalisation minimum. Les valeurs valides "
-"sont \"trace\", \"debug\", \"info\", \"warn\" et \"error\".<br />Par défaut, "
-"cette valeur est \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays indique le nombre maximal de jours pendant lesquels les "
-"informations du journal doivent être conservées avant d'être supprimées. "
-"Cette valeur n'est utilisée que si LogWay == \"file\".<br />Par défaut, "
-"cette valeur est 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit contrôle si le client doit quitter ou non après une tentative "
-"de connexion échouée. Si la valeur est false, le client réessayera jusqu'à "
-"ce qu'une tentative de connexion réussisse.<br />Par défaut, cette valeur "
-"est vraie."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NON-EXÉCUTANT"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
-msgid "Plugin"
-msgstr "Plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Réglages Plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocole"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
 msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+"Only visitors from specified users can connect. Use * to allow all users."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Paramètres du proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
+msgid "Plugin"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Nom du proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Type de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "EXÉCUTION"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Port distant"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Réapparaître en cas de crash"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rôle"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Exécuter le démon en tant que groupe"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Exécuter le démon en tant qu'utilisateur"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Mot de passe SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5 utilisateur"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Adresse du serveur"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nom du serveur"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Port serveur"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr spécifie l'adresse du serveur auquel se connecter.<br />Par "
-"défaut, cette valeur est \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort spécifie le port sur lequel se connecter au serveur.<br />Par "
-"défaut, cette valeur est 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Paramètres de démarrage"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Sous-domaine"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
-msgstr "TLS"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"TcpMux bascule le multiplexage de flux TCP. Cela permet à plusieurs demandes "
-"d'un client de partager une seule connexion TCP. Si cette valeur est vraie, "
-"le multiplexage TCP doit également être activé sur le serveur.<br />Par "
-"défaut, cette valeur est vraie."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"Cette liste peut être utilisée pour spécifier des paramètres additionnels "
-"qui n'ont pas été inclus dans ce LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token spécifie le jeton d'autorisation utilisé pour créer les clés à envoyer "
-"au serveur. Le serveur doit avoir un jeton correspondant pour que "
-"l'autorisation réussisse.<br />Par défaut, cette valeur est \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Chemin de socket de domaine Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression contrôle si la communication avec le serveur sera compressée "
-"ou non.<br />Par défaut, cette valeur est false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption contrôle si la communication avec le serveur sera chiffrée ou "
-"non. Le chiffrement est effectué à l'aide des jetons fournis dans la "
-"configuration du serveur et du client.<br />Par défaut, cette valeur est "
-"fausse."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Utilisateur"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"L'utilisateur spécifie un préfixe pour les noms de proxy pour les distinguer "
-"des autres clients. Si cette valeur n'est pas \"\", les noms de proxy seront "
-"automatiquement modifiés en \"{user}.{Proxy_name}\".<br />Par défaut, cette "
-"valeur est \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
-msgstr "frp Client"
+msgstr ""
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Les environnements de système d'exploitation passent à frp pour le modèle "
-#~ "de fichier de configuration, voir <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocol spécifie le protocole à utiliser lors de l'interaction avec le "
-#~ "serveur. Les valeurs valides sont \"tcp\", \"kcp\" et \"websocket\".<br /"
-#~ ">Par défaut, cette valeur est \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType spécifie le type de ce proxy. Les valeurs valides sont \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\" et \"xtcp\".<br />Par défaut, "
-#~ "cette valeur est \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable spécifie si TLS doit être utilisé ou non lors de la "
-#~ "communication avec le serveur."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/ga/frpc.po
+++ b/applications/luci-app-frpc/po/ga/frpc.po
@@ -7,142 +7,408 @@ msgstr ""
 "Language: ga\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :(n>"
-"6 && n<11) ? 3 : 4;\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Cuir seachfhreastalaí nua leis..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Cumraíochtaí breise"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Socruithe breise"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Seoladh riaracháin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Pasfhocal riarthóra"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Port admin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Úsáideoir admin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"Sonraíonn AdminAddr an seoladh a nascann an freastalaí riaracháin leis.<br /"
-">De réir réamhshocraithe, is é an luach seo ná \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"Sonraíonn AdminPort an port a bhféadfaidh an freastalaí admin éisteacht air. "
-"Más é 0 an luach seo, ní thosófar an freastalaí riaracháin.<br />De réir "
-"réamhshocraithe, is é 0 an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"Sonraíonn AdminPwd an pasfhocal a úsáidfidh an freastalaí riaracháin le "
-"haghaidh logáil isteach.<br />De réir réamhshocraithe, is é an luach seo ná "
-"\"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Ardleibhéil"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"Sonraíonn AdminUser an t-ainm úsáideora a úsáidfidh an freastalaí riaracháin "
-"chun logáil isteach.<br />De réir réamhshocraithe, is é an luach seo ná "
-"\"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Sócmhainní dir"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Fíordheimhniú"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"Sonraíonn AssetsDir an t-eolaire áitiúil a luchtóidh an freastalaí "
-"riaracháin acmhainní uaithi. Más é \" \"an luach seo, déanfar sócmhainní a "
-"luchtú ón inrite cuachta le staticí.<br />De réir réamhshocraithe, is \" \" "
-"é an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "Seoladh Ceangailteach"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Seoladh ceangail"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Port ceangail"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Sonraí á mbailiú ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Socruithe Coitianta"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Comhbhrú"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Áirítear comhaid cumraíochta sa chomhad cumraíochta sealadach"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Fearainn saincheaptha"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Díchumasaigh dath an loga"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"Díchumasaíonn DisableLogColor dathanna loga nuair a bhíonn LogWay == "
-"\"consól\" socraithe nuair atá siad fíor."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Míchumasaithe"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Cumasaithe"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Criptiú"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Athróg timpeallachta"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Scoir nuair a theipeann ar logáil isteach"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Socruithe Ginearálta"
 
@@ -150,414 +416,810 @@ msgstr "Socruithe Ginearálta"
 msgid "Grant access to LuCI app frpc"
 msgstr "Deonaigh rochtain ar app LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Socruithe HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Pasfhocal HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "seachfhreastalaí HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Úsáideoir HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"Sonraíonn HeartBeatInterval cad iad na buillí croí eatramh a sheoltar chuig "
-"an bhfreastalaí, i soicindí. Ní mholtar an luach seo a athrú.<br />De réir "
-"réamhshocraithe, is é 30 an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"Sonraíonn HeartBeatTimeout an t-uasmhoill freagartha buille croí a "
-"cheadaítear sula gcuirtear deireadh leis an nasc, i soicindí. Ní mholtar an "
-"luach seo a athrú.<br />De réir réamhshocraithe, is é 90 an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Eatramh buille croí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Teorainn ama buille croí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Athscríobh ceanntásc an óstaigh"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"Sonraíonn HttpProxy seoladh seachfhreastalaí chun ceangal leis an "
-"bhfreastalaí tríd. Más é \" \"an luach seo, nascfar an freastalaí go díreach "
-"leis.<br />De réir réamhshocraithe, léitear an luach seo ón athróg "
-"timpeallachta \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Más 0 é remote_port, sannfaidh frps port randamach duit"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP Áitiúil"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Port áitiúil"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"Sonraíonn LocalIp an seoladh IP nó an t-ainm óstaigh chun an "
-"seachfhreastalaí dó."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "Sonraíonn LocalPort an port le seachfhreastalaí chuige."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Suímh"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Comhad logála"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Socruithe Logála"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Leibhéal loga"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Íoslódáil max laethanta"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Logáil isteach stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Logáil isteach stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"Sonraíonn LogFile comhad a mbeidh logs scríofa chuige. Ní úsáidfear an luach "
-"seo ach amháin má tá LogWay socraithe go cuí.<br />De réir réamhshocraithe, "
-"is \"consól\" an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"Sonraíonn LogLevel an t-íosleibhéal logála. Is iad na luachanna bailí "
-"\"rian\", \"debug\", \"info\", \"rabhadh\", agus \"earráid\".<br />De réir "
-"réamhshocraithe, is é an luach seo \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"Sonraíonn LogMaxDays an t-uaslíon laethanta chun faisnéis logála a stóráil "
-"roimh scriosadh. Ní úsáidtear é seo ach amháin i gcás LogWay == \"comhad\"."
-"<br />De réir réamhshocraithe, is é 0 an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"Rialaíonn LoginFailExit cibé ar cheart don chliant imeacht tar éis theip ar "
-"iarracht logáil isteach. Má tá sé bréagach, bainfidh an cliant triail eile "
-"as go dtí go n-éireoidh le hiarracht logáil isteach.<br />De réir "
-"réamhshocraithe, tá an luach seo fíor."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NÍ RÚCHÁN"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"Téann timpeallachtaí OS chuig frp le haghaidh teimpléad comhaid "
-"chumraíochta, féach %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Breiseán"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Socruithe Breiseán"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Prótacal"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Sonraíonn prótacal an prótacal atá le húsáid agus idirghníomhú á dhéanamh "
-"leis an bhfreastalaí. Is iad na luachanna bailí ná \"tcp\", \"kcp\", "
-"\"quic\" agus \"websocket\".<br />De réir réamhshocraithe, is é \"tcp\" an "
-"luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Socruithe Seachfhreastalaí"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Ainm seachfhreastalaí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Cineál seachfhreastalaí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"Sonraíonn Cineál Proxy cineál an seachfhreastalaí seo. I measc na luachanna "
-"bailí tá \"tcp\", \"udp\", \"http\", \"https\", \"stcp\" agus \"xtcp\".<br /"
-">De réir réamhshocraithe, is é \"tcp\" an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "REATHA"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Port cianda"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Respawn nuair a tuairteála"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Ról"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Rith deamhan mar ghrúpa"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Rith deamhan mar úsáideoir"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Pasfhocal SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5 úsáideora"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Seoladh freastalaí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Ainm freastalaí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Port freastalaí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"Sonraíonn ServerAddr seoladh an fhreastalaí le ceangal leis.<br />De réir "
-"réamhshocraithe, is é an luach seo ná \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"Sonraíonn ServerPort an port le ceangal leis an bhfreastalaí air.<br />De "
-"réir réamhshocraithe, is é 7000 an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Socruithe Tosaithe"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Fofhearann"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"Sonraíonn Cumasaigh TLS an bhfuil nó nach bhfuil TLS le húsáid agus "
-"cumarsáid á déanamh leis an bhfreastalaí."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"Déanann TcpMux ilphléacsáil sruth TCP a scoránú. Ligeann sé seo iarratais "
-"iolracha ó chliant chun nasc TCP amháin a roinnt. Má tá an luach seo fíor, "
-"caithfidh an freastalaí ilphléacsáil TCP a bheith cumasaithe freisin.<br /"
-">De réir réamhshocraithe, tá an luach seo fíor."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Is féidir an liosta seo a úsáid chun roinnt paraiméadair bhreise nach bhfuil "
-"san áireamh sa LUCI seo a shonrú."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Comhartha"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Sonraíonn Token an comhartha údaraithe a úsáidtear chun eochracha a chruthú "
-"a sheolfar chuig an bhfreastalaí. Ní mór comhartha meaitseála a bheith ag an "
-"bhfreastalaí le go n-éireoidh leis an údarú. <br />De réir réamhshocraithe, "
-"is é \" \"an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Conair soicéad fearainn Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"Rialaíonn UseCompression cé acu an ndéanfar cumarsáid leis an bhfreastalaí a "
-"chomhbhrú nó nach ndéanfar.<br />De réir réamhshocraithe, tá an luach seo "
-"bréagach."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"Rialaíonn UseEncryption cibé an mbeidh cumarsáid leis an bhfreastalaí "
-"criptithe nó nach mbeidh. Déantar an criptiú trí úsáid a bhaint as na "
-"comharthaí a soláthraíodh i gcumraíocht an fhreastalaí agus an chliaint.<br /"
-">De réir réamhshocraithe, tá an luach seo bréagach."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Úsáideoir"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Sonraíonn an t-úsáideoir réimír d’ainmneacha seachfhreastalaí chun iad a "
-"idirdhealú ó chliaint eile. Mura luach é seo \" \", athrófar ainmneacha "
-"seachfhreastalaí go huathoibríoch go \"{user}.{proxy_name}\".<br />De réir "
-"réamhshocraithe, is \" \"an luach seo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "frp Cliant"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Gabhann timpeallachtaí OS chuig frp le haghaidh teimpléad comhaid "
-#~ "cumraíochta, féach <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Sonraíonn Prótacal an prótacal atá le húsáid agus tú ag idirghníomhú leis "
-#~ "an bhfreastalaí. Is iad na luachanna bailí ná \"tcp\", \"kcp\", agus "
-#~ "\"websocket\".<br />De réir réamhshocraithe, is é an luach seo ná \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Sonraíonn ProxyType cineál an seachfhreastalaí seo. Áirítear le luachanna "
-#~ "bailí \"tcp\", \"udp\", \"http\", \"https\", \"stcp\", agus \"xtcp\".<br /"
-#~ ">De réir réamhshocraithe, is é an luach seo ná \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "Sonraíonn TLSEnable cé acu ar cheart nó nár cheart TLS a úsáid agus tú i "
-#~ "mbun cumarsáide leis an bhfreastalaí."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/he/frpc.po
+++ b/applications/luci-app-frpc/po/he/frpc.po
@@ -11,121 +11,404 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.0.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "אימות"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
 msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "פעילה"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
-msgstr ""
+msgstr "הצפנה"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "הגדרות כלליות"
 
@@ -133,319 +416,810 @@ msgstr "הגדרות כלליות"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "פרוטוקול"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/hi/frpc.po
+++ b/applications/luci-app-frpc/po/hi/frpc.po
@@ -4,121 +4,404 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "सक्रिय"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -126,319 +409,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/hu/frpc.po
+++ b/applications/luci-app-frpc/po/hu/frpc.po
@@ -10,132 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Új proxy hozzáadása..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "További konfigurációk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "További beállítások"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Admin cím"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Rendszergazda jelszó"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Admin port"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Rendszergazda felhasználó"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr azt a címet határozza meg amihez az admin szerver kötődik.<br /"
-">Alapértelmezés szerint ez az érték „0.0.0.0”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort meghatározza melyik porton figyeljen az admin szerver. Ha ez az "
-"érték 0, az admin szerver nem indul el.<br />Alapértelmezés szerint ez az "
-"érték 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-#, fuzzy
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd meghatározza azt a jelszót, amelyet az admin szerver a "
-"bejelentkezéshez használ.<br />Alapértelmezés szerint ez az érték „admin”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Speciális"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser meghatározza a felhasználónevet, amit az admin szerver a "
-"bejelentkezéshez használ.<br />Alapértelmezés szerint ez az érték „admin”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Hitelesítés"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Cím kötése"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Adatgyűjtés..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Általános Beállítások"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Tömörítés"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-#, fuzzy
-msgid "Config files include in temporary config file"
-msgstr "A konfig fájlok ideiglenes konfigurációs fájlban találhatók"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Egyedi domainek"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Színek kikapcsolása a naplóban"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Titkosítás"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Környezeti változó"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Kikapcsolás, ha a belépés sikertelen"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Általános beállítások"
 
@@ -143,322 +415,810 @@ msgstr "Általános beállítások"
 msgid "Grant access to LuCI app frpc"
 msgstr "Hozzáférés engedélyezése a <em>frpc</em> LuCI alkalmazáshoz"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP beállítások"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP jelszó"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "HTTP felhasználó"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
-msgstr ""
-"HeartBeatInterval meghatározza, hogy milyen gyakorisággal küldenek "
-"szívveréseket a szervernek, másodpercekben. Nem ajánlott megváltoztatni ezt "
-"az értéket.<br />Alapértelmezés szerint ez az érték 30."
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Lokális IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Helyi port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Naplózás szintje"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NEM FUT"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokoll"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "FUT"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Szerep"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Démon futtatása csoportként"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Démon futtatása felhasználóként"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Kiszolgáló címe"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Kiszolgáló neve"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Kiszolgáló port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Felhasználó (user)"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/it/frpc.po
+++ b/applications/luci-app-frpc/po/it/frpc.po
@@ -10,122 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Aggiungi un nuovo proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configurazioni aggiuntive"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Altre impostazioni"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Indirizzo dell'amministratore"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Admin password"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Porta admin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Utente Admin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avanzato"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Attività dir"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autenticazione"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Associa indirizzo"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "collega porta"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Caricamento dei dati in corso..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Impostazioni Comuni"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
-"I file di configurazione sono inclusi nel file di configurazione temporaneo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Disattivato"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Abilita"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Crittografia"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Impostazioni Generali"
 
@@ -133,319 +415,810 @@ msgstr "Impostazioni Generali"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Porta locale"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "File registro eventi"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Impostazioni log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Livello dei log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NON IN ESECUZIONE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
-msgid "Plugin"
-msgstr "Plugin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocollo"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
 msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+"Only visitors from specified users can connect. Use * to allow all users."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
+msgid "Plugin"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "IN ESECUZIONE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Porta remota"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Esegui il demone come utente"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Indirizzo del server"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nome del server"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Porta del server"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Utente"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/ja/frpc.po
+++ b/applications/luci-app-frpc/po/ja/frpc.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-12-07 21:54+0000\n"
-"Last-Translator: Monarch <monarch.scrap-0p@users.noreply.hosted.weblate.org>"
-"\n"
+"Last-Translator: Monarch "
+"<monarch.scrap-0p@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsfrpc/ja/>\n"
 "Language: ja\n"
@@ -11,121 +11,404 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "新しいプロキシを追加..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "追加の構成"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "追加設定"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "詳細設定"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "認証"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "バインドするIPアドレス"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "バインドするポート"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "共通設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "圧縮"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "ログの色を無効にする"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "無効"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "有効"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "暗号化"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "環境変数"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -133,319 +416,810 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP 設定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP パスワード"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "HTTP ユーザー"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "ハートビート間隔"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "ハートビート・タイムアウト"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "ローカル IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "ローカル・ポート"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "ログレベル"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "停止中"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "プロトコル"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "プロキシ設定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "実行中"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "役割"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "デーモンをグループとして実行"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "デーモンをユーザーとして実行"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "サーバー アドレス"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "サーバー名"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "サーバーのポート"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "トークン"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "ユーザー"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/ko/frpc.po
+++ b/applications/luci-app-frpc/po/ko/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "새 프록시 추가..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "추가 설정"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "추가 설정"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "관리자 암호"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "관리자 계정"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "고급"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "인증"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "바인드 주소"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "바인드 포트"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "데이터 수집 중 ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "일반 설정"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "사용자 정의 도메인"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "비활성화"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "활성화"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "암호화"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "환경 변수"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "일반 설정"
 
@@ -132,319 +415,810 @@ msgstr "일반 설정"
 msgid "Grant access to LuCI app frpc"
 msgstr "LuCI 앱 frpc에 접근 권한 부여"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP 설정"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "로컬 IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "로컬 포트"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr ""
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "로그 설정"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "로그 수준"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "표준 오류(stderr) 기록"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "표준 출력(stdout) 기록"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "중지됨"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "플러그인"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "프로토콜"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "프록시 설정"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "실행 중"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "원격 포트"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "충돌 시 자동 재시작"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "역할"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "데몬 실행 그룹"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "데몬 실행 사용자"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "서버 주소"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "서버 이름"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "서버 포트"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "시작 설정"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "하위 도메인"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "토큰"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "사용자"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/lo/frpc.po
+++ b/applications/luci-app-frpc/po/lo/frpc.po
@@ -10,131 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "ເພີ່ມພຣັອກຊີໃໝ່..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "ການຕັ້ງຄ່າເພີ່ມເຕີມ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "ການຕັ້ງຄ່າເພີ່ມເຕີມ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "ທີ່ຢູ່ຜູ້ເບິ່ງແຍງ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "ລະຫັດຜ່ານຜູ້ເບິ່ງແຍງ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "ພອດຜູ້ເບິ່ງແຍງ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "ຜູ້ໃຊ້ຜູ້ເບິ່ງແຍງ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr ກຳນົດທີ່ຢູ່ທີ່ເຊີເວີຜູ້ເບິ່ງແຍງເຊື່ອມຕໍ່.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort ກຳນົດພອດສຳລັບເຊີເວີຜູ້ເບິ່ງແຍງໃນການຟັງ. ຖ້າຄ່ານີ້ແມ່ນ 0, ເຊີເວີຜູ້ເບິ່ງແຍງຈະບໍ່ຖືກເປີ"
-"ດ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd ກຳນົດລະຫັດຜ່ານທີ່ເຊີເວີຜູ້ເບິ່ງແຍງຈະໃຊ້ສຳລັບການເຂົ້າສູ່ລະບົບ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ "
-"\"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "ຂັ້ນສູງ"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser ກຳນົດຊື່ຜູ້ໃຊ້ທີ່ເຊີເວີຜູ້ເບິ່ງແຍງຈະໃຊ້ສຳລັບການເຂົ້າສູ່ລະບົບ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ "
-"\"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "ໄດເຣັກທໍຣີຊັບສິນ (Assets)"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "ການຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"AssetsDir ກຳນົດໄດເຣັກທໍຣີພາຍໃນທີ່ເຊີເວີຜູ້ເບິ່ງແຍງຈະໂຫຼດຊັບພະຍາກອນ. ຖ້າຄ່ານີ້ເປັນ \"\", ຊັບສິນຈະຖືກ"
-"ໂຫຼດຈາກ executable ທີ່ລວມມາໂດຍໃຊ້ statik.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ເປັນ \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "ທີ່ຢູ່ການເຊື່ອມຕໍ່ (Bind addr)"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "ທີ່ຢູ່ການເຊື່ອມຕໍ່ (Bind address)"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "ພອດການເຊື່ອມຕໍ່ (Bind port)"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "ກຳລັງເກັບຂໍ້ມູນ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "ການບີບອັດ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "ໄຟລ໌ຕັ້ງຄ່າທີ່ລວມຢູ່ໃນໄຟລ໌ຕັ້ງຄ່າຊົ່ວຄາວ"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "ໂດເມນກຳນົດເອງ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "ປິດການໃຊ້ງານສີໃນ Log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor ປິດການໃຊ້ງານສີໃນ Log ເມື່ອ LogWay == \"console\" ເມື່ອຕັ້ງຄ່າເປັນ true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "ປິດໃຊ້ງານ"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "ເປີດໃຊ້ງານ"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "ການເຂົ້າລະຫັດ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "ຕົວແປສະພາບແວດລ້ອມ (Environment variable)"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "ອອກເມື່ອການເຂົ້າສູ່ລະບົບລົ້ມເຫຼວ"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 
@@ -142,351 +415,810 @@ msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 msgid "Grant access to LuCI app frpc"
 msgstr "ໃຫ້ສິດເຂົ້າເຖິງແອັບ LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "ການຕັ້ງຄ່າ HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "ລະຫັດຜ່ານ HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP ພຣັອກຊີ"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "ຜູ້ໃຊ້ HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval ກຳນົດໄລຍະເວລາທີ່ Heartbeat ຈະຖືກສົ່ງໄປຍັງເຊີເວີ, ມີຫົວໜ່ວຍເປັນວິນາທີ. ບໍ່ແນະ"
-"ນຳໃຫ້ປ່ຽນແປງຄ່ານີ້.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout ກຳນົດຄວາມລ່າຊ້າສູງສຸດຂອງການຕອບສະໜອງ Heartbeat ກ່ອນທີ່ການເຊື່ອມຕໍ່ຈະຖືກຕັ"
-"ດ, ມີຫົວໜ່ວຍເປັນວິນາທີ. ບໍ່ແນະນຳໃຫ້ປ່ຽນແປງຄ່ານີ້.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "ໄລຍະເວລາ Heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "ເວລາໝົດກຳນົດ Heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "ຂຽນ Host header ຄືນໃໝ່"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy ກຳນົດທີ່ຢູ່ພຣັອກຊີເພື່ອໃຊ້ໃນການເຊື່ອມຕໍ່ຫາເຊີເວີ. ຖ້າຄ່ານີ້ເປັນ \"\", ຈະເຊື່ອມຕໍ່ຫາເຊີເວີໂດຍກົ"
-"ງ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ຈະຖືກອ່ານຈາກຕົວແປສະພາບແວດລ້ອມ \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "ຖ້າ remote_port ເປັນ 0, frps ຈະກຳນົດພອດແບບສຸ່ມໃຫ້ທ່ານ"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP ພາຍໃນ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "ພອດພາຍໃນ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp ກຳນົດທີ່ຢູ່ IP ຫຼື ຊື່ໂຮສທີ່ຈະສົ່ງພຣັອກຊີໄປຫາ."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort ກຳນົດພອດທີ່ຈະສົ່ງພຣັອກຊີໄປຫາ."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "ຕຳແໜ່ງ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "ໄຟລ໌ບັນທຶກ (Log)"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "ການຕັ້ງຄ່າບັນທຶກ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "ລະດັບການບັນທຶກ (Log)"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "ຈຳນວນມື້ສູງສຸດຂອງ Log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Log stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Log stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile ກຳນົດໄຟລ໌ທີ່ຈະໃຊ້ຂຽນ Log. ຄ່ານີ້ຈະຖືກໃຊ້ກໍຕໍ່ເມື່ອ LogWay ຖືກຕັ້ງຄ່າຢ່າງເໝາະສົມ.<br />ໂດຍຄ່"
-"າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel ກຳນົດລະດັບ Log ຕໍ່າສຸດ. ຄ່າທີ່ໃຊ້ໄດ້ຄື \"trace\", \"debug\", \"info\", "
-"\"warn\", ແລະ \"error\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays ກຳນົດຈຳນວນມື້ສູງສຸດໃນການເກັບຂໍ້ມູນ Log ກ່ອນທີ່ຈະຖືກລຶບ. ຄ່ານີ້ຈະຖືກໃຊ້ກໍຕໍ່ເມື່ອ LogWay "
-"== \"file\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit ຄວບຄຸມວ່າໄຄລ໌ແອນຄວນອອກຫຼັງຈາກການເຂົ້າສູ່ລະບົບລົ້ມເຫຼວຫຼືບໍ່. ຖ້າຕັ້ງເປັນ false, ໄຄລ໌ແ"
-"ອນຈະລອງໃໝ່ຈົນກວ່າການເຂົ້າສູ່ລະບົບຈະສຳເລັດ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "ບໍ່ໄດ້ເຮັດວຽກ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
-msgstr "ຕົວແປສະພາບແວດລ້ອມ OS ສົ່ງໄປຍັງ frp ສຳລັບແມ່ແບບໄຟລ໌ຕັ້ງຄ່າ, ເບິ່ງ %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "ປລັກອິນ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "ການຕັ້ງຄ່າປລັກອິນ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "ໂປຣໂຕຄອນ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Protocol ກຳນົດໂປຣໂຕຄອນທີ່ຈະໃຊ້ໃນການຕິດຕໍ່ກັບເຊີເວີ. ຄ່າທີ່ໃຊ້ໄດ້ຄື \"tcp\", \"kcp\", "
-"\"quic\", ແລະ \"websocket\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "ການຕັ້ງຄ່າພຣັອກຊີ"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "ຊື່ພຣັອກຊີ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "ປະເພດພຣັອກຊີ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType ກຳນົດປະເພດຂອງພຣັອກຊີນີ້. ຄ່າທີ່ໃຊ້ໄດ້ລວມມີ \"tcp\", \"udp\", \"http\", "
-"\"https\", \"stcp\", ແລະ \"xtcp\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "ກຳລັງເຮັດວຽກ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "ພອດທາງໄກ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "ເລີ່ມການເຮັດວຽກໃໝ່ເມື່ອຂັດຂ້ອງ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "ບົດບາດ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "ແລ່ນ daemon ໃນຖານະກຸ່ມ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "ແລ່ນ daemon ໃນຖານະຜູ້ໃຊ້"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "ລະຫັດຜ່ານ SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "ຜູ້ໃຊ້ SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "ທີ່ຢູ່ເຊີເວີ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "ຊື່ເຊີເວີ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "ພອດເຊີເວີ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr ກຳນົດທີ່ຢູ່ຂອງເຊີເວີທີ່ຈະເຊື່ອມຕໍ່ໄປຫາ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort ກຳນົດພອດທີ່ຈະໃຊ້ເຊື່ອມຕໍ່ຫາເຊີເວີ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk (ລະຫັດລັບ)"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "ການຕັ້ງຄ່າເລີ່ມຕົ້ນລະບົບ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "ໂດເມນຍ່ອຍ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
-msgstr "TLS Enable ກຳນົດວ່າຄວນໃຊ້ TLS ເມື່ອຕິດຕໍ່ກັບເຊີເວີຫຼືບໍ່."
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"TcpMux ສະຫຼັບການເຮັດວຽກຂອງ TCP stream multiplexing. ສິ່ງນີ້ຊ່ວຍໃຫ້ຫຼາຍຄຳຮ້ອງຂໍຈາກໄຄລ໌ແອນສາ"
-"ມາດແບ່ງປັນການເຊື່ອມຕໍ່ TCP ດຽວກັນໄດ້. ຖ້າຄ່ານີ້ແມ່ນ true, ເຊີເວີຕ້ອງເປີດໃຊ້ TCP multiplexing ເຊັ່"
-"ນກັນ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"ລາຍການນີ້ສາມາດໃຊ້ເພື່ອລະບຸພາຣາມິເຕີເພີ່ມເຕີມບາງຢ່າງທີ່ຍັງບໍ່ໄດ້ລວມຢູ່ໃນ LuCI ນີ້."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "ໂທເຄັນ (Token)"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token ກຳນົດໂທເຄັນການອະນຸຍາດທີ່ໃຊ້ສ້າງຄີເພື່ອສົ່ງໄປຍັງເຊີເວີ. ເຊີເວີຕ້ອງມີໂທເຄັນທີ່ກົງກັນເພື່ອໃຫ້ການອະນຸຍາ"
-"ດສຳເລັດ. <br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "ເສັ້ນທາງ Unix domain socket"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression ຄວບຄຸມວ່າການຕິດຕໍ່ສື່ສານກັບເຊີເວີຈະຖືກບີບອັດຫຼືບໍ່.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ "
-"false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption ຄວບຄຸມວ່າການຕິດຕໍ່ສື່ສານກັບເຊີເວີຈະຖືກເຂົ້າລະຫັດຫຼືບໍ່. ການເຂົ້າລະຫັດຈະຖືກເຮັດໂດຍໃຊ້ໂທເ"
-"ຄັນທີ່ໃຫ້ໄວ້ໃນການຕັ້ງຄ່າເຊີເວີ ແລະ ໄຄລ໌ແອນ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "ຜູ້ໃຊ້"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"User ກຳນົດຄຳນຳໜ້າສຳລັບຊື່ພຣັອກຊີເພື່ອແຍກພວກມັນອອກຈາກໄຄລ໌ແອນອື່ນ. ຖ້າຄ່ານີ້ບໍ່ແມ່ນ \"\", ຊື່ພຣັອກຊີຈະຖື"
-"ກປ່ຽນໂດຍອັດຕະໂນມັດເປັນ \"{user}.{proxy_name}\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "ໄຄລ໌ແອນ frp"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/lt/frpc.po
+++ b/applications/luci-app-frpc/po/lt/frpc.po
@@ -13,139 +13,404 @@ msgstr ""
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Pridėti naują įgaliotąjį..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Papildomi konfigūravimai"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Papildomi nustatymai"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Administratoriaus adresas"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Administratoriaus slaptažodis"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Administratoriaus prievadas"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Administratoriaus naudotojas/vartotojas"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"„AdminAddr“ nurodo adresą, prie kurio pririšą administratoriaus serverį.<br /"
-">Pagal numatytuosius nustatymus, ši reikšmė yra – „0.0.0.0“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"„AdminPort“ nurodo prievadą, kuriuo administratoriaus serveris turi laukti "
-"prisijungimo/jungties ryšio. Jei ši reikšmė yra – 0-is, administratoriaus "
-"serveris nebus paleistas.<br />Pagal numatytuosius nustatymus, ši reikšmė "
-"yra – 0-is."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"„AdminPwd“ nurodo slaptažodį, kurį administratoriaus serveris naudos "
-"naudotojo/vartotojo prisijungimui.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – „admin“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Pažangūs"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"„AdminUser“ nurodo naudotojo/vartotojo vardą (t.y. slapyvardį), kurį "
-"administratoriaus serveris naudos naudotojo/vartotojo prisijungimui.<br /"
-">Pagal numatytuosius nustatymus, ši reikšmė yra – „admin“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "„Assets“ katalogas/vietovė"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"„Assets katalogas/vietovė“ („AssetsDir“) – nurodo vietinę katalogą/vietovę, "
-"iš kurio administratoriaus serveris įkels išteklius. Jei ši reikšmė yra – "
-"„“, ištekliai bus įkeliami iš vykdomojo failo paketo naudojant – „statik“."
-"<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „“."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autentifikavimas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "Pririšti adresą"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Pririšti prievadą"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Renkami duomenys..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Tipiniai nustatymai"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Suspaudimas/Suglaudimas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Konfigūracijos failai įtraukti į laikinąjį konfigūracijos failą"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Pasirinktiniai domenai-sritys"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Išjungti žurnalo spalvą"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"„DisableLogColor“ išjungia/neįgalina žurnalo spalvas, kai „LogWay“ == "
-"„konsole“; kai nustatyta į – „true“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Išjungta/Neįgalinta (-s/-i)"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Įjungta/Įgalinta (-s/-i)"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Šifravimas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Aplinkybių kintamumas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Išeiti, kai nepavyksta prisijungti"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Bendri nustatymai"
 
@@ -153,418 +418,810 @@ msgstr "Bendri nustatymai"
 msgid "Grant access to LuCI app frpc"
 msgstr "Suteikti prieigą prie „LuCI“ programos – „frpc“"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "„HTTP“ nustatymai"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "„HTTP“ slaptažodis"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "„HTTP“ įgaliotinis serveris"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "„HTTP“ naudotojas/vartotojas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"„Širdies ritmo intervalas“ („HeartBeatInterval“) – nurodo, kokiu intervalu "
-"„širdies ritmai“ yra siunčiami į serverį – sekundėmis. Keisti šios reikšmės "
-"nėra rekomenduojama.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – "
-"30-imt."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"„Širdies ritmo“ pasibaigusios užklausos laikas („HeartBeatTimeout“) – nurodo "
-"didžiausią leistiną „širdies ritmo“ atidėjimą, prieš nutraukiant ryšį – "
-"sekundėmis. Keisti šios reikšmės nėra rekomenduojama.<br />Pagal "
-"numatytuosius nustatymus, ši reikšmė yra – 90-imt."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "„Širdies ritmo“ intervalas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "„Širdies ritmo“ pasibaigusios užklausos laikas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Skleidėjo/Vedėjo antraštės perrašymas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"„HTTP įgaliotinis“ („HttpProxy“) – nurodo įgaliotojo adresą, per kurį reikia "
-"prisijungti prie serverio. Jei ši reikšmė yra – „“, tada serveris bus "
-"tiesiogiai prijungtas.<br />Pagal numatytuosius nustatymus, ši reikšmė yra "
-"nuskaitoma iš – „http_proxy“ aplinkos kintamojo."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Jeigu „remote_port“ yra 0, tada „frps“ priskirs atsitiktinį prievadą"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Vietinis IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Vietinis prievadas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"„LocalIp“ nurodo esamą IP adresą arba skleidėjo/vedėjo pavadinimą į kurį "
-"įgaliotai pereiti."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "„LocalPort“ nurodo prievadą į kurį įgaliotai pereiti."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Vietovės"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Žurnalo failas"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Žurnalo nustatymai"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Žurnalo lygis"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Maksimalus dienų žurnalinimas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Žurnalinti „stderr“"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Žurnalinti „stdout“"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"„LogFile“ nurodo failą, kuriame bus rašomi žurnalai. Ši reikšmė bus "
-"naudojama tik tada, jei „LogWay“ bus nustatytas tinkamai.<br />Pagal "
-"numatytuosius nustatymus, ši reikšmė yra – „console“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"„Žurnalo lygis“ („LogLevel“) – nurodo minimalų žurnalo lygį. Tinkamos "
-"reikšmės yra – „trace“, „debug“, „info“, „warn“ ir „error“.<br />Pagal "
-"numatytuosius nustatymus ši reikšmė yra – „info“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"„Žurnalo maksimalios dienos“ („LogMaxDays“) – nurodo žurnalo maksimalų dienų "
-"skaičių, kiek dienų reikia saugoti žurnalo informaciją prieš ištrinant. Tai "
-"yra naudojama tik tada, jei – „LogWay“ == „failas“.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – 0-is."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"„Prisijungimo nevykęs/nesėkmingas išėjimas“ („LoginFailExit“) – valdo, ar "
-"klientas turi išeiti po nevykusio/nesėkmingo prisijungimo bandymo. Jei "
-"„false“, tada klientas pakartos/bandys iš naujo, kol pavyks prisijungti.<br /"
-">Pagal numatytuosius nustatymus, ši reikšmė yra – „true“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NEVEIKIA"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"OS aplinkybės perduodamos „frp“ konfigūracijos failo šablonui, žr. – %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Plėtinys"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Plėtinio nustatymai"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokolas"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Protokolas nurodo protokolą, kuris turi būti naudojamas sąveikaujant su "
-"serveriu. Galimos reikšmės yra – „tcp“, „kcp“, „quic“ ir „websocket“.<br /"
-">Pagal numatytuosius nustatymus ši reikšmė yra – „tcp“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Įgaliotojo nustatymai"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Įgaliotojo pavadinimas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Įgaliojimo tipas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"„ProxyType“ nurodo šio įgaliotojo tipą. Galimos reikšmės įtraukia – „tcp“, "
-"„udp“, „http“, „https“, „stcp“ ir „xtcp“.<br />Pagal numatytuosius "
-"nustatymus ši reikšmė yra – „tcp“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "VEIKIA"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Nuotolinis prievadas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Atkurti/Perjungti (vardžiuojamai: „Atgimti“), kai užstringa"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Vaidmuo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Vykdyti „daemon“ kaip grupę"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Vykdyti paslaugų teikimo sistema kaip naudotojas/vartotojas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "„SOCKS5“ slaptažodis"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "„SOCKS5“ naudotojas/vartotojas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Serverio adresas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Serverio pavadinimas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Serverio prievadas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"„Serverio adresas“ („ServerAddr“) – nurodo serverio adresą, prie kurio "
-"reikia prisijungti/užmegzti ryšį.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – „127.0.0.1“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"„Serverio priedas“ („ServerPort“) – nurodo prievadą, per kurį reikia "
-"prisijungti/užmegzti ryšį prie serverio.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "„Sk“"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Paleidimo nustatymai"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Sub-domenas/sritis"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "„TCP“ tankintuvas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "„TLS“"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"„TLS“ įjungimas/įgalinimas nurodo, ar „TLS“ turėtų būti naudojamas, kai "
-"komunikuojamas su serveriu."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"„„TCP“ tankintuvas/-imas“ („TcpMux“) – perjungia „TCP“ srauto tankinimą. Tai "
-"leidžia kelioms kliento užklausoms bendrinti vieną „TCP“ ryšį. Jei ši "
-"reikšmė yra „true“, tada serveryje taip pat turi būti įjungtas/įgalintas "
-"„TCP“ tankinimas.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – "
-"„true“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Šis sąrašas gali būti naudojamas nurodyti, kai kuriuos papildomus "
-"parametrus, kurie nebuvo įtraukti į šį – „LuCI“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Žetonas"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Žetonas nurodo prieigos žetoną, naudojamas kuriant raktus, kurie bus "
-"siunčiami į serverį. Kad leidimas būtų sėkmingas, serveris turi turėti "
-"atitinkamą prieigos žetoną. <br />Pagal numatytuosius nustatymus, ši reikšmė "
-"yra – „“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "„Unix“ domeno-srities lizdo kelias"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"„Naudoti suspaudimą/suglaudi(ni)mą“ („UseCompression“) – valdo, ar ryšys su "
-"serveriu bus suspaustas/suglaudintas, ar ne.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – „false“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"„Naudoti užšifravimą“ („UseEncryption“) – valdo, ar ryšys su serveriu bus "
-"užšifruotas, ar ne. Užšifruojama, naudojant žetonus, pateiktus serverio ir "
-"kliento konfigūracijoje.<br />Pagal numatytuosius nustatymus, ši reikšmė yra "
-"– „false“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Naudotojas/Vartotojas"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Naudotojas/Vartotojas nurodo priešdėlį, įgaliotojo pavadinimams , kad "
-"atskirtų juos nuo kitų klientų. Jei ši reikšmė nėra – „“, tada įgaliotųjų "
-"serverių pavadinimai bus automatiškai pakeisti į – „{user}.{proxy_name}“."
-"<br />Pagal numatytuosius nustatymus ši, reikšmė yra – „“."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "„frp“ klientas"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "„OS“ aplinkybės yra perduodamos į – „frp“, skirtos konfigūracijos failo "
-#~ "šablonui, žr.: <a href=\"https://github.com/fatedier/frp#configuration-"
-#~ "file-template\">„frp README“</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "„Protokolas“ („Protocol“) – nurodo protokolą, kuris bus naudojamas "
-#~ "sąveikaujant su serveriu. Tinkamos reikšmės yra – „tcp“, „kcp“ ir "
-#~ "„websocket“.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „tcp“."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "„Įgaliotojo tipas“ („ProxyType“) – nurodo šio įgaliotojo tipą. Tinkamos "
-#~ "reikšmės apima – „tcp“, „udp“, „http“, „https“, „stcp“ ir „xtcp“.<br /"
-#~ ">Pagal numatytuosius nustatymus, ši reikšmė yra – „tcp“."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "„TLS“ įjungimas/įgalinimas“ („TLSEnable“) – nurodo, ar reikia naudoti – "
-#~ "„TLS“, komunikuojant/susisiekiant su serveriu."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/mr/frpc.po
+++ b/applications/luci-app-frpc/po/mr/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "अतिरिक्त कॉन्फिगरेशन"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "अक्षम"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "सक्षम केले"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "सामान्य सेटिंग्ज"
 
@@ -132,319 +415,810 @@ msgstr "सामान्य सेटिंग्ज"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "प्रोटोकॉल"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/ms/frpc.po
+++ b/applications/luci-app-frpc/po/ms/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.11.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Konfig tambahan"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Lanjutan"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Authentifizierung"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Dibolehkan"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Penyulitan"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -132,319 +415,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokol"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/nb_NO/frpc.po
+++ b/applications/luci-app-frpc/po/nb_NO/frpc.po
@@ -10,123 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.11-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-#, fuzzy
-msgid "Add new proxy..."
-msgstr "Legg til ny mellomtjener …"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Ytterligere oppsett"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Ytterligere innstillinger"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avansert"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Godkjenning"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Bind-adresse"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Bind-port"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Samler data …"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
-#, fuzzy
-msgid "Common Settings"
-msgstr "Generelle innstillinger"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Egendefinerte domener"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Avskrudd"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Påskrudd"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Generelle innstillinger"
 
@@ -134,319 +415,810 @@ msgstr "Generelle innstillinger"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP-innstillinger"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Lokal IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Lokal port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Loggingsnivå"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "Kjører ikke"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokoll"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "KJØRER"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Kjør nisse som gruppe"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Kjør nisse som bruker"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Tjeneradresse"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Tjenerport"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Oppstartsinnstillinger"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Underdomene"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Symbol"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Bruker"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/nl/frpc.po
+++ b/applications/luci-app-frpc/po/nl/frpc.po
@@ -12,121 +12,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.15.1\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Nieuwe proxy toevoegen..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Additionele configuraties"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Aanvullende instellingen"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Authenticatie"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Bind poort"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
+msgstr "Verzamelen gegevens ..."
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
 msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
-msgstr ""
+msgstr "Versleuteling"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Algemene instellingen"
 
@@ -134,319 +417,810 @@ msgstr "Algemene instellingen"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr ""
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Logboek instellingen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
-msgstr ""
+msgstr "Logboek niveau"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
+msgstr "NIET ACTIEF"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
-msgstr ""
+msgstr "ACTIEF"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
-msgstr ""
+msgstr "Voer daemon uit als groep"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
-msgstr ""
+msgstr "Voer daemon uit als gebruiker"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
-msgstr ""
+msgstr "Server adres"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
+msgstr "Servernaam"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
+msgstr "Server poort"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
+msgstr "TLS"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
+msgstr "Token"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Gebruiker"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/pl/frpc.po
+++ b/applications/luci-app-frpc/po/pl/frpc.po
@@ -11,135 +11,404 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Dodaj nowy serwer proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Dodatkowe konfiguracje"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Dodatkowe ustawienia"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Adres administratora"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Hasło administratora"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Port administratora"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Login administratora"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr określa adres, do którego podłączony jest serwer administracyjny."
-"<br />Domyślnie ta wartość to \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort określa port, na którym serwer administracyjny ma nasłuchiwać. "
-"Jeśli ta wartość wynosi 0, serwer administracyjny nie zostanie uruchomiony."
-"<br />Domyślnie ta wartość wynosi 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd określa hasło, którego będzie używał serwer administracyjny do "
-"logowania.<br />Domyślnie ta wartość to \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser określa nazwę użytkownika, która będzie używana przed admina do "
-"logowania.<br />Domyślnie ta wartość to \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Katalog zasobów"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir określa katalog lokalny, z którego serwer administracyjny będzie "
-"ładował zasoby. Jeśli ta wartość to \"\", zasoby zostaną załadowane z "
-"pakietu wykonywalnego przy użyciu statik.<br />Domyślnie ta wartość to \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Uwierzytelnienie"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "Adres wiązania"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Port wiązania"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Zbieranie danych..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Wspólne ustawienia"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Kompresja"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Pliki konfiguracyjne znajdują się w tymczasowym pliku konfiguracyjnym"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Własne domeny"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Wyłącz kolor dziennika"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor wyłącza kolory dziennika, gdy LogWay == \"konsola\", jest "
-"ustawiona na true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Włączone"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Szyfrowanie"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Zmienna środowiskowa"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Wyjdź, gdy logowanie się nie powiedzie"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
@@ -147,407 +416,810 @@ msgstr "Ustawienia główne"
 msgid "Grant access to LuCI app frpc"
 msgstr "Udziel dostępu do aplikacji LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Ustawienia HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Hasło HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Użytkownik HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval określa, w jakich odstępach czasu pulsy są wysyłane do "
-"serwera, w sekundach. Nie zaleca się zmiany tej wartości.<br />Domyślnie ta "
-"wartość wynosi 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout określa maksymalne dozwolone opóźnienie odpowiedzi pulsu "
-"przed zakończeniem połączenia (w sekundach). Nie zaleca się zmiany tej "
-"wartości.<br />Domyślnie ta wartość wynosi 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Interwał pulsu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Limit czasu pulsu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Przepisz nagłówek hosta"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy określa adres proxy do połączenia z serwerem. Jeśli ta wartość to "
-"\"\", serwer zostanie podłączony bezpośrednio.<br />Domyślnie ta wartość "
-"jest odczytywana ze zmiennej środowiskowej \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Jeśli port_zdalny wynosi 0, frps przypisze Ci losowy port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Lokalny IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Port lokalny"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"LocalIp określa adres IP lub nazwę hosta, do którego ma zostać wysłany proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort określa port, do którego należy się zwrócić."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Lokalizacje"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Plik dziennika"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Ustawienia dziennika"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Poziom rejestrowania"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Maks. dni logowania"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Dziennik stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Dziennik stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile określa plik, w którym będą zapisywane dzienniki. Ta wartość będzie "
-"używana tylko wtedy, gdy LogWay zostanie odpowiednio ustawiony.<br /"
-">Domyślnie ta wartość to \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel określa minimalny poziom dziennika. Poprawne wartości to \"trace\", "
-"\"debug\", \"info\", \"warn\" i \"error\".<br />Domyślnie jest to \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
+msgstr "Metadata"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LogMaxDays określa maksymalną liczbę dni przechowywania informacji dziennika "
-"przed usunięciem. Jest używana tylko wtedy, gdy LogWay == \"file\".<br /"
-">Domyślnie ta wartość wynosi 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
 msgstr ""
-"LoginFailExit kontroluje, czy klient powinien zakończyć działanie po "
-"nieudanej próbie logowania. Jeśli jest ustawiona na false, klient spróbuje "
-"ponownie, dopóki próba logowania nie zakończy się sukcesem.<br />Domyślnie "
-"wartość to true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NIEURUCHOMIONE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"Przekazanie środowiska systemu operacyjnego do frp w celu uzyskania szablonu "
-"pliku konfiguracyjnego, zobacz %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Wtyczka"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Ustawienia wtyczki"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokół"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Protocol określa protokół używany podczas interakcji z serwerem. Prawidłowe "
-"wartości to \"tcp\", \"kcp\", \"quic\" i \"websocket\".<br />Domyślnie ta "
-"wartość to \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Ustawienia proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Nazwa serwera proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Typ proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType określa typ tego serwera proxy. Prawidłowe wartości to \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />Domyślnie ta "
-"wartość to \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "URUCHOMIONE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Port zdalny"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Odradzaj się po awarii"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rola"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Uruchom demona jako grupę"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Uruchom demona jako użytkownik"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Hasło SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "Użytkownik SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Adres serwera"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nazwa serwera"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Port serwera"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr określa adres serwera, z którym należy się połączyć.<br /"
-">Domyślnie ta wartość to \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort określa port, na którym należy połączyć się z serwerem.<br /"
-">Domyślnie wartość ta wynosi 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Ustawienia uruchamiania"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Subdomena"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "Mux TCP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"Włączenie TLS określa, czy protokół TLS ma być używany podczas komunikacji z "
-"serwerem."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux przełącza multipleksowanie strumienia TCP. Pozwala to wielu żądaniom "
-"klienta na współużytkowanie jednego połączenia TCP. Jeśli ta wartość to "
-"\"true\", serwer musi również mieć włączone multipleksowanie TCP.<br /"
-">Domyślnie ta wartość to \"true\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Ta lista może służyć do określenia dodatkowych parametrów, które nie zostały "
-"uwzględnione w tym LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token określa token autoryzacji używany do tworzenia kluczy, które mają "
-"zostać wysłane na serwer. Serwer musi mieć pasujący token, aby autoryzacja "
-"zakończyła się powodzeniem.<br />Domyślnie ta wartość to \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Ścieżka gniazda domeny uniksowej"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression kontroluje, czy komunikacja z serwerem będzie kompresowana."
-"<br />Domyślnie ta wartość to \"false\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption kontroluje, czy komunikacja z serwerem będzie szyfrowana. "
-"Szyfrowanie odbywa się przy użyciu tokenów dostarczonych w konfiguracji "
-"serwera i klienta.<br />Domyślnie ta wartość to \"false\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Użytkownik"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Użytkownik określa prefiks nazw serwerów proxy, aby odróżnić je od innych "
-"klientów. Jeśli ta wartość nie jest \"\", nazwy serwerów proxy zostaną "
-"automatycznie zmienione na \"{user}. {proxy_name}\".<br />Domyślnie ta "
-"wartość to \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "Klient frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Środowiska systemu operacyjnego przechodzą do frp w celu uzyskania "
-#~ "szablonu pliku konfiguracyjnego, patrz <a href=\"https://github.com/"
-#~ "fatedier/frp#configuration-file-template\"> frp README </a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protokół określa protokół używany podczas interakcji z serwerem. "
-#~ "Prawidłowe wartości to \"tcp\", \"kcp\" i \"websocket\". <br /> Domyślnie "
-#~ "ta wartość to \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType określa typ tego proxy. Prawidłowe wartości to \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\" i \"xtcp\". <br /> Domyślnie ta "
-#~ "wartość to \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable określa, czy podczas komunikacji z serwerem należy stosować "
-#~ "TLS, czy też nie."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/pt/frpc.po
+++ b/applications/luci-app-frpc/po/pt/frpc.po
@@ -10,136 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.5.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Adicionar um novo proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Configurações adicionais"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Endereço do administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Palavra-passe do administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Porto de administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Utilizador do Administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr especifica o endereço para o qual o servidor admin se liga.<br /"
-">Por padrão, este valor é \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort especifica a porta onde o servidor de administração escuta. Se "
-"este valor for 0, o servidor admin não será iniciado.<br />Por padrão, este "
-"valor é 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd especifica a palavra-passe que o servidor admin usará para login."
-"<br />Por padrão, este valor é \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avançado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser especifica o nome de utilizador que o servidor admin usará para "
-"login.<br />Por padrão, este valor é \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Diretório de ativos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"AssetsDir determina um diretório local de onde o painel carregará recursos. "
-"Se o valor for \"\", os ativos serão carregados do que estiver embutido no "
-"executável usando o statik. <br />O valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "Ender. BIND"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Endereço de ligação"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Porta do BIND"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "A coletar dados..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Configurações Comuns"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Compressão"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
-"Ficheiros de configuração incluídos no ficheiro de configuração temporário"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Domínios personalizados"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Desativar cores nos registos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor desativa o registo de cores quando LogWay == \"console\" for "
-"definido como true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Desativado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Ativado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Encriptação"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Variável de ambiente"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Saír caso início de sessão falhar"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -147,406 +415,810 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app frpc"
 msgstr "Conceder acesso à app frps do LuCI"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Configurações HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Palavra-passe HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Proxy HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Utilizador HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval determina em que intervalo heartbeats serão enviados para "
-"o servidor em segundos. Não é recomendável alterar este valor. <br />O valor "
-"predefinido é 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout especifica o atraso máximo permitido de resposta ao "
-"heartbeat antes que a conexão seja encerrada, em segundos. Não é "
-"recomendável alterar esse valor. <br />O valor predefinido é 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Intervalo do heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Tempo limite do heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Reescrever o cabeçalho do host"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"O HttpProxy especifica um endereço proxy para conectar ao servidor através "
-"dele. Se esse valor for \"\", o servidor será conectado diretamente. <br />O "
-"valor predefinido desse valor é lido da variável do ambiente \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Se remote_port for 0, frps atribuirá uma porta aleatória para si"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Porta local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp especifica o endereço IP ou nome de host para ser proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort especifica a porta para ser proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Locais"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Ficheiro de registo"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Configurações do registo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Nível de registo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Máximo de dias de registo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Regisro do stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Registo do stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"O LogFile especifica um ficheiro onde os registos serão escritos. Este valor "
-"só será usado se o LogWay for definido apropriadamente.<br />Por "
-"predefinição, este valor é \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"O LogLevel determina o nível mínimo de registo. Valores válidos são "
-"\"trace\", \"debug\", \"info\", \"warn\" e \"error\". <br />O valor "
-"predefinido é \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays especifica a quantidade máxima de dias para armazenar informações "
-"de registo antes de apagar. Isto só é usado se LogWay == \"file\".<br />Por "
-"predefinição, este valor é 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit controla se o cliente deve ou não sair após a falha de uma "
-"tentativa de login. Se falso, o cliente tentará novamente até que uma "
-"tentativa de login seja bem sucedida. <br />O valor predefinido é true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NÃO EM EXECUÇÃO"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"Os ambientes do sistema operativo passam para frp para o modelo de ficheiros "
-"de configuração, veja %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
-msgid "Plugin"
-msgstr "Plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Configurações do plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocolo"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
 msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+"Only visitors from specified users can connect. Use * to allow all users."
 msgstr ""
-"O protocolo especifica o protocolo a utilizar quando interagir com o "
-"servidor. Os valores válidos são \"tcp\", \"kcp\", \"quic\" e \"websocket\"."
-"<br /> Por predefinição, esse valor é \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Configurações de Proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
+msgid "Plugin"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Nome do proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Tipo de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType especifica o tipo deste proxy. Os valores válidos incluem \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\", e \"xtcp\".<br />O valor predefinido "
-"é \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "EXECUTADO"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Porta remota"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Reiniciar caso travado"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Função"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Executar daemon como grupo"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Executar serviço como utilizador"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Palavra-passe do SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "Utilizador do SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Endereço do servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nome do servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Porta do servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr especifica o endereço do servidor ao qual se conectar.<br />O "
-"valor predefinido é \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort especifica a porta ao qual se conectar no servidor.<br />O valor "
-"predefinido é 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Configurações de inicialização"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Subdomínio"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"TLS Ativado especifica se o TLS deve ou não ser usado ao comunicar com o "
-"servidor."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux alterna multiplexação de fluxo TCP. Isso permite que várias "
-"solicitações de um cliente compartilhem uma única conexão TCP. Se esse valor "
-"for true, o servidor deve ter multiplexing TCP ativado também. <br />O valor "
-"predefinido é verdadeiro."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Esta lista pode ser usada para definir parâmetros adicionais que não estavam "
-"incluídos neste LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Chave eletrónica"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token especifica o token de autorização para criar chaves a serem enviadas "
-"ao servidor. O servidor deve ter um token correspondente para a autorização "
-"ter sucesso. <br />A predefinição é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Caminho do soquete do domínio Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression controla se a comunicação com o servidor será compactada ou "
-"não. <br />O valor predefinido é false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption controla se a comunicação com o servidor será criptografada ou "
-"não. A criptografia é feita a usar os tokens fornecidos na configuração do "
-"servidor e do cliente. <br />O valor predefinido é false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Utilizador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"O utilizador especifica um prefixo aos nomes de proxy para distingui-los de "
-"outros clientes. Se este valor não for \"\", os nomes de proxy serão "
-"automaticamente alterados para \"{utilizador}. {nome_do_proxy}\". <br />O "
-"valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "Cliente frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "As variáveis de ambiente do sistema operacional passam para o frp como "
-#~ "modelo de configuração, veja <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "O protocolo especifica o protocolo a ser usado ao interagir com o "
-#~ "servidor. Os valores válidos são \"tcp\", \"kcp\" e \"websocket\". <br /"
-#~ ">O valor predefinido é \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType especifica o tipo deste proxy. Os valores válidos incluem "
-#~ "\"tcp\", \"udp\", \"http\", \"https\", \"stcp\", e \"xtcp\".<br />O valor "
-#~ "predefinido é \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "O TLSEnable especifica se o TLS deve ou não ser usado ao comunicar com o "
-#~ "servidor."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/pt_BR/frpc.po
+++ b/applications/luci-app-frpc/po/pt_BR/frpc.po
@@ -10,137 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.6.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Adiciona um novo proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Configurações adicionais"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Endereço do administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Senha do administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Porta do administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Usuário administrador"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr determina o endereço a ser vinculado para uso do administrador do "
-"servidor.<br />O valor predefinido é \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"O AdminPort determina a porta onde o servidor administrativo atende. Se esse "
-"valor for 0, o servidor administrativo não será iniciado. <br />O valor "
-"predefinido é 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd determina a senha de login que será usado para o administrador do "
-"servidor.<br />O valor predefinido é \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avançada"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser determina o nome de login do usuário que será usado pelo "
-"administrador do servidor.<br />O valor predefinido é \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Diretório de ativos"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"AssetsDir determina o diretório onde o administrador do servidor irá buscar "
-"recursos para serem carregados. Se o valor for \"\", os ativos serão "
-"carregados do que estiver embutido no executável usando o statik.<br />O "
-"valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "Endereço Bind"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Vincular endereço"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Porta Bind"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Coletando dados..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Configurações Comuns"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Compressão"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
-"Arquivos de configuração incluídos no arquivo de configuração temporário"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Domínios customizados"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Desativar cores nos registros de log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor desativa as cores nos registros de log quando LogWay == "
-"\"console\" for definido como verdadeiro."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Desativado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Ativado"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Criptografia"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Variável de ambiente"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Encerre caso a autenticação falhe"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -148,404 +415,810 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app frpc"
 msgstr "Conceder acesso ao aplicativo LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Configurações HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Senha HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Proxy HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Usuário HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval determina em que intervalo o heartbeats serão enviados "
-"para o servidor em segundos. Não é recomendável alterar este valor. <br />O "
-"valor predefinido é 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout determina o atraso máximo permitido de resposta do "
-"heartbeat antes que a conexão seja encerrada em segundos. Não é recomendável "
-"alterar este valor. <br />O valor predefinido é 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Intervalo do Heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Tempo limite do heartbeat"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Reescrever cabeçalho do host"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
-"O HttpProxy determina um endereço proxy a ser usado pelo servidor. Se este "
-"valor for \"\", o servidor usará conexão direta. <br />O valor predefinido é "
-"lido a partir da variável \"http_proxy\" do ambiente."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-"Se o remote_port for 0, o frps irá atribuir uma porta aleatória para você"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP Local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Porta local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp determina o endereço IP ou o nome do host a ser procurado."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "O LocalPort determina a porta a ser procurada."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Locais"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Arquivo log"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Configurações do registro"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Nível do registro"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Registro máximo de dias"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Registro log do stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Registro log do stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"O LogFile especifica um arquivo onde os registro logs serão gravados. Este "
-"valor só será usado se o LogWay estiver configurado adequadamente.<br />Por "
-"padrão, esse valor é \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"O LogLevel determina o nível mínimo de registro no log. Valores válidos são "
-"\"trace\", \"debug\", \"info\", \"warn\" e \"error\". <br />O valor "
-"predefinido é \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays especifica a quantidade máxima de dias para armazenar informações "
-"do registro log antes da exclusão. Isso só é usado se LogWay == \"arquivo\"."
-"<br />Por padrão, este valor é 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit controla se o cliente deve ou não sair após uma tentativa de "
-"login fracassada. Se falso, o cliente tentará novamente até que uma "
-"tentativa de login seja bem sucedida. <br />O valor predefinido é verdadeiro."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NÃO ESTÁ EM EXECUÇÃO"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Plug-in"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Configurações do plug-in"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocolo"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Protocol especifica o protocolo a ser usado ao interagir com o servidor. Os "
-"valores válidos são “tcp”, “kcp”, “quic” e “websocket”.<br />Por padrão, "
-"esse valor é “tcp”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Configurações de Proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Nome do proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Tipo de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType especifica o tipo deste proxy. Os valores válidos incluem “tcp”, "
-"“udp”, “http”, “https”, “stcp” e “xtcp”.<br />Por padrão, esse valor é “tcp”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Porta remota"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Reiniciar caso entre em colapso"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Papel"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Executar serviço como usuário"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Executar serviço como usuário"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Senha SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "usuário SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Endereço do servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nome do servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Porta do servidor"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr determina o endereço do servidor para se conectar. <br />O valor "
-"predefinido é \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"O ServerPort determina a porta para se conectar ao servidor. <br />O valor "
-"predefinido é 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Configurações de inicialização"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Subdomínio"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"TLS Enable especifica se o TLS deve ou não ser usado ao se comunicar com o "
-"servidor."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux alterna a multiplexação do fluxo TCP. Isso permite que várias "
-"solicitações de um cliente compartilhem uma única conexão TCP. Se esse valor "
-"for verdadeiro, o servidor também deve ter a multiplexação TCP ativada. <br /"
-">O valor predefinido é verdadeiro."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Esta lista pode ser usada para definir alguns parâmetros adicionais que não "
-"foram incluídos neste LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"O token determina o token de autorização usado para criar chaves que serão "
-"enviadas ao servidor. O servidor deve ter um token correspondente para que a "
-"autorização seja bem sucedida. <br />O valor predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Caminho do soquete do domínio Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression controla se a comunicação com o servidor será compactada ou "
-"não. <br />O valor predefinido é falso."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption controla se a comunicação com o servidor será criptografada ou "
-"não. A criptografia é feita usando os tokens fornecidos na configuração do "
-"servidor e do cliente. <br />O valor predefinido é falso."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Usuário"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"O usuário determina um prefixo para os nomes de proxy para distingui-los de "
-"outros clientes. Se esse valor não for \"\", os nomes de proxy serão "
-"automaticamente alterados para \"{user}. {proxy_name}\". <br />O valor "
-"predefinido é \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "Cliente frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "As variáveis de ambiente do sistema operacional passam para o frp como "
-#~ "modelo de configuração, veja <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocolo determina o protocolo a ser usado quando interagir com o "
-#~ "servidor. Os valores válidos são \"tcp\", \"kcp\" e \"websocket\". <br /"
-#~ ">O valor predefinido é \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType determina o tipo deste proxy. Os valores válidos incluem "
-#~ "\"tcp\", \"udp\", \"http\", \"https\", \"stcp\" e \"xtcp\". <br />O valor "
-#~ "predefinido é \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "O TLSEnable determina se o TLS deve ou não ser usado ao se comunicar com "
-#~ "o servidor."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/ro/frpc.po
+++ b/applications/luci-app-frpc/po/ro/frpc.po
@@ -7,141 +7,408 @@ msgstr ""
 "Language: ro\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : "
-"(n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Adăugați un nou proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Configurații suplimentare"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Setări adiționale"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Adresa administratorului"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Parola de administrator"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Port administrativ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Utilizator administrator"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr specifică adresa la care se leagă serverul de administrare.<br /"
-">În mod implicit, această valoare este \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort specifică portul pe care serverul de administrare trebuie să "
-"asculte. Dacă această valoare este 0, serverul de administrare nu va fi "
-"pornit.<br />În mod implicit, această valoare este 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd specifică parola pe care serverul de administrare o va utiliza "
-"pentru autentificare.<br />Din mod implicit, această valoare este \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avansat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser specifică numele de utilizator pe care serverul de administrare îl "
-"va utiliza pentru autentificare.<br />În mod implicit, această valoare este "
-"\"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Directorul de resurse"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir specifică directorul local din care serverul de administrare va "
-"încărca resursele. Dacă această valoare este \"\", resursele vor fi "
-"încărcate din executabilul inclus în pachet, utilizând statik.<br />Din mod "
-"implicit, această valoare este \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autentificare"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Adresa de legătură"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Legați portul"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Colectare date ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Setări Comune"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Comprimare"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Fișiere de configurare incluse în fișierul de configurare temporar"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Domenii personalizate"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Dezactivați culoarea jurnalului"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor dezactivează culorile jurnalului atunci când LogWay == "
-"\"console\" este setat la adevărat."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Activat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Criptare"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Variabila de mediu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Paritate"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Setări Generale"
 
@@ -149,401 +416,810 @@ msgstr "Setări Generale"
 msgid "Grant access to LuCI app frpc"
 msgstr "Acordă acces la aplicația LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Setări HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Parola HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Proxy HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Utilizator HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval specifică la ce interval de timp sunt trimise bătăile "
-"inimii către server, în secunde. Nu este recomandat să modificați această "
-"valoare.<br />În mod implicit, această valoare este 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout specifică timpul maxim de așteptare a unei bătăi de inimă "
-"înainte de a încheia conexiunea. Nu se recomandă modificarea acestei valori."
-"<br />În mod implicit, această valoare este 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Intervalul bătăilor inimii"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Timpul limită a bătăilor inimii"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Rescrierea antetului gazdă"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
-"HttpProxy specifică o adresă de proxy prin care să se conecteze la server. "
-"Dacă această valoare este \"\", serverul va fi conectat direct.<br />În mod "
-"implicit, această valoare este citită din variabila de mediu \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-"Dacă remote_port este 0, frps va aloca un port aleatoriu pentru dumneavoastră"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Port local"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"LocalIp specifică adresa IP sau numele de gazdă către care se face proxy."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort specifică portul la care se face proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Locații"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Fișier jurnal"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Setări jurnal"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Nivel de jurnal"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Jurnal maxim zile"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Jurnal stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Jurnal stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile specifică un fișier în care vor fi scrise jurnalele. Această valoare "
-"va fi utilizată numai dacă LogWay este setat în mod corespunzător.<br />În "
-"mod implicit, această valoare este \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel specifică nivelul minim al jurnalului. Valorile valabile sunt "
-"\"trace\", \"debug\", \"info\", \"warn\" și \"error\".<br />Prin definiție, "
-"această valoare este \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays specifică numărul maxim de zile de stocare a informațiilor din "
-"jurnal înainte de ștergere . Acest lucru se utilizează numai dacă LogWay == "
-"\"file\".<br />În mod implicit, această valoare este 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit controlează dacă clientul trebuie sau nu să iasă după o "
-"încercare eșuată de conectare. Dacă este falsă, clientul va încerca din nou "
-"până când o încercare de autentificare reușește.<br />Din mod implicit, "
-"această valoare este adevărată."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "NU FUNCȚIONEAZĂ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
-msgid "Plugin"
-msgstr "Plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Setările plugin-ului"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
 msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+"Only visitors from specified users can connect. Use * to allow all users."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Setări Proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
+msgid "Plugin"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Nume proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Tipul de proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "Funcţionare"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Port la distanță"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Respawn când crapă"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rol"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Rularea daemonului ca grup"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Rulați daemonul ca utilizator"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Parola SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "Utilizator SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Adresa serverului"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Nume server"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Port de server"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr specifică adresa serverului la care trebuie să se conecteze.<br /"
-">În mod implicit, această valoare este \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort specifică portul de conectare la server.<br />În mod implicit, "
-"această valoare este 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Setări de pornire"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Subdomeniu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "Mux TCP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux comută multiplexarea fluxurilor TCP. Acest lucru permite ca mai multe "
-"cereri de la un client să partajeze o singură conexiune TCP. Dacă această "
-"valoare este adevărată, serverul trebuie să aibă activată și multiplexarea "
-"TCP.<br />În mod implicit, această valoare este adevărată."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Această listă poate fi utilizată pentru a specifica anumiți parametri "
-"suplimentari care nu au fost incluși în acest LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token specifică tokenul de autorizare utilizat pentru a crea cheile care "
-"urmează să fie trimise către server. Serverul trebuie să aibă un token "
-"corespunzător pentru ca autorizarea să reușească. <br />În mod implicit, "
-"această valoare este \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Calea socket-ului de domeniu Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression controlează dacă comunicarea cu serverul va fi sau nu "
-"comprimată.<br />În mod implicit, această valoare este falsă."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption controlează dacă comunicarea cu serverul va fi sau nu "
-"criptată. Criptarea se face cu ajutorul token-urilor furnizate în "
-"configurația serverului și a clientului.<br />În mod implicit, această "
-"valoare este falsă."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Utilizator"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Utilizatorul specifică un prefix pentru numele proxy pentru a le distinge de "
-"alți clienți. Dacă această valoare nu este \"\", numele proxy-ului va fi "
-"schimbat automat în \"{utilizator}.{nume_proxy}\".<br />În mod implicit, "
-"această valoare este \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "client frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Mediile sistemului de operare trec la frp pentru șablonul fișierului de "
-#~ "configurare, vezi <a href=\"https://github.com/fatedier/frp#configuration-"
-#~ "file-template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocol specifică protocolul care trebuie utilizat la interacțiunea cu "
-#~ "serverul. Valorile valide sunt \"tcp\", \"kcp\" și \"websocket\".<br /"
-#~ ">Prin definiție, această valoare este \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType specifică tipul acestui proxy. Valorile valide includ \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\" și \"xtcp\".<br />Prin definiție, "
-#~ "această valoare este \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable specifică dacă TLS trebuie să fie utilizat sau nu atunci când "
-#~ "se comunică cu serverul."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/ru/frpc.po
+++ b/applications/luci-app-frpc/po/ru/frpc.po
@@ -3,6 +3,9 @@ msgstr ""
 "PO-Revision-Date: 2026-08-28 06:20+0000\n"
 "Last-Translator: SnIPeRSnIPeR <snipersniper@users.noreply.hosted.weblate.org>"
 "\n"
+"PO-Revision-Date: 2026-04-25 12:14+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsfrpc/ru/>\n"
 "Language: ru\n"
@@ -12,137 +15,404 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Добавить новый прокси..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Дополнительные конфигурации"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Дополнительные настройки"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Адрес администратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Пароль администратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Порт администратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Пользователь администратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr указывает адрес, к которому привязывается сервер администратора."
-"<br />По умолчанию это значение равно \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort указывает порт, на котором будет прослушиваться сервер "
-"администратора. Если это значение равно 0, сервер администратора не будет "
-"запущен.<br />По умолчанию это значение равно 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd указывает пароль, который сервер администраторов будет использовать "
-"для входа в систему.<br />По умолчанию это значение равно \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser указывает имя пользователя, которое сервер администраторов будет "
-"использовать для входа в систему.<br />По умолчанию это значение равно "
-"\"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Каталог ресурсов"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir указывает локальный каталог, из которого сервер администрирования "
-"будет загружать ресурсы. Если это значение равно \"\", то ресурсы будут "
-"загружаться из исполняемого файла fprc с помощью statik (библиотека на Go "
-"для встраивания ресурсов).<br />По умолчанию это значение равно \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Аутентификация"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "Адрес сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Порт сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Сбор данных ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Компрессия"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Конфигурационные настройки записаны во временный конфигурационный файл"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Пользовательские домены"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Отключить цвета в журнале"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor отключает цвета журнала, когда LogWay == \"console\", если "
-"установлено значение true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Отключено"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Включено"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Переменные окружения"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Выход при неудачном входе в систему"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Основные настройки"
 
@@ -150,401 +420,810 @@ msgstr "Основные настройки"
 msgid "Grant access to LuCI app frpc"
 msgstr "Предоставить доступ к LuCI-приложению frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Настройки HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Пароль HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP-прокси"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Пользователь HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval указывает, с каким интервалом в секундах пульс "
-"отправляется на сервер. Не рекомендуется изменять это значение.<br />По "
-"умолчанию это значение равно 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout задаёт максимально допустимую задержку ответа heartbeat до "
-"разрыва соединения (в секундах). Не рекомендуется изменять это значение.<br /"
-">По умолчанию: 90 секунд."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Heartbeat интервал"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Heartbeat тайм-аут"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Перезапись заголовка хоста"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy указывает прокси-адрес для подключения к серверу. Если это "
-"значение равно \"\", сервер будет подключён напрямую.<br />По умолчанию это "
-"значение считывается из переменной окружения \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Если remote_port равен 0, frps выберет для вас случайный порт"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Локальный IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Локальный порт"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp указывает IP-адрес или имя хоста для проксирования."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort указывает порт для проксирования."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Локации"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Файл журнала"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Настройки журнала"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Уровень журналирования"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Хранить журнал (дней)"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Сохранять вывод stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Сохранять вывод stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile указывает файл, в который будут записываться журналы. Это значение "
-"будет использоваться только в том случае, если LogWay установлен "
-"соответствующим образом.<br />По умолчанию это значение равно \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel задаёт минимальный уровень журнала. Допустимые значения: \"trace\", "
-"\"debug\", \"info\", \"warn\" и \"error\".<br />По умолчанию это значение "
-"равно \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays определяет максимальное количество дней хранения информации "
-"журнала перед удалением. Это значение используется, только если LogWay == "
-"\"file\".<br />По умолчанию это значение равно 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit контролирует, должен ли клиент завершать работу после "
-"неудачной попытки входа в систему. Если значение равно false, клиент будет "
-"повторять попытки до тех пор, пока попытка входа не увенчается успехом.<br /"
-">По умолчанию это значение равно true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "НЕ ЗАПУЩЕНО"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
-msgstr "Переменные окружения ОС для шаблона конфигурации frp, см. %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Плагин"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Настройки плагина"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Протокол"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Указывает протокол для взаимодействия с сервером. Допустимые значения: "
-"\"tcp\", \"kcp\", \"quic\" и \"websocket\".<br />По умолчанию: \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Настройки прокси"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Имя прокси"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Тип прокси"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"Указывает тип прокси. Допустимые значения: \"tcp\", \"udp\", \"http\", "
-"\"https\", \"stcp\" и \"xtcp\".<br />По умолчанию: \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "ЗАПУЩЕН"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Удалённый порт"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Перезапускаться после вылета"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Роль"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Запуск демона от имени группы"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Запуск демона от имени пользователя"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "SOCKS5-пароль"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5-пользователь"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Адрес сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Имя сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Порт сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr указывает адрес сервера для подключения.<br />По умолчанию это "
-"значение равно \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort указывает порт для подключения к серверу.<br />По умолчанию это "
-"значение равно 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Настройки запуска"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Поддомен"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP мультиплексор"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
-msgstr "Включает использование TLS при взаимодействии с сервером."
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"TcpMux включает мультиплексирование потока TCP. Это позволяет нескольким "
-"запросам от клиента использовать одно TCP-соединение. Если это значение "
-"равно true, на сервере также должно быть включено мультиплексирование TCP."
-"<br />По умолчанию это значение равно true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"Этот список может быть использован для указания некоторых дополнительных "
-"параметров, которые не были включены в данный LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Токен"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token указывает маркер авторизации, используемый для создания ключей, "
-"отправляемых на сервер. Для успешной авторизации сервер должен иметь "
-"соответствующий токен. <br />По умолчанию это значение равно \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Путь к сокету домена Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression определяет, будет ли сжиматься трафик при общении с сервером."
-"<br />По умолчанию это значение равно false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption контролирует, будет ли шифроваться связь с сервером. "
-"Шифрование осуществляется на основе токенов, заданных в настройках сервера и "
-"клиента.<br />По умолчанию это значение равно false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Пользователь"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Пользователь указывает префикс для имён прокси, чтобы отличать их от других "
-"клиентов. Если это значение не \"\", имена прокси будут автоматически "
-"изменены на \"{user}.{proxy_name}\".<br />По умолчанию это значение равно "
-"\"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "frp клиент"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Переменные среды, передаваемые frp, используются для подстановки в "
-#~ "шаблоны в файле конфигурации. Подробнее читай в <a href=\"https://"
-#~ "github.com/fatedier/frp#using-environment-variables\">справке frp</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocol указывает протокол, который будет использоваться при "
-#~ "взаимодействии с сервером. Допустимые значения: \"tcp\", \"kcp\" и "
-#~ "\"websocket\".<br />По умолчанию это значение равно \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType указывает тип этого прокси. Допустимые значения: \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\" и \"xtcp\".<br />По умолчанию это "
-#~ "значение равно \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable определяет, следует ли использовать TLS при взаимодействии с "
-#~ "сервером."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/sk/frpc.po
+++ b/applications/luci-app-frpc/po/sk/frpc.po
@@ -10,121 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Pridať nové proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Ďalšie konfigurácie"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Overenie totožnosti"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Zakázané"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Zapnuté"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Šifrovanie"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Všeobecné nastavenia"
 
@@ -132,319 +415,810 @@ msgstr "Všeobecné nastavenia"
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Úroveň záznamu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokol"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Adresa servera"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Názov servera"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Port servera"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Používateľ"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/sv/frpc.po
+++ b/applications/luci-app-frpc/po/sv/frpc.po
@@ -10,503 +10,1234 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Lägg till ny proxy…"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Ytterligare konfigurationer"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Extra inställningar"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Administrationsadress"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Administratörslösenord"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Administrationsport"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Administratörsanvändare"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 "AdminAddr anger adressen som administrationsservern binds till.<br />Som "
 "standard är värdet ”0.0.0.0”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Avancerat"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 "AdminPort anger porten som administrationsservern ska lyssna på. Om värdet "
 "är 0 startas inte administrationsservern.<br />Som standard är värdet 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 "AdminPwd anger lösenordet som administrationsservern använder för "
 "inloggning.<br />Som standard är värdet ”admin”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 "AdminUser anger användarnamnet som administrationsservern använder för "
 "inloggning.<br />Som standard är värdet ”admin”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
-msgstr "Resurskatalog"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
 msgstr ""
-"AssetsDir anger den lokala katalog som administrationsservern läser in "
-"resurser från. Om värdet är ”” läses resurserna från den medföljande körbara "
-"filen med statik.<br />Som standard är värdet ””."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Autentisering"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "Bindningsadress"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
-msgstr "Bindningsport"
+msgstr "Bind port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Samlar in data ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
-msgid "Common Settings"
-msgstr "Gemensamma inställningar"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
+msgid "Common Settings"
+msgstr "Vanliga inställningar"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Kompression"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
-"Konfigurationsfiler som inkluderas i den tillfälliga konfigurationsfilen"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Anpassade domäner"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid "Disable log color"
-msgstr "Inaktivera loggfärger"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
 msgstr ""
-"DisableLogColor inaktiverar loggfärger när LogWay == ”console” om värdet är "
-"true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
+msgid "Disable log color"
+msgstr "Inaktivera logg-färg"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Aktiverad"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Miljövariabel"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Avsluta när inloggningen misslyckas"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Allmänna inställningar"
 
 #: applications/luci-app-frpc/root/usr/share/rpcd/acl.d/luci-app-frpc.json:3
 msgid "Grant access to LuCI app frpc"
-msgstr "Ge LuCI-appen frpc åtkomst"
+msgstr "Godkänn åtkomst till LuCi-appen frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Inställningar för HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Lösenord för HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Proxy för HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Användare för HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval anger intervallet i sekunder för heartbeat-meddelanden "
-"till servern. Det rekommenderas inte att ändra värdet.<br />Som standard är "
-"värdet 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout anger den längsta tillåtna svarsfördröjningen för heartbeat "
-"i sekunder innan anslutningen avslutas. Det rekommenderas inte att ändra "
-"värdet.<br />Som standard är värdet 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Heartbeat-intervall"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid "Heartbeat timeout"
-msgstr "Tidsgräns för heartbeat"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
-msgid "Host header rewrite"
-msgstr "Omskrivning av Host-rubrik"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
 msgstr ""
-"HttpProxy anger en proxyadress som används för anslutning till servern. Om "
-"värdet är ”” ansluts direkt till servern.<br />Som standard läses värdet "
-"från miljövariabeln ”http_proxy”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Om remote_port är 0 tilldelar frps automatiskt en slumpmässig port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
+msgid "Heartbeat timeout"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
+msgid "Host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Lokal IP-adress"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Lokal port"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 "LocalIp anger IP-adressen eller värdnamnet som proxyn ska vidarebefordra "
 "till."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort anger porten som proxyn ska vidarebefordra till."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Platser"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Loggfil"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Loggnivå"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
-msgstr "Högsta antal loggdagar"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Logga stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Logga stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile anger filen som loggar skrivs till. Värdet används endast om LogWay "
-"är korrekt inställt.<br />Som standard är värdet ”console”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel anger den lägsta loggningsnivån. Giltiga värden är ”trace”, ”debug"
-"”, ”info”, ”warn” och ”error”.<br />Som standard är värdet ”info”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays anger det högsta antalet dagar som logginformation lagras innan "
-"den tas bort. Detta används endast om LogWay == ”file”.<br />Som standard är "
-"värdet 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
 msgstr ""
 "LoginFailExit styr om klienten ska avslutas efter ett misslyckat "
 "inloggningsförsök. Om värdet är false försöker klienten igen tills en "
 "inloggning lyckas.<br />Som standard är värdet true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "KÖRS INTE"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"OS-miljövariabler som skickas till frp för konfigurationsfilsmallen, se %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Insticksmodul"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Insticksmodulsinställningar"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokoll"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Protocol anger protokollet som används för kommunikation med servern. "
-"Giltiga värden är ”tcp”, ”kcp”, ”quic” och ”websocket”.<br />Som standard är "
-"värdet ”tcp”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Inställningar för proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
-msgstr "Proxynamn"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Typ av proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType anger typen av proxy. Giltiga värden omfattar ”tcp”, ”udp”, ”http"
-"”, ”https”, ”stcp” och ”xtcp”.<br />Som standard är värdet ”tcp”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "KÖRS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Fjärrport"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
-msgid "Respawn when crashed"
-msgstr "Starta om efter krasch"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
+msgid "Respawn when crashed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Roll"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Kör demonen som grupp"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Kör demonen som användare"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
-msgstr "SOCKS5-lösenord"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
-msgstr "SOCKS5-användare"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Serveradress"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
-msgstr "Servernamn"
+msgstr "Namn på servern"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
-msgstr "Serverport"
+msgstr "Port för server"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr anger adressen till servern som ska anslutas.<br />Som standard "
-"är värdet ”127.0.0.1”."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort anger porten som används för anslutning till servern.<br />Som "
-"standard är värdet 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Inställningar för uppstart"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Underdomän"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid "TCP mux"
-msgstr "TCP-multiplexering"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
+msgid "TCP mux"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
-msgstr "TLS Enable anger om TLS ska användas vid kommunikation med servern."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
 msgstr ""
 "TcpMux aktiverar eller inaktiverar multiplexering av TCP-strömmar. Det gör "
 "att flera begäranden från en klient kan dela en enda TCP-anslutning. Om "
 "värdet är true måste även servern ha TCP-multiplexering aktiverad.<br />Som "
 "standard är värdet true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
 msgstr ""
 "Den här listan kan användas för att ange ytterligare parametrar som inte har "
 "tagits med i LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token anger den auktoriseringstoken som används för att skapa nycklar som "
-"skickas till servern. Servern måste ha en matchande token för att "
-"auktoriseringen ska lyckas. <br />Som standard är värdet ””."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
-msgstr "Sökväg till Unix-domänsocket"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
 msgstr ""
-"UseCompression styr om kommunikationen med servern ska komprimeras.<br />Som "
-"standard är värdet false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseEncryption styr om kommunikationen med servern ska krypteras. "
-"Krypteringen görs med de token som anges i server- och "
-"klientkonfigurationen.<br />Som standard är värdet false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Användare"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"User anger ett prefix för proxynamn för att skilja dem från andra klienter. "
-"Om värdet inte är ”” ändras proxynamnen automatiskt till ”{user}.{proxy_name}"
-"”.<br />Som standard är värdet ””."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "frp-klient"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/ta/frpc.po
+++ b/applications/luci-app-frpc/po/ta/frpc.po
@@ -10,134 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "புதிய ப்ராக்சியைச் சேர்க்கவும் ..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "கூடுதல் உள்ளமைவுகள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "கூடுதல் அமைப்புகள்"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "நிர்வாக முகவரி"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "நிர்வாகி கடவுச்சொல்"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "நிர்வாக துறைமுகம்"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "நிர்வாக பயனர்"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"நிர்வாகி சேவையகம் பிணைக்கும் முகவரியை adminaddr குறிப்பிடுகிறது. <br /> இயல்பாக, "
-"இந்த மதிப்பு \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"நிர்வாகி சேவையகத்திற்கான துறைமுகத்தை நிர்வாகி குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக "
-"இருந்தால், நிர்வாக சேவையகம் தொடங்கப்படாது. <br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"நிர்வாகி சேவையகம் உள்நுழைவுக்கு பயன்படுத்தும் கடவுச்சொல்லை adminpwd குறிப்பிடுகிறது. "
-"<br /> இயல்பாக, இந்த மதிப்பு \"நிர்வாகி\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "மேம்பட்ட"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"நிர்வாகி சேவையகம் உள்நுழைவுக்கு பயன்படுத்தும் பயனர்பெயரை நிர்வாகி குறிப்பிடுகிறார். "
-"<br /> இயல்பாக, இந்த மதிப்பு \"நிர்வாகி\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "சொத்துக்கள் டிர்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"நிர்வாக சேவையகம் வளங்களை ஏற்றும் உள்ளக கோப்பகத்தை ASSETSDIR குறிப்பிடுகிறது. இந்த "
-"மதிப்பு \"\" என்றால், ச்டேட்டிக் பயன்படுத்தி தொகுக்கப்பட்ட இயங்கக்கூடியவற்றிலிருந்து "
-"சொத்துக்கள் ஏற்றப்படும். <br /> இயல்பாக, இந்த மதிப்பு \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "ஏற்பு"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "முகவரியை பிணைக்கவும்"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "துறைமுகம் பிணைப்பு"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "தரவு சேகரித்தல் ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "பொதுவான அமைப்புகள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "சுருக்க"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "கட்டமைப்பு கோப்புகள் தற்காலிக கட்டமைப்பு கோப்பில் அடங்கும்"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "தனிப்பயன் களங்கள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "பதிவு வண்ணத்தை முடக்கு"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"LOGCOLOR ஐ முடக்கு லாங்வே == \"கன்சோல்\" உண்மைக்கு அமைக்கும்போது வண்ணங்களை முடக்கு "
-"வண்ணங்களை முடக்கு."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "முடக்கப்பட்டது"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "இயக்கப்பட்டது"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "குறியாக்கம்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "சுற்றுச்சூழல் மாறி"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "உள்நுழைவு தோல்வியடையும் போது வெளியேறவும்"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "பொது அமைப்புகள்"
 
@@ -145,395 +415,810 @@ msgstr "பொது அமைப்புகள்"
 msgid "Grant access to LuCI app frpc"
 msgstr "லூசி ஆப் எஃப்ஆர்பிசிக்கு அணுகல் வழங்கவும்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP அமைப்புகள்"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP கடவுச்சொல்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP பதிலாள்"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "HTTP பயனர்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"ஆர்ட் பீட் இன்டர்வல் எந்த இடைவெளி இதயத் துடிப்புகள் சேவையகத்திற்கு நொடிகளில் "
-"அனுப்பப்படுகின்றன என்பதைக் குறிப்பிடுகிறது. இந்த மதிப்பை மாற்ற பரிந்துரைக்கப்படவில்லை. "
-"<br /> இயல்பாக, இந்த மதிப்பு 30 ஆகும்."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"ஆர்ட் பீட் டைம்அவுட் இணைப்பு நிறுத்தப்படுவதற்கு முன்னர், நொடிகளில் அனுமதிக்கப்பட்ட அதிகபட்ச "
-"இதய துடிப்பு மறுமொழி தாமதத்தைக் குறிப்பிடுகிறது. இந்த மதிப்பை மாற்ற "
-"பரிந்துரைக்கப்படவில்லை. <br /> இயல்பாக, இந்த மதிப்பு 90 ஆகும்."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "இதய துடிப்பு இடைவெளி"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "இதய துடிப்பு நேரம் முடிந்தது"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "புரவலன் தலைப்பு மீண்டும் எழுதவும்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy சேவையகத்துடன் இணைக்க ஒரு பதிலாள் முகவரியைக் குறிப்பிடுகிறது. இந்த மதிப்பு "
-"\"\" என்றால், சேவையகம் நேரடியாக இணைக்கப்படும். <br /> இயல்பாக, இந்த மதிப்பு "
-"\"http_proxy\" சூழல் மாறியிலிருந்து படிக்கப்படுகிறது."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Remote_port 0 ஆக இருந்தால், FRP கள் உங்களுக்காக ஒரு சீரற்ற துறைமுகத்தை ஒதுக்கும்"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "உள்ளக ஐபி"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "உள்ளக துறைமுகம்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "லோக்கல்ஐபி ஐபி முகவரி அல்லது புரவலன் பெயரை ப்ராக்சிக்கு குறிப்பிடுகிறது."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "உள்ளக துறைமுகம் துறைமுகத்தை ப்ராக்சிக்கு குறிப்பிடுகிறது."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "இருப்பிடங்கள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "பதிவு கோப்பு"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "பதிவு அமைப்புகள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "பதிவு நிலை"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "பதிவு அதிகபட்ச நாட்கள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "பதிவு நிலைபிழை"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "பதிவு நிலைவெளி"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"பதிவுகள் எழுதப்படும் ஒரு கோப்பை logfile குறிப்பிடுகிறது. உள்நுழைவு சரியான முறையில் "
-"அமைக்கப்பட்டால் மட்டுமே இந்த மதிப்பு பயன்படுத்தப்படும். <br /> இயல்பாக, இந்த மதிப்பு "
-"\"கன்சோல்\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"லோக்லெவல் குறைந்தபட்ச பதிவு அளவைக் குறிப்பிடுகிறது. செல்லுபடியாகும் மதிப்புகள் "
-"\"சுவடு\", \"பிழைத்திருத்த\", \"தகவல்\", \"எச்சரிக்கை\" மற்றும் \"பிழை\". <br /> "
-"இயல்பாக, இந்த மதிப்பு \"தகவல்\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"நீக்குவதற்கு முன் பதிவு தகவல்களை சேமிக்க அதிகபட்ச நாட்களின் எண்ணிக்கையை logmaxdays "
-"குறிப்பிடுகிறது. உள்நுழைவு == \"கோப்பு\" என்றால் மட்டுமே இது பயன்படுத்தப்படுகிறது. "
-"<br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"தோல்வியுற்ற உள்நுழைவு முயற்சியின் பின்னர் வாடிக்கையாளர் வெளியேற வேண்டுமா இல்லையா என்பதை "
-"உள்நுழைவு கட்டுப்படுத்துகிறது. பொய்யானது என்றால், உள்நுழைவு முயற்சி வெற்றிபெறும் வரை "
-"வாடிக்கையாளர் மீண்டும் முயற்சிப்பார். <br /> இயல்பாக, இந்த மதிப்பு உண்மை."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "ஓடவில்லை"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "சொருகு"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "சொருகி அமைப்புகள்"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "நெறிமுறை"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "பதிலாள் அமைப்புகள்"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "பதிலாள் பெயர்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "பதிலாள் வகை"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "இயங்கும்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "தொலை துறைமுகம்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "செயலிழந்தபோது ரெச்பான்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "பங்கு"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "டீமனை குழுவாக இயக்கவும்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "டீமனை பயனராக இயக்கவும்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "SOCKS5 கடவுச்சொல்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5 பயனர்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "சேவையக முகவரி"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "சேவையக பெயர்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "சேவையக துறைமுகம்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr உடன் இணைக்க சேவையகத்தின் முகவரியைக் குறிப்பிடுகிறது. <br /> இயல்பாக, இந்த "
-"மதிப்பு \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"சேவையகத்துடன் இணைக்க ServerPort போர்ட்டைக் குறிப்பிடுகிறது. <br /> இயல்பாக, இந்த "
-"மதிப்பு 7000 ஆகும்."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "எச்.கே."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "தொடக்க அமைப்புகள்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "துணை டொமைன்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP MUX"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "டி.எல்.எச்"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TCPMUX TCP ச்ட்ரீம் மல்டிபிளெக்சிங்கை மாற்றுகிறது. இது ஒரு வாடிக்கையாளரிடமிருந்து பல "
-"கோரிக்கைகளை ஒரு TCP இணைப்பைப் பகிர அனுமதிக்கிறது. இந்த மதிப்பு உண்மையாக இருந்தால், "
-"சேவையகத்தில் TCP மல்டிபிளெக்சிங் இயக்கப்பட்டிருக்க வேண்டும். <br /> இயல்பாக, இந்த மதிப்பு "
-"உண்மை."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"இந்த லூசியில் சேர்க்கப்படாத சில கூடுதல் அளவுருக்களைக் குறிப்பிட இந்த பட்டியல் "
-"பயன்படுத்தப்படலாம்."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "கிள்ளாக்கு"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"சேவையகத்திற்கு அனுப்பப்பட வேண்டிய விசைகளை உருவாக்க பயன்படுத்தப்படும் அங்கீகார கிள்ளாக்கை "
-"கிள்ளாக்கு குறிப்பிடுகிறது. ஏற்பு வெற்றிபெற சேவையகம் பொருந்தக்கூடிய டோக்கனைக் "
-"கொண்டிருக்க வேண்டும். <br /> இயல்பாக, இந்த மதிப்பு \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "யூனிக்ச் டொமைன் சாக்கெட் பாதை"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"சேவையகத்துடனான தொடர்பு சுருக்கப்படுமா இல்லையா என்பதை USECOMPRESSION "
-"கட்டுப்படுத்துகிறது. <br /> இயல்பாக, இந்த மதிப்பு தவறானது."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"சேவையகத்துடனான தொடர்பு குறியாக்கம் செய்யப்படுமா இல்லையா என்பதை USEENCRYPTION "
-"கட்டுப்படுத்துகிறது. சேவையகம் மற்றும் கிளையன்ட் உள்ளமைவில் வழங்கப்பட்ட டோக்கன்களைப் "
-"பயன்படுத்தி குறியாக்கம் செய்யப்படுகிறது. <br /> இயல்பாக, இந்த மதிப்பு தவறானது."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "பயனர்"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"பிற வாடிக்கையாளர்களிடமிருந்து வேறுபடுவதற்கு பதிலாள் பெயர்களுக்கான முன்னொட்டியை பயனர் "
-"குறிப்பிடுகிறார். இந்த மதிப்பு \"\" இல்லையென்றால், பதிலாள் பெயர்கள் தானாக \"{user}. "
-"{proxy_name}\" என மாற்றப்படும். <br /> இயல்பாக, இந்த மதிப்பு \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "FRP வாங்கி"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "OS சூழல்கள் கட்டமைப்பு கோப்பு வார்ப்புருவுக்கு FRP க்கு அனுப்பப்படுகின்றன, <a href = "
-#~ "\"https://github.com/fatedier/frp#configuration-file-template\"> frp "
-#~ "ReadMe </a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "சேவையகத்துடன் தொடர்பு கொள்ளும்போது பயன்படுத்த வேண்டிய நெறிமுறையை நெறிமுறை "
-#~ "குறிப்பிடுகிறது. செல்லுபடியாகும் மதிப்புகள் \"டி.சி.பி\", \"கே.சி.பி\" மற்றும் "
-#~ "\"வெப்சாக்கெட்\". <br /> இயல்பாக, இந்த மதிப்பு \"டி.சி.பி\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ப்ராக்சிடைப் இந்த ப்ராக்சியின் வகையைக் குறிப்பிடுகிறது. செல்லுபடியாகும் மதிப்புகளில் "
-#~ "\"டி.சி.பி\", \"யுடிபி\", \"எச்.டி.டி.பி\", \"எச்.டி.டி.பி.எச்\", "
-#~ "\"எச்.டி.சி.பி\" மற்றும் \"எக்ச்.டி.சி.பி\".<br /> இயல்பு மதிப்பு \"டி.சி.பி\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "சேவையகத்துடன் தொடர்பு கொள்ளும்போது TLS ஐப் பயன்படுத்த வேண்டுமா இல்லையா என்பதைக் "
-#~ "குறிப்பிடுகிறது."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/templates/frpc.pot
+++ b/applications/luci-app-frpc/po/templates/frpc.pot
@@ -1,121 +1,404 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr ""
 
@@ -123,319 +406,810 @@ msgstr ""
 msgid "Grant access to LuCI app frpc"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr ""
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
 msgstr ""

--- a/applications/luci-app-frpc/po/tr/frpc.po
+++ b/applications/luci-app-frpc/po/tr/frpc.po
@@ -10,136 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Yeni proxy ekle..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Ek yapılandırmalar"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Ek ayarlar"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Yönetici adresi"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Yönetici şifresi"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Yönetici bağlantı noktası"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Yönetici kullanıcı"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr, yönetici sunucusunun bağlandığı adresi belirtir.<br />Varsayılan "
-"olarak bu değer \"0.0.0.0\" dir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort, yönetici sunucusunun dinleneceği bağlantı noktasını belirtir. Bu "
-"değer 0 ise, yönetici sunucusu başlatılmayacaktır.<br />Varsayılan olarak bu "
-"değer 0'dır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd, yönetici sunucusunun oturum açmak için kullanacağı parolayı "
-"belirtir.<br />Varsayılan olarak bu değer \"admin\" dir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser, yönetici sunucusunun oturum açma için kullanacağı kullanıcı adını "
-"belirtir.<br />Varsayılan olarak bu değer \"admin\" dir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Varlıklar dizini"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir, yönetici sunucusunun kaynakları yükleyeceği yerel dizini "
-"belirtir. Bu değer \"\" ise, varlıklar statik kullanılarak paketlenmiş "
-"yürütülebilir dosyadan yüklenecektir.<br />Varsayılan olarak bu değer \"\" "
-"şeklindedir."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Kimlik Doğrulama"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Bağlantı adresi"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Porta bağla"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Veri toplama ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Ortak Ayarlar"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Sıkıştırma"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Yapılandırma dosyaları, geçici yapılandırma dosyasına dahil edilir"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Özel alan adları"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Günlük renklerini devre dışı bırak"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor, doğru olarak ayarlandığında LogWay == \"console\" olduğunda "
-"günlük renklerini devre dışı bırakır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Etkin"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Şifreleme"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Çevre değişkeni"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Giriş başarısız olduğunda çık"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
@@ -147,400 +415,810 @@ msgstr "Genel Ayarlar"
 msgid "Grant access to LuCI app frpc"
 msgstr "LuCI uygulaması frpc'ye erişim izni verin"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP Ayarları"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP şifresi"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "HTTP kullanıcısı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval, sunucuya hangi aralıklarla sinyal gönderileceğini saniye "
-"cinsinden belirtir. Bu değerin değiştirilmesi önerilmez.<br />Varsayılan "
-"olarak bu değer 30'dur."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout, bağlantı sonlandırılmadan önce izin verilen maksimum kalp "
-"atışı yanıt gecikmesini saniye cinsinden belirtir. Bu değerin değiştirilmesi "
-"önerilmez.<br />Varsayılan olarak bu değer 90'dır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Heartbeat aralığı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Heartbeat zaman aşımı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Ana bilgisayar üstbilgisini yeniden yazma"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy, sunucuya bağlanmak için bir proxy adresi belirtir. Bu değer \"\" "
-"ise, sunucuya doğrudan bağlanılacaktır.<br />Varsayılan olarak, bu değer "
-"\"http_proxy\" ortam değişkeninden okunur."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "remote_port 0 ise, frps sizin için rastgele bir port atayacaktır"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Yerel IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Yerel bağlantı noktası"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
 msgstr ""
-"LocalIp proxy olarak kullanılacak IP adresini veya ana bilgisayar adını "
-"belirtir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort proxy olarak kullanılacak portu belirtir."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Konumlar"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Günlük dosyası"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Günlük Ayarları"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Günlük seviyesi"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Maksimum günleri günlüğe kaydet"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Stderr'i günlüğe kaydet"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Stdout'u günlüğe kaydet"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile günlüklerin yazılacağı dosyayı belirtir. Bu değer yalnızca LogWay "
-"doğru bir şekilde ayarlanmışsa kullanılacaktır.<br />Varsayılan olarak bu "
-"değer \"console\" şeklindedir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel, minimum günlük seviyesini belirtir. Geçerli değerler \"trace\", "
-"\"debug\", \"info\", \"warn\" ve \"error\" dir.<br />Varsayılan olarak bu "
-"değer \"info\" dır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays, günlük bilgilerinin silinmeden önce saklanacağı maksimum gün "
-"sayısını belirtir. Bu yalnızca LogWay == \"file\" ise kullanılır.<br /"
-">Varsayılan olarak bu değer 0'dır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit, istemcinin başarısız bir oturum açma girişiminden sonra çıkıp "
-"çıkmayacağını kontrol eder. Yanlışsa, istemci başarılı bir oturum açma "
-"girişimi olana kadar yeniden deneyecektir.<br />Varsayılan olarak bu değer "
-"doğrudur."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "ÇALIŞMIYOR"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Eklenti"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Eklenti Ayarları"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Protokol"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Proxy Ayarları"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Proxy adı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Proxy türü"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "ÇALIŞIYOR"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Uzak bağlantı noktası"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Çöktüğünde yeniden çıkart"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Rol"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Arka plan programı grup olarak çalıştır"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Arka plan programı kullanıcı olarak çalıştır"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "SOCKS5 parolası"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5 kullanıcısı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Sunucu adresi"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Sunucu adı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Sunucu bağlantı noktası"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr bağlanılacak sunucunun adresini belirtir.<br />Varsayılan olarak "
-"bu değer \"127.0.0.1\" dır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort, sunucuya bağlanılacak bağlantı noktasını belirtir.<br /"
-">Varsayılan olarak bu değer 7000'dir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Başlangıç Ayarları"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Alt alan adı"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux, TCP akış çoklamasını değiştirir. Bu, bir istemciden gelen birden çok "
-"isteğin tek bir TCP bağlantısını paylaşmasına izin verir. Bu değer true ise, "
-"sunucuda da TCP çoklama etkinleştirilmiş olmalıdır.<br />Varsayılan olarak "
-"bu değer doğrudur."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Bu liste, bu LuCI'ye dahil edilmemiş bazı ek parametreleri belirtmek için "
-"kullanılabilir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Belirteç, sunucuya gönderilecek anahtarları oluşturmak için kullanılan "
-"yetkilendirme jetonunu belirtir. Yetkilendirmenin başarılı olması için "
-"sunucunun eşleşen bir jetona sahip olması gerekir.<br />Varsayılan olarak bu "
-"değer \"\" dir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Unix etki alanı soketi yolu"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression, sunucuyla iletişimin sıkıştırılıp sıkıştırılmayacağını "
-"denetler.<br />Varsayılan olarak bu değer yanlıştır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption, sunucu ile iletişimin şifrelenip şifrelenmeyeceğini kontrol "
-"eder. Şifreleme, sunucu ve istemci yapılandırmasında sağlanan belirteçler "
-"kullanılarak yapılır.<br />Varsayılan olarak bu değer yanlıştır."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Kullanıcı"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Kullanıcı, proxy adlarını diğer istemcilerden ayırmak için bir önek "
-"belirler. Bu değer \"\" değilse, proxy adları otomatik olarak \"{kullanıcı}. "
-"{Proxy_name}\" olarak değiştirilecektir.<br />Varsayılan olarak bu değer "
-"\"\" şeklindedir."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "frp İstemcisi"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "İşletim sistemi ortamları, yapılandırma dosyası şablonu için frp'ye "
-#~ "geçer, bkz. <a href=\"https://github.com/fatedier/frp#configuration-file-"
-#~ "template\">frp README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protokol, sunucuyla etkileşimde bulunulduğunda kullanılacak protokolü "
-#~ "belirtir. Geçerli değerler \"tcp\", \"kcp\" ve \"websocket\" dir.<br /"
-#~ ">Varsayılan olarak bu değer \"tcp\" dir."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType, bu proxy'nin türünü belirtir. Geçerli değerler arasında "
-#~ "\"tcp\", \"udp\", \"http\", \"https\", \"stcp\" ve \"xtcp\" bulunur.<br /"
-#~ ">Varsayılan olarak bu değer \"tcp\" dir."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable, sunucuyla iletişim kurulurken TLS'nin kullanılıp "
-#~ "kullanılmayacağını belirtir."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/uk/frpc.po
+++ b/applications/luci-app-frpc/po/uk/frpc.po
@@ -11,136 +11,404 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.5-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Додати новий проксі…"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Додаткові параметри"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Додаткові налаштування"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Адреса адміністратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Пароль адміністратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Порт адміністратора"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Адміністратор"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr встановлює адресу, до якої підключається сервер "
-"адміністратора.<br />Типово це значення — \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort встановлює порт, який буде прослуховуватися сервером "
-"адміністратора. Якщо вказано значення 0, сервер адміністратора не буде "
-"запущений.<br />Типово це значення — 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd визначає пароль, який сервер адміністратора використовуватиме для "
-"входу.<br />Типово це значення — «admin»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Розширені"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser визначає імʼя користувача, яке сервер адміністратора "
-"використовуватиме для входу.<br />Типово це значення — «admin»."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Каталог ресурсів"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Автентифікація"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
-"AssetsDir визначає локальний каталог, з якого сервер адміністратора "
-"завантажуватиме ресурси. Якщо це значення дорівнює \"\", ресурси будуть "
-"завантажені з пакетного виконуваного файлу за допомогою statik.<br />Типово "
-"це значення — \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
-msgstr "Привʼязана адреса"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Адреса привʼязки"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "Порт привʼязки"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Збір даних…"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Загальні налаштування"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Стиснення"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Долучити файли конфігурації до тимчасового файлу конфігурації"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Користувацькі домени"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Вимкнути колір журналу"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor вимикає кольори журналу, якщо LogWay == \"console\", коли "
-"встановлено значення true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Шифрування"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Змінна середовища"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Вийти, якщо вхід не вдається"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Загальні налаштування"
 
@@ -148,406 +416,810 @@ msgstr "Загальні налаштування"
 msgid "Grant access to LuCI app frpc"
 msgstr "Надати доступ до UCI для luci-app-frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Налаштування HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Пароль HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "Проксі HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Користувач HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval визначає інтервал у секундах, через який контрольні "
-"сигнали надсилаються на сервер. Не рекомендується змінювати це "
-"значення.<br />Типово це значення — 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout визначає максимальну дозволену затримку відповіді "
-"контрольного сигналу перед розривом підключення в секундах. Не "
-"рекомендується змінювати це значення.<br />Типово це значення — 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "Інтервал контрольного сигналу"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Час очікування контрольного сигналу"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Перезапис заголовка вузла"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy визначає адресу проксі для підключення до сервера. Якщо це "
-"значення дорівнює \"\", сервер буде підключено напряму.<br />Типово це "
-"значення зчитується зі змінної середовища \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Якщо remote_port дорівнює 0, frps призначить випадковий порт"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "Локальна IP-адреса"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Локальний порт"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp визначає IP-адресу або імʼя вузла для проксі-сервера."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort визначає порт для проксі."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Розташування"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Файл журналу"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Налаштування журналу"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Рівень журналювання"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Максимальна кількість днів журналу"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Журнал stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Журнал stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile визначає файл, куди будуть записуватися журнали. Це значення "
-"використовуватиметься, лише якщо LogWay встановлено належним чином.<br />"
-"Типово це значення — \"console\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel визначає мінімальний рівень журналювання. Дійсні значення: "
-"\"trace\", \"debug\", \"info\", \"warn\" і \"error\".<br />Типово це "
-"значення — \"info\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays визначає максимальну кількість днів для зберігання інформації "
-"журналу перед видаленням. Це використовується, лише якщо LogWay == "
-"\"file\".<br />Типово це значення — 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit контролює, чи повинен клієнт вийти після невдалої спроби "
-"входу. Якщо false, клієнт повторюватиме спробу, доки спроба входу не буде "
-"успішною.<br />Типово це значення — true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "НЕ ПРАЦЮЄ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
-"Змінні середовища ОС, що передаються frp як шаблон для файлу конфігурації, "
-"дивіться %s."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "Плагін"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Налаштування плагіна"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Протокол"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
 msgstr ""
-"Протокол визначає протокол, який використовуватиметься під час взаємодії із "
-"сервером. Дійсні значення: \"tcp\", \"kcp\", \"quic\" та \"websocket\".<br />"
-"Типово це значення — \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Налаштування проксі"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Імʼя проксі"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Тип проксі"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
-"ProxyType визначає тип цього проксі-сервера. Допустимі значення: \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" та \"xtcp\".<br />Типово це значення "
-"— \"tcp\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "ЗАПУЩЕНО"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "Віддалений порт"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Перезапускати після збою"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Роль"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Запускати службу від імені групи"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Запускати службу від імені користувача"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Пароль SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "Користувач SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Адреса сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Імʼя сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Порт сервера"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr вказує адресу сервера для підключення.<br />Типово це значення — "
-"\"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort визначає порт для підключення до сервера.<br />Типово це значення "
-"— 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Параметри запуску"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Субдомен"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "Мультиплексування TCP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
-"Параметр «Увімкнути TLS» визначає, чи слід використовувати TLS під час "
-"звʼязку із сервером."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux вмикає мультиплексування потоку TCP. Це дозволяє кільком запитам від "
-"клієнта використовувати одне TCP-підключення. Якщо це значення дорівнює "
-"true, на сервері також має бути ввімкнено мультиплексування TCP.<br />Типово "
-"це значення — true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Цей список можна використовувати для визначення деяких додаткових "
-"параметрів, які не були включені в цей LuCI."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Токен"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Токен визначає токен авторизації, який використовується для створення ключів "
-"для надсилання на сервер. Для успішної авторизації сервер повинен мати "
-"відповідний токен.<br />Типово це значення — \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Шлях до сокета Unix-домену"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression визначає, чи стискатиметься звʼязок із сервером.<br />Типово "
-"це значення — false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption визначає, чи буде звʼязок із сервером зашифрований. Шифрування "
-"виконується за допомогою токенів, наданих у конфігурації сервера та "
-"клієнта.<br />Типово це значення — false."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Користувач"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Користувач вказує префікс для імен проксі, щоб відрізняти їх від інших "
-"клієнтів. Якщо це значення не дорівнює \"\", імена проксі-серверів будуть "
-"автоматично змінені на \"{user}.{proxy_name}\".<br />Типово це значення — "
-"\"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "Клієнт frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Середовища ОС передають до frp для шаблону файлу конфігурації, див. <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Protocol визначає протокол, який використовуватиметься під час взаємодії "
-#~ "з сервером. Дійсні значення: «tcp», «kcp» і «websocket».<br />За "
-#~ "умовчанням це значення «tcp».\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType визначає тип цього проксі. Дійсні значення включають \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\" і \"xtcp\".<br />За умовчанням це "
-#~ "значення \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable визначає, чи слід використовувати TLS під час зв’язку із "
-#~ "сервером."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/vi/frpc.po
+++ b/applications/luci-app-frpc/po/vi/frpc.po
@@ -10,135 +10,404 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "Thêm proxy mới..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
 msgstr "Cấu hình thêm"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "Cài đặt mở rộng"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "Admin address"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "Mật khẩu Admin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "Admin port"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "Người dùng Admin"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
 msgstr ""
-"AdminAddr chỉ định địa chỉ mà máy chủ quản trị liên kết đến.<br />Theo mặc "
-"định, giá trị này là \"0.0.0.0\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
 msgstr ""
-"AdminPort chỉ định cổng để máy chủ quản trị lắng nghe. Nếu giá trị này là 0, "
-"máy chủ quản trị sẽ không được khởi động.<br />Theo mặc định, giá trị này là "
-"0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
 msgstr ""
-"AdminPwd chỉ định mật khẩu mà máy chủ quản trị sẽ sử dụng để đăng nhập.<br /"
-">Theo mặc định, giá trị này là \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "Nâng cao"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
 msgstr ""
-"AdminUser chỉ định tên người dùng mà máy chủ quản trị sẽ sử dụng để đăng "
-"nhập.<br />Theo mặc định, giá trị này là \"admin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "Assets dir"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir chỉ định thư mục cục bộ mà máy chủ quản trị sẽ tải tài nguyên từ "
-"đó. Nếu giá trị này là \"\", thì nội dung sẽ được tải từ tệp thực thi đi kèm "
-"bằng cách sử dụng thống kê.<br />Theo mặc định, giá trị này là \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "Xác thực"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
+msgstr "Gán địa chỉ"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
+msgstr "Cổng Bind"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "Đang thu thập dữ liệu ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "Thiết lập chung"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "Nén"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "Tệp cấu hình bao gồm trong tệp cấu hình tạm thời"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "Tên miền tùy chỉnh"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
 msgstr "Disable log color"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor disables log colors when LogWay == \"console\" khi đặt là "
-"true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "Vô hiệu hoá"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
+msgid ""
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "Kích Hoạt"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "Mã hóa"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "Environment variable"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
-msgstr "Thoát khi đăng nhập thất bại"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "Các cài đặt chung"
 
@@ -146,393 +415,810 @@ msgstr "Các cài đặt chung"
 msgid "Grant access to LuCI app frpc"
 msgstr "Cấp quyền truy cập vào ứng dụng LuCI frpc"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "Cài đặt HTTP"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "Mật khẩu HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
 msgstr "Người dùng HTTP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
 msgstr ""
-"HeartBeatInterval chỉ định khoảng thời gian nhịp tim được gửi đến máy chủ, "
-"tính bằng giây. Bạn không nên thay đổi giá trị này.<br />Theo mặc định, giá "
-"trị này là 30."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
 msgstr ""
-"HeartBeatTimeout chỉ định độ trễ phản hồi nhịp tim tối đa được phép trước "
-"khi kết nối bị ngắt, tính bằng giây. Bạn không nên thay đổi giá trị này.<br /"
-">Theo mặc định, giá trị này là 90."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
-msgstr "Heartbeat interval"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "Heartbeat timeout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "Viết lại tiêu đề máy chủ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
 msgstr ""
-"HttpProxy chỉ định một địa chỉ proxy để kết nối với máy chủ thông qua. Nếu "
-"giá trị này là \"\", thì máy chủ sẽ được kết nối trực tiếp.<br />Theo mặc "
-"định, giá trị này được đọc từ biến môi trường \"http_proxy\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "Nếu remote_port bằng 0, fps sẽ chỉ định một cổng ngẫu nhiên cho bạn"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "IP nội bộ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "Cổng nội bộ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "LocalIp chỉ định địa chỉ IP hoặc tên máy chủ để ủy quyền."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "LocalPort chỉ định cổng cho proxy."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "Vị trí"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "Tệp nhật ký"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "Cài đặt Log"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "Mức độ nhật ký"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "Log max days"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "Log stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "Log stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
 msgstr ""
-"LogFile chỉ định một tệp mà nhật ký sẽ được ghi vào. Giá trị này sẽ chỉ được "
-"sử dụng nếu LogWay được đặt phù hợp.<br />Theo mặc định, giá trị này là "
-"\"bảng điều khiển\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"LogLevel chỉ định mức nhật ký tối thiểu. Các giá trị hợp lệ là \"dấu vết\", "
-"\"gỡ lỗi\", \"thông tin\", \"cảnh báo\" và \"lỗi\".<br />Theo mặc định, giá "
-"trị này là \"thông tin\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
 msgstr ""
-"LogMaxDays chỉ định số ngày tối đa để lưu trữ thông tin nhật ký trước khi "
-"xóa. Giá trị này chỉ được sử dụng nếu LogWay == \"file\".<br />Theo mặc "
-"định, giá trị này là 0."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
 msgstr ""
-"LoginFailExit kiểm soát việc khách hàng có nên thoát ra sau một lần thử đăng "
-"nhập không thành công hay không. Nếu sai, ứng dụng sẽ thử lại cho đến khi "
-"đăng nhập thành công.<br />Theo mặc định, giá trị này là đúng."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "Không chạy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
-msgid "Plugin"
-msgstr "Plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "Cài đặt Plugin"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "Giao thức"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
 msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
+"Only visitors from specified users can connect. Use * to allow all users."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "Cài đặt Proxy"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
+msgid "Plugin"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "Tên Proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "Loại Proxy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "Đang chạy"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
-msgstr "Remote port"
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "Respawn khi bị lỗi"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "Vai trò"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "Chạy daemon theo nhóm"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "Chạy daemon với tư cách người dùng"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "Mật khẩu SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "Tài khoản người dùng SOCKS5"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "Địa chỉ máy chủ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "Tên máy chủ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "Cổng máy chủ"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
-msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
 msgstr ""
-"ServerAddr chỉ định địa chỉ của máy chủ để kết nối.<br />Theo mặc định, giá "
-"trị này là \"127.0.0.1\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
 msgstr ""
-"ServerPort chỉ định cổng để kết nối với máy chủ trên.<br />Theo mặc định, "
-"giá trị này là 7000."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
+msgid ""
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "Cài đặt khởi động"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "Miền con"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
 msgstr ""
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
 msgstr ""
-"TcpMux chuyển đổi ghép kênh luồng TCP. Điều này cho phép nhiều yêu cầu từ "
-"máy khách chia sẻ một kết nối TCP. Nếu giá trị này là true, thì máy chủ cũng "
-"phải bật tính năng ghép kênh TCP.<br />Theo mặc định, giá trị này là true."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
 msgstr ""
-"Danh sách này có thể được sử dụng để chỉ định một số tham số bổ sung chưa "
-"được đưa vào LuCI này."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Mã thông báo chỉ định mã thông báo ủy quyền được sử dụng để tạo các khóa "
-"được gửi đến máy chủ. Máy chủ phải có mã thông báo phù hợp để ủy quyền thành "
-"công. <br />Theo mặc định, giá trị này là \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Đường dẫn tên miền socket Unix"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
 msgstr ""
-"UseCompression kiểm soát việc có nén giao tiếp với máy chủ hay không.<br /"
-">Theo mặc định, giá trị này là sai."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
 msgstr ""
-"UseEncryption kiểm soát việc giao tiếp với máy chủ có được mã hóa hay không. "
-"Quá trình mã hóa được thực hiện bằng cách sử dụng mã thông báo được cung cấp "
-"trong cấu hình máy chủ và máy khách.<br />Theo mặc định, giá trị này là sai."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "Người dùng"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
 msgstr ""
-"Người dùng chỉ định tiền tố cho tên proxy để phân biệt chúng với các máy "
-"khách khác. Nếu giá trị này không phải là \"\", tên proxy sẽ tự động được "
-"đổi thành \"{user}.{proxy_name}\".<br />Theo mặc định, giá trị này là \"\"."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr ""
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
-msgstr "frp Client"
+msgstr ""
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Môi trường hệ điều hành chuyển sang frp cho mẫu tệp cấu hình, xem <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-
-#~ msgid ""
-#~ "Protocol specifies the protocol to use when interacting with the server. "
-#~ "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "Giao thức chỉ định giao thức sẽ sử dụng khi tương tác với máy chủ. Các "
-#~ "giá trị hợp lệ là \"tcp\", \"kcp\" và \"websocket\".<br />Theo mặc định, "
-#~ "giá trị này là \"tcp\"."
-
-#~ msgid ""
-#~ "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, "
-#~ "this value is \"tcp\"."
-#~ msgstr ""
-#~ "ProxyType chỉ định loại proxy này. Các giá trị hợp lệ bao gồm \"tcp\", "
-#~ "\"udp\", \"http\", \"https\", \"stcp\" và \"xtcp\".<br />Theo mặc định, "
-#~ "giá trị này là \"tcp\"."
-
-#~ msgid ""
-#~ "TLSEnable specifies whether or not TLS should be used when communicating "
-#~ "with the server."
-#~ msgstr ""
-#~ "TLSEnable chỉ định có nên sử dụng TLS hay không khi giao tiếp với máy chủ."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr ""

--- a/applications/luci-app-frpc/po/zh_Hant/frpc.po
+++ b/applications/luci-app-frpc/po/zh_Hant/frpc.po
@@ -1,134 +1,421 @@
 msgid ""
 msgstr ""
 "PO-Revision-Date: 2026-04-16 07:27+0000\n"
+"Project-Id-Version: luci-app-frpc\n"
 "Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
 "projects/openwrt/luciapplicationsfrpc/zh_Hant/>\n"
 "Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
-msgid "Add new proxy..."
-msgstr "加入新代理..."
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1454
+msgid "Add new proxy or visitor..."
+msgstr "新增新的代理或訪問者..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:360
+msgid "Additional OIDC token endpoint params. Use key=value."
+msgstr "附加 OIDC 權杖端點參數。使用 key=value。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:250
+msgid "Additional auth scopes"
+msgstr "額外認證範圍"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:612
+msgid "Additional client metadata. Use key=value."
+msgstr "附加用戶端元資料。使用 key=value。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+msgid "Additional config files included by frpc."
+msgstr "frpc 包含的附加設定檔案。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:174
 msgid "Additional configs"
-msgstr "額外配置"
+msgstr "額外設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid "Additional settings"
-msgstr "進階設定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1060
+msgid "Additional proxy metadata. Use key=value."
+msgstr "附加代理元資料。使用 key=value。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid "Admin address"
-msgstr "管理員位址"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:251
+msgid "Additional scopes to include authentication information."
+msgstr "包含驗證資訊的附加作用域。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid "Admin password"
-msgstr "管理員密碼"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:187
+msgid "Address of the frps server."
+msgstr "frps 伺服器位址。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid "Admin port"
-msgstr "管理員連接埠"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1430
+msgid "Advanced"
+msgstr "高階"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid "Admin user"
-msgstr "管理員用戶"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:839
+msgid "Allow users"
+msgstr "允許使用者"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
-msgid ""
-"AdminAddr specifies the address that the admin server binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr "AdminAddr 指定管理伺服器繫結到的位址。<br />預設情況下，此值為「0.0.0.0」。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1069
+msgid "Annotations"
+msgstr "註解"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
-msgid ""
-"AdminPort specifies the port for the admin server to listen on. If this "
-"value is 0, the admin server will not be started.<br />By default, this "
-"value is 0."
-msgstr ""
-"AdminPort 指定管理伺服器監聽的連接埠。若此值為 0，則不會啟動管理伺服器"
-"。<br />預設情況下，此值為0。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1070
+msgid "Annotations displayed on frps dashboard. Use key=value."
+msgstr "顯示在 frps 儀錶板上的註解。使用 key=value。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
-msgid ""
-"AdminPwd specifies the password that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr "AdminPwd 指定管理伺服器登入密碼。<br />此值預設為「admin」。"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
-msgid ""
-"AdminUser specifies the username that the admin server will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr "AdminUser 指定管理伺服器登入用戶名稱。<br />此值預設為「admin」。"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:464
 msgid "Assets dir"
 msgstr "資產目錄"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
-msgid ""
-"AssetsDir specifies the local directory that the admin server will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir 指定管理伺服器載入資源的本地目錄。若此值為空，將使用 statik 從組合"
-"執行檔中載入資產。<br />此值為預設空。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1426
+msgid "Authentication"
+msgstr "認證"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
-msgid "Bind addr"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:231
+msgid "Authentication method"
+msgstr "認證方式"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:232
+msgid "Authentication method."
+msgstr "驗證方式。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:680
+msgid "Bandwidth limit"
+msgstr "頻寬限制"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:684
+msgid "Bandwidth limit mode"
+msgstr "頻寬限制模式"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:681
+msgid "Bandwidth limit, for example 1MB."
+msgstr "頻寬限制，例如 1MB。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:861
+msgid "Bind address"
 msgstr "繫結位址"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:865
 msgid "Bind port"
 msgstr "繫結連接埠"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:873
+msgid "Bind port is required for visitors."
+msgstr "訪問者必須填寫繫結連接埠。"
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:11
+msgid "Client"
+msgstr "用戶端"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:183
+msgid "Client ID"
+msgstr "用戶端 ID"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:611
+msgid "Client metadata"
+msgstr "用戶端元資料"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1417
 msgid "Collecting data ..."
 msgstr "收集資料中..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:317
+msgid "Command arguments passed to token source exec."
+msgstr "傳遞給權杖來源執行命令的參數。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:294
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+"用於獲取權杖的命令。使用此來源類型時，init 指令碼會新增 --allow-"
+"unsafe=TokenSourceExec。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1425
 msgid "Common Settings"
 msgstr "通用設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:832
+msgid ""
+"Compatibility field for UCI. Server sections are emitted as proxy entries; "
+"visitor sections are emitted as visitor entries."
+msgstr "UCI 相容欄位。伺服端段會產生為代理項目；訪問者段會產生為訪問者項目。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:693
+msgid "Compress proxy traffic."
+msgstr "壓縮代理流量。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:692
 msgid "Compression"
 msgstr "壓縮"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:16
-msgid "Config files include in temporary config file"
-msgstr "配置檔包含在臨時配置檔案中"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:348
+msgid "Configuration key: auth.oidc.audience."
+msgstr "設定鍵：auth.oidc.audience。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:340
+msgid "Configuration key: auth.oidc.clientID."
+msgstr "設定鍵：auth.oidc.clientID。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:344
+msgid "Configuration key: auth.oidc.clientSecret."
+msgstr "設定鍵：auth.oidc.clientSecret。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:352
+msgid "Configuration key: auth.oidc.scope."
+msgstr "設定鍵：auth.oidc.scope。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:356
+msgid "Configuration key: auth.oidc.tokenEndpointURL."
+msgstr "設定鍵：auth.oidc.tokenEndpointURL。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:388
+msgid "Configuration key: log.level."
+msgstr "設定鍵：log.level。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:980
+msgid "Configuration key: plugin.crtPath."
+msgstr "設定鍵：plugin.crtPath。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1004
+msgid "Configuration key: plugin.hostHeaderRewrite."
+msgstr "設定鍵：plugin.hostHeaderRewrite。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:936
+msgid "Configuration key: plugin.httpPassword."
+msgstr "設定鍵：plugin.httpPassword。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:932
+msgid "Configuration key: plugin.httpUser."
+msgstr "設定鍵：plugin.httpUser。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:992
+msgid "Configuration key: plugin.keyPath."
+msgstr "設定鍵：plugin.keyPath。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:959
+msgid "Configuration key: plugin.localPath."
+msgstr "設定鍵：plugin.localPath。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:944
+msgid "Configuration key: plugin.password."
+msgstr "設定鍵：plugin.password。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:963
+msgid "Configuration key: plugin.stripPrefix."
+msgstr "設定鍵：plugin.stripPrefix。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:948
+msgid "Configuration key: plugin.unixPath."
+msgstr "設定鍵：plugin.unixPath。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:940
+msgid "Configuration key: plugin.username."
+msgstr "設定鍵：plugin.username。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:703
+msgid "Configuration key: proxies[].customDomains."
+msgstr "設定鍵：proxies[].customDomains。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:764
+msgid "Configuration key: proxies[].loadBalancer.group."
+msgstr "設定鍵：proxies[].loadBalancer.group。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:768
+msgid "Configuration key: proxies[].loadBalancer.groupKey."
+msgstr "設定鍵：proxies[].loadBalancer.groupKey。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:707
+msgid "Configuration key: proxies[].subdomain."
+msgstr "設定鍵：proxies[].subdomain。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:581
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr "設定鍵：transport.quic.keepalivePeriod。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:585
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr "設定鍵：transport.quic.maxIdleTimeout。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:589
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr "設定鍵：transport.quic.maxIncomingStreams。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:522
+msgid "Connect server local IP"
+msgstr "連線伺服器本地 IP"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:494
+msgid "Connection pool count"
+msgstr "連線池數量"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:495
+msgid "Connections established in advance."
+msgstr "預先建立的連線數。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:370
+msgid "Custom CA certificate file for OIDC endpoint."
+msgstr "OIDC 端點的自訂 CA 憑證檔案。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+msgid "Custom DNS server used by frpc."
+msgstr "frpc 使用的自訂 DNS 伺服器。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:702
 msgid "Custom domains"
 msgstr "自訂網域"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
+msgid "DNS server"
+msgstr "DNS 伺服器"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:486
+msgid "Dial server keepalive"
+msgstr "撥號伺服器保活"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:482
+msgid "Dial server timeout"
+msgstr "撥號伺服器逾時"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:903
+msgid "Disable NAT assisted addresses"
+msgstr "停用 NAT 輔助位址"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:568
+msgid "Disable custom TLS first byte"
+msgstr "停用自定義 TLS 首位元組"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:904
+msgid "Disable local interface assisted addresses for XTCP NAT traversal."
+msgstr "停用用於 XTCP NAT 穿透的本地介面輔助位址。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:395
 msgid "Disable log color"
-msgstr "禁用紀錄顏色"
+msgstr "停用紀錄顏色"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:396
+msgid "Disable log colors when log output is console."
+msgstr "當日誌輸出到主控台時停用日誌顏色。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:258
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:698
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:786
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:913
+msgid "Disabled"
+msgstr "已停用"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:888
+msgid "Effective when XTCP keep tunnel open is enabled."
+msgstr "啟用 XTCP 保持隧道開啟時生效。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:469
+msgid "Enable Go pprof handlers in web server."
+msgstr "在 Web 伺服器中啟用 Go pprof 處理器。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1016
+msgid "Enable HTTP/2 for HTTPS bridge plugins."
+msgstr "為 HTTPS 橋接外掛啟用 HTTP/2。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:418
 msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true."
-msgstr "當 LogWay ==「console」設定為 true 時，DisableLogColor 會停用紀錄顏色。"
+"Enable HTTPS for the frpc web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+"為 frpc Web 伺服器啟用 HTTPS。此開關控制是否產生 webServer.tls.certFile 和 "
+"webServer.tls.keyFile。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:499
+msgid "Enable TCP stream multiplexing."
+msgstr "啟用 TCP 流多路複用。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:541
+msgid ""
+"Enable TLS when communicating with frps. Since frp v0.50.0, default is true."
+msgstr "與 frps 通訊時啟用 TLS。自 frp v0.50.0 起預設為 true。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:648
+msgid "Enable or disable this proxy."
+msgstr "啟用或停用此代理。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:468
+msgid "Enable pprof"
+msgstr "啟用 pprof"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:417
+msgid "Enable web HTTPS"
+msgstr "啟用 Web HTTPS"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:647
+msgid "Enabled"
+msgstr "已啟用"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:689
+msgid "Encrypt proxy traffic."
+msgstr "加密代理流量。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:688
 msgid "Encryption"
 msgstr "加密"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
 msgid "Environment variable"
 msgstr "環境變數"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid "Exit when login fail"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1201
+msgid "Environment variable must use KEY=value format."
+msgstr "環境變數必須使用 KEY=value 格式。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:327
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr "傳遞給權杖來源執行命令的環境變數。使用 KEY=value。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
+msgid "Exit frpc when the first login fails."
+msgstr "首次登入失敗時退出 frpc。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:201
+msgid "Exit when login fails"
 msgstr "登入失敗時退出"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:595
+msgid "Experimental feature gates. Use key=value, for example VirtualNet=true."
+msgstr "實驗性功能開關。使用 key=value，例如 VirtualNet=true。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+msgid ""
+"Extra root-level configuration fragments included before generated proxy and "
+"visitor sections. Use frp includes or per-proxy raw settings for proxy/"
+"visitor tables."
+msgstr ""
+"在產生的代理和訪問者段之前包含額外的根層級設定片段。代理/訪問者表請使用 frp "
+"includes 或每個代理的原始設定。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:900
+msgid "Fallback timeout in milliseconds for XTCP."
+msgstr "XTCP 回退逾時時間，單位為毫秒。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:899
+msgid "Fallback timeout ms"
+msgstr "回退逾時毫秒數"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:895
+msgid "Fallback to"
+msgstr "回退到"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:896
+msgid "Fallback visitor name for XTCP."
+msgstr "XTCP 回退訪問者名稱。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:594
+msgid "Feature gates"
+msgstr "功能開關"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1047
+msgid "For virtual_net visitor plugin."
+msgstr "用於 virtual_net 訪問者外掛。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1460
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -136,354 +423,815 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app frpc"
 msgstr "授予存取 luci-app-frpc 的權限"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
-msgid "HTTP Settings"
-msgstr "HTTP 設定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1462
+msgid "HTTP / Domain"
+msgstr "HTTP / 域名"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:820
+msgid "HTTP health check headers. Use Header=Value."
+msgstr "HTTP 健康檢查請求標頭。使用 Header=Value。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:801
+msgid "HTTP health check path."
+msgstr "HTTP 健康檢查路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:747
+msgid "HTTP or TCPMUX basic auth password."
+msgstr "HTTP 或 TCPMUX 基本驗證密碼。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:744
+msgid "HTTP or TCPMUX basic auth username."
+msgstr "HTTP 或 TCPMUX 基本驗證使用者名稱。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:746
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:935
 msgid "HTTP password"
 msgstr "HTTP 密碼"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
-msgid "HTTP proxy"
-msgstr "HTTP 代理"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1211
+msgid "HTTP path must start with /."
+msgstr "HTTP 路徑必須以 / 開頭。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:743
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:931
 msgid "HTTP user"
-msgstr "HTTP 用戶"
+msgstr "HTTP 使用者"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
-msgid ""
-"HeartBeatInterval specifies at what interval heartbeats are sent to the "
-"server, in seconds. It is not recommended to change this value.<br />By "
-"default, this value is 30."
-msgstr ""
-"HeartBeatInterval 以秒為單位指定將心跳發送到伺服器的間隔。不建議更改此值。"
-"<br />預設情況下，此值為 30。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1465
+msgid "Health Check"
+msgstr "健康檢查"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
-msgid ""
-"HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
-"before the connection is terminated, in seconds. It is not recommended to "
-"change this value.<br />By default, this value is 90."
-msgstr ""
-"HeartBeatTimeout 指定終止連線之前允許的最大心跳回應延遲，以秒為單位。不建議更"
-"改此值。<br />預設情況下，此值為 90。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:819
+msgid "Health check headers"
+msgstr "健康檢查請求標頭"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:796
+msgid "Health check interval"
+msgstr "健康檢查間隔"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:797
+msgid "Health check interval in seconds."
+msgstr "健康檢查間隔，單位為秒。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:792
+msgid "Health check max failed"
+msgstr "健康檢查最大失敗次數"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:800
+msgid "Health check path"
+msgstr "健康檢查路徑"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:813
+msgid "Health check path is required when health check type is http."
+msgstr "健康檢查類型為 http 時必須填寫健康檢查路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:788
+msgid "Health check timeout"
+msgstr "健康檢查逾時"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:789
+msgid "Health check timeout in seconds."
+msgstr "健康檢查逾時時間，單位為秒。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:784
+msgid "Health check type"
+msgstr "健康檢查類型"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:785
+msgid "Health check type."
+msgstr "健康檢查類型。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:530
 msgid "Heartbeat interval"
 msgstr "心跳間隔"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:531
+msgid "Heartbeat interval in seconds."
+msgstr "心跳間隔，單位為秒。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:534
 msgid "Heartbeat timeout"
 msgstr "心跳逾時"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:535
+msgid "Heartbeat timeout in seconds."
+msgstr "心跳逾時時間，單位為秒。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:720
 msgid "Host header rewrite"
 msgstr "主機標頭重寫"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+msgid "Include config files"
+msgstr "包含設定檔案"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:884
+msgid "Keep XTCP tunnel open."
+msgstr "保持 XTCP 隧道開啟。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:883
+msgid "Keep tunnel open"
+msgstr "保持隧道開啟"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:511
+msgid "Keepalive interval for TCP mux."
+msgstr "TCP 多路複用保活間隔。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1466
+msgid "Load Balancer"
+msgstr "負載均衡"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:763
+msgid "Load balancer group"
+msgstr "負載均衡組"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:776
+msgid "Load balancer group is required when group key is set."
+msgstr "設定負載平衡群組金鑰時必須填寫負載平衡群組。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:767
+msgid "Load balancer group key"
+msgstr "負載均衡組金鑰"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:255
 msgid ""
-"HttpProxy specifies a proxy address to connect to the server through. If "
-"this value is \"\", the server will be connected to directly.<br />By "
-"default, this value is read from the \"http_proxy\" environment variable."
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
 msgstr ""
-"HttpProxy 指定透過其連線至伺服器的代理位址。若此值為空，則伺服器將直接連線"
-"。<br />預設將從環境變數「http_proxy」中讀取此值。"
+"從外部來源載入權杖。file 從本地檔案讀取權杖；exec 執行命令並需要 frp unsafe "
+"權限。與 auth.token 互斥。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-msgid "If remote_port is 0, frps will assign a random port for you"
-msgstr "如果遠端連接埠為 0，frps 會分配一個隨機連接埠"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:659
 msgid "Local IP"
 msgstr "本地 IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:523
+msgid ""
+"Local IP bound when connecting to frps. Only valid for tcp, websocket or wss."
+msgstr "連線 frps 時繫結的本地 IP。僅對 tcp、websocket 或 wss 有效。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:967
+msgid ""
+"Local backend address used by bridge plugins. For https2http, https2https "
+"and tls2raw, this is the local service address reached after frp terminates "
+"external TLS; for http2https/http2http, it is the local upstream address."
+msgstr ""
+"橋接外掛使用的本機後端位址。對於 https2http、https2https 和 tls2raw，這是 "
+"frp 終止外部 TLS 後存取的本機服務位址；對於 http2https/http2http，這是本機上"
+"游位址。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:862
+msgid "Local bind address for visitor."
+msgstr "訪問者本地繫結位址。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:866
+msgid "Local bind port for visitor. Use a negative value to avoid binding."
+msgstr "訪問者本地繫結連接埠。使用負值可避免繫結。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:663
 msgid "Local port"
 msgstr "本地連接埠"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-msgid "LocalIp specifies the IP address or host name to proxy to."
-msgstr "指定要代理的 IP 位址或主機名。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:660
+msgid "Local service IP or host."
+msgstr "本地服務 IP 或主機名稱。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-msgid "LocalPort specifies the port to proxy to."
-msgstr "指定要代理的連接埠。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:664
+msgid "Local service port."
+msgstr "本地服務連接埠。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:711
 msgid "Locations"
 msgstr "地點"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid "Log file"
-msgstr "紀錄檔案"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1431
+msgid "Log Settings"
+msgstr "日誌設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:387
 msgid "Log level"
 msgstr "紀錄等級"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:391
 msgid "Log max days"
 msgstr "紀錄最大天數"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:11
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:383
+msgid "Log output"
+msgstr "日誌輸出"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:384
+msgid "Log output path or console."
+msgstr "日誌輸出路徑或 console。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:142
 msgid "Log stderr"
 msgstr "紀錄 stderr"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:10
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:132
 msgid "Log stdout"
 msgstr "紀錄 stdout"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
-msgstr ""
-"LogFile 指定寫入紀錄的檔案。僅當正確設定 LogWay 時，才會使用此值。<br />預設"
-"值為「console」。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:887
+msgid "Max retries per hour"
+msgstr "每小時最大重試次數"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel 指定最低紀錄等級。有效值為「trace」,「debug」,「info」,「warn」和「"
-"error」。<br />預設情況下，此值為「info」。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:392
+msgid "Maximum number of days to keep logs."
+msgstr "保留日誌的最大天數。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays 指定刪除前儲存紀錄資訊的最長天數。僅當 LogWay ==「file」時才使用"
-"。<br />預設值為 0。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1467
+msgid "Metadata"
+msgstr "元資料"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
-msgid ""
-"LoginFailExit controls whether or not the client should exit after a failed "
-"login attempt. If false, the client will retry until a login attempt "
-"succeeds.<br />By default, this value is true."
-msgstr ""
-"LoginFailExit 控制在嘗試登入失敗後用戶端是否應該退出。若為 false，則用戶端將"
-"重試，直到成功登入為止。<br />預設為 true。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:891
+msgid "Min retry interval"
+msgstr "最小重試間隔"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:892
+msgid "Minimum XTCP retry interval."
+msgstr "XTCP 最小重試間隔。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:757
+msgid "Multiplexer"
+msgstr "多路複用器"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
+msgid "NAT hole STUN server"
+msgstr "NAT 打洞 STUN 伺服器"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "NOT RUNNING"
 msgstr "未執行"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
-msgid "OS environments pass to frp for config file template, see %s."
-msgstr "傳遞作業系統環境至frp以取得配置檔模板，請參閱%s。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:359
+msgid "OIDC additional endpoint params"
+msgstr "OIDC 額外端點參數"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:347
+msgid "OIDC audience"
+msgstr "OIDC 受眾"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:339
+msgid "OIDC client ID"
+msgstr "OIDC 用戶端 ID"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:343
+msgid "OIDC client secret"
+msgstr "OIDC 用戶端金鑰"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:373
+msgid "OIDC insecure skip verify"
+msgstr "OIDC 不安全跳過驗證"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:377
+msgid "OIDC proxy URL"
+msgstr "OIDC 代理 URL"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:351
+msgid "OIDC scope"
+msgstr "OIDC 範圍"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:355
+msgid "OIDC token endpoint URL"
+msgstr "OIDC 權杖端點 URL"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:369
+msgid "OIDC trusted CA file"
+msgstr "OIDC 受信任 CA 檔案"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr "傳遞給 frp 設定檔案模板的 OS 環境變數，請參見 %s。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+msgid "Only start specified proxies or visitors. Empty means start all."
+msgstr "僅啟動指定的代理或訪問者。留空表示啟動全部。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1231
+msgid "Only the virtual_net plugin is valid for visitors."
+msgstr "訪問者僅支援 virtual_net 外掛。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:712
+msgid "Only valid for HTTP proxy."
+msgstr "僅對 HTTP 代理有效。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:840
+msgid ""
+"Only visitors from specified users can connect. Use * to allow all users."
+msgstr "僅允許指定使用者的訪問者連線。使用 * 允許所有使用者。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:184
+msgid "Optional unique identifier for this frpc instance."
+msgstr "此 frpc 例項的可選唯一識別符號。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:271
+msgid "Path of token file."
+msgstr "權杖來源檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:553
+msgid "Path to the TLS certificate file."
+msgstr "TLS 憑證檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:557
+msgid "Path to the TLS private key file."
+msgstr "TLS 私鑰檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:429
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr "HTTPS Web 伺服器使用的憑證檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:447
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr "HTTPS Web 伺服器使用的私鑰檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:561
+msgid "Path to the trusted CA certificate file."
+msgstr "受信任 CA 憑證檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:608
+msgid ""
+"Persist runtime proxy and visitor configuration for Web UI or API management."
+msgstr "持久化執行時代理和訪問者設定，用於 Web UI 或 API 管理。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1221
+msgid "Please use KEY=value format."
+msgstr "請使用 KEY=value 格式。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:909
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1463
 msgid "Plugin"
 msgstr "外掛"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
-msgid "Plugin Settings"
-msgstr "外掛設定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1015
+msgid "Plugin HTTP/2"
+msgstr "外掛 HTTP/2"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid "Protocol"
-msgstr "協定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:979
+msgid "Plugin certificate path"
+msgstr "外掛憑證路徑"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
-msgid ""
-"Protocol specifies the protocol to use when interacting with the server. "
-"Valid values are \"tcp\", \"kcp\", \"quic\" and \"websocket\".<br />By "
-"default, this value is \"tcp\"."
-msgstr ""
-"Protocol 指定與伺服器互動時使用的協定。有效值為「tcp」，「kcp」，「quic」和「"
-"websocket」。<br />此值預設為「tcp」。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1003
+msgid "Plugin host header rewrite"
+msgstr "外掛 Host 標頭重寫"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
-msgid "Proxy Settings"
-msgstr "代理設定"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:991
+msgid "Plugin key path"
+msgstr "外掛金鑰路徑"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:966
+msgid "Plugin local address"
+msgstr "外掛本地位址"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1031
+msgid "Plugin request headers"
+msgstr "外掛請求標頭"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:910
+msgid "Plugin type."
+msgstr "外掛類型。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1168
+msgid "Port must be a number between 0 and 65535."
+msgstr "連接埠必須是 0 到 65535 之間的數字。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1172
+msgid "Port must be between 0 and 65535."
+msgstr "連接埠必須介於 0 到 65535 之間。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1187
+msgid "Port must be negative or a number between 1 and 65535."
+msgstr "連接埠必須為負數，或為 1 到 65535 之間的數字。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1191
+msgid "Port must be negative or between 1 and 65535."
+msgstr "連接埠必須為負數，或介於 1 到 65535 之間。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:191
+msgid "Port of the frps server. Default is 7000."
+msgstr "frps 伺服器連接埠。預設值為 7000。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:195
+msgid "Prefix for proxy names. If set, proxy names become {user}.{proxy}."
+msgstr "代理名稱字首。如果設定，代理名稱將變為 {user}.{proxy}。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1449
+msgid "Proxy / Visitor Settings"
+msgstr "代理 / 訪問者設定"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:490
+msgid "Proxy URL"
+msgstr "代理 URL"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:378
+msgid "Proxy URL for OIDC token endpoint."
+msgstr "OIDC 權杖端點的代理 URL。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:491
+msgid "Proxy URL used to connect to frps. Supports http, socks5 and ntlm."
+msgstr "用於連線 frps 的代理 URL。支援 http、socks5 和 ntlm。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1059
+msgid "Proxy metadatas"
+msgstr "代理元資料"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:640
 msgid "Proxy name"
 msgstr "代理名稱"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:194
+msgid "Proxy name prefix"
+msgstr "代理名稱字首"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:696
+msgid "Proxy protocol version"
+msgstr "代理協議版本"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:643
 msgid "Proxy type"
 msgstr "代理類型"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-msgid ""
-"ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
-"\"udp\", \"http\", \"https\", \"stcp\" and \"xtcp\".<br />By default, this "
-"value is \"tcp\"."
-msgstr ""
-"ProxyType 指定此代理的類型。有效值為「tcp」，「udp」，「http」，「https」，「"
-"stcp」和「xtcp」。<br />此值預設為「tcp」。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:644
+msgid "Proxy type."
+msgstr "代理類型。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:580
+msgid "QUIC keepalive period"
+msgstr "QUIC 保活週期"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:584
+msgid "QUIC max idle timeout"
+msgstr "QUIC 最大空閒逾時"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:588
+msgid "QUIC max incoming streams"
+msgstr "QUIC 最大傳入流數"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1390
 msgid "RUNNING"
 msgstr "執行中"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:667
 msgid "Remote port"
 msgstr "遠端連接埠"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:14
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:668
+msgid "Remote port listened by frps. If 0, frps assigns a random port."
+msgstr "frps 監聽的遠端連接埠。若為 0，frps 會分配隨機連接埠。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:793
+msgid "Remove proxy from frps after continuous failures."
+msgstr "連續失敗後從 frps 移除此代理。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:723
+msgid "Request headers"
+msgstr "請求標頭"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:155
 msgid "Respawn when crashed"
 msgstr "崩潰時重生"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:732
+msgid "Response headers"
+msgstr "回應標頭"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:721
+msgid "Rewrite Host header."
+msgstr "重寫 Host 頭。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:831
 msgid "Role"
 msgstr "角色"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:13
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:753
+msgid "Route HTTP or TCPMUX requests by HTTP basic auth user."
+msgstr "按 HTTP 基本驗證使用者路由 HTTP 或 TCPMUX 請求。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:752
+msgid "Route by HTTP user"
+msgstr "按 HTTP 使用者路由"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:153
 msgid "Run daemon as group"
 msgstr "以此群組身分執行常駐程式"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:12
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:152
 msgid "Run daemon as user"
 msgstr "以此使用者身分執行常駐程式"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:943
 msgid "SOCKS5 password"
 msgstr "SOCKS5 密碼"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:939
 msgid "SOCKS5 user"
 msgstr "SOCKS5 使用者"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1464
+msgid "STCP / XTCP / SUDP"
+msgstr "STCP / XTCP / SUDP"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+msgid "STUN server used for NAT traversal."
+msgstr "用於 NAT 穿透的 STUN 伺服器。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:835
+msgid "Secret key"
+msgstr "金鑰"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:836
+msgid "Secret key used by STCP/XTCP/SUDP proxies and visitors."
+msgstr "STCP/XTCP/SUDP 代理和訪問者使用的金鑰。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:186
 msgid "Server address"
 msgstr "伺服器位址"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:847
 msgid "Server name"
 msgstr "伺服器名稱"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:855
+msgid "Server name is required for visitors."
+msgstr "訪問者必須填寫伺服器名稱。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:565
+msgid "Server name used for TLS verification."
+msgstr "用於 TLS 驗證的伺服器名稱。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:190
 msgid "Server port"
 msgstr "伺服器連接埠"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:848
+msgid "Server proxy name to visit."
+msgstr "要訪問的伺服器代理名稱。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:843
+msgid "Server user"
+msgstr "伺服器使用者"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:844
+msgid "Server user for visitor."
+msgstr "訪問者對應的伺服器使用者。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:724
+msgid "Set request headers. Use Header=Value."
+msgstr "設定請求標頭。使用 Header=Value。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:733
+msgid "Set response headers. Use Header=Value."
+msgstr "設定回應標頭。使用 Header=Value。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:569
+msgid "Since frp v0.50.0, default is true."
+msgstr "自 frp v0.50.0 起預設為 true。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:374
 msgid ""
-"ServerAddr specifies the address of the server to connect to.<br />By "
-"default, this value is \"127.0.0.1\"."
-msgstr "ServerAddr 指定要連線的伺服器的位址。<br />預設情況下，此值為「127.0.0.1」。"
+"Skip TLS verification for OIDC endpoint. Not recommended for production."
+msgstr "跳過 OIDC 端點的 TLS 驗證。不建議在生產環境使用。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
-msgid ""
-"ServerPort specifies the port to connect to the server on.<br />By default, "
-"this value is 7000."
-msgstr "ServerPort 指定用於連線伺服器的連接埠。<br />預設情況下，此值為 7000。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
+msgid "Start proxies / visitors"
+msgstr "啟動代理 / 訪問者"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:74
-msgid "Sk"
-msgstr "Sk"
-
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1432
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1442
 msgid "Startup Settings"
 msgstr "啟動設定"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:958
+msgid "Static file local path"
+msgstr "靜態檔案本地路徑"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:962
+msgid "Static file strip prefix"
+msgstr "靜態檔案剝離字首"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:607
+msgid "Store file path"
+msgstr "儲存檔案路徑"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:706
 msgid "Subdomain"
 msgstr "子網域"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:487
+msgid "TCP keepalive interval in seconds. Negative value disables keepalive."
+msgstr "TCP 保活間隔，單位為秒。負值表示停用保活。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:758
+msgid "TCP multiplexer."
+msgstr "TCP 多路複用器。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:498
 msgid "TCP mux"
 msgstr "TCP 多路複用器"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:510
+msgid "TCP mux keepalive interval"
+msgstr "TCP mux 保活間隔"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:540
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
-msgid ""
-"TLS Enable specifies whether or not TLS should be used when communicating "
-"with the server."
-msgstr "TLS Enable 指定與伺服器通訊時是否使用 TLS。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1428
+msgid "TLS / QUIC"
+msgstr "TLS / QUIC"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection. If this value is true, the server "
-"must have TCP multiplexing enabled as well.<br />By default, this value is "
-"true."
-msgstr ""
-"TcpMux 切換 TCP 串流多路複用。這允許來自用戶端的多個請求共享一個 TCP 連線。若"
-"此值為 true，則伺服器也必須啟用 TCP 複用。<br />預設情況下，此值為 true。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:428
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:552
+msgid "TLS certificate path"
+msgstr "TLS 憑證路徑"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
-msgstr "此清單用於指定此 LuCI 中未包含的某些其他額外參數。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:440
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr "啟用 Web HTTPS 時必須填寫 TLS 憑證路徑。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:446
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:556
+msgid "TLS private key path"
+msgstr "TLS 私鑰路徑"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:458
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr "啟用 Web HTTPS 時必須填寫 TLS 私鑰路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:564
+msgid "TLS server name"
+msgstr "TLS 伺服器名稱"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:560
+msgid "TLS trusted CA path"
+msgstr "TLS 受信任 CA 路徑"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:483
+msgid "Timeout in seconds for connecting to frps."
+msgstr "連線 frps 的逾時時間，單位為秒。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:235
 msgid "Token"
 msgstr "權杖"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
-msgid ""
-"Token specifies the authorization token used to create keys to be sent to "
-"the server. The server must have a matching token for authorization to "
-"succeed. <br />By default, this value is \"\"."
-msgstr ""
-"Token 指定用於建立要發送到伺服器的密鑰的授權金鑰。伺服器必須具有匹配的權杖才"
-"能授權成功。<br />此值預設為空。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:244
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:264
+msgid "Token and token source are mutually exclusive."
+msgstr "權杖和權杖來源互斥。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:83
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:293
+msgid "Token source command"
+msgstr "權杖來源命令"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:316
+msgid "Token source command arguments"
+msgstr "權杖來源命令參數"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:310
+msgid "Token source command is required when token source type is exec."
+msgstr "權杖來源類型為 exec 時必須填寫權杖來源命令。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:326
+msgid "Token source environment"
+msgstr "權杖來源環境變數"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:270
+msgid "Token source file"
+msgstr "權杖來源檔案"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:287
+msgid "Token source file path is required when token source type is file."
+msgstr "權杖來源類型為檔案時必須填寫權杖來源檔案路徑。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:254
+msgid "Token source type"
+msgstr "權杖來源類型"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:236
+msgid "Token used for authentication."
+msgstr "用於驗證的權杖。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1461
+msgid "Transport"
+msgstr "傳輸"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1427
+msgid "Transport Settings"
+msgstr "傳輸設定"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:514
+msgid "Transport protocol"
+msgstr "傳輸協議"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:515
+msgid "Transport protocol used to connect to frps."
+msgstr "用於連線 frps 的傳輸協議。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
+msgid "UDP packet size"
+msgstr "UDP 封包大小"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+msgid "UDP packet size in bytes. Should match frps. Default is 1500."
+msgstr "UDP 資料包大小，單位為位元組。應與 frps 匹配。預設值為 1500。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:947
 msgid "Unix domain socket path"
 msgstr "Unix 網域 socket 路徑"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
-msgid ""
-"UseCompression controls whether or not communication with the server will be "
-"compressed.<br />By default, this value is false."
-msgstr ""
-"UseCompression 控制是否壓縮與伺服器的通訊。<br />預設情況下，此值為 false。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1032
+msgid "Use Header=Value."
+msgstr "使用 Header=Value。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
-msgid ""
-"UseEncryption controls whether or not communication with the server will be "
-"encrypted. Encryption is done using the tokens supplied in the server and "
-"client configuration.<br />By default, this value is false."
-msgstr ""
-"UseEncryption 控制是否加密與伺服器的通訊。使用伺服器和用戶端配置中提供的權杖"
-"來完成加密。<br />預設情況下，此值為 false。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:697
+msgid "Use proxy protocol to transfer connection info to local service."
+msgstr "使用 proxy protocol 向本機服務傳遞連線資訊。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid "User"
-msgstr "使用者"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:604
+msgid "Virtual network address. Requires VirtualNet feature gate."
+msgstr "虛擬網路位址。需要 VirtualNet 功能開關。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
-msgid ""
-"User specifies a prefix for proxy names to distinguish them from other "
-"clients. If this value is not \"\", proxy names will automatically be "
-"changed to \"{user}.{proxy_name}\".<br />By default, this value is \"\"."
-msgstr ""
-"用戶為代理名稱指定首碼，以將其與其他用戶端區分開。若此值非空，則代理名稱將自"
-"動更改為「{user}.{proxy_name}」。<br />此值預設為空。"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:603
+msgid "VirtualNet address"
+msgstr "VirtualNet 位址"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
-#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1046
+msgid "VirtualNet destination IP"
+msgstr "VirtualNet 目標 IP"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1245
+msgid "VirtualNet destination IP is required for virtual_net visitors."
+msgstr "virtual_net 訪問者必須填寫 VirtualNet 目標 IP。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1429
+msgid "Web Server"
+msgstr "Web 伺服器"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:401
+msgid "Web server address"
+msgstr "Web 伺服器位址"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:465
+msgid "Web server assets directory."
+msgstr "Web 伺服器資源目錄。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:402
+msgid "Web server bind address."
+msgstr "Web 伺服器繫結位址。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:413
+msgid "Web server password"
+msgstr "Web 伺服器密碼"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:414
+msgid "Web server password."
+msgstr "Web 伺服器密碼。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:405
+msgid "Web server port"
+msgstr "Web 伺服器連接埠"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:406
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr "Web 伺服器連接埠。留空或設為 0 表示停用 Web 伺服器。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:409
+msgid "Web server user"
+msgstr "Web 伺服器使用者"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:410
+msgid "Web server username."
+msgstr "Web 伺服器使用者名稱。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:685
+msgid "Where to limit bandwidth."
+msgstr "頻寬限制位置。"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:518
+msgid "Wire protocol"
+msgstr "線路協議"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:879
+msgid "XTCP protocol"
+msgstr "XTCP 協議"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:880
+msgid "XTCP visitor tunnel protocol."
+msgstr "XTCP 訪問者隧道協議。"
+
+#: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:4
+msgid "frp"
+msgstr "frp"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1393
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:1400
 msgid "frp Client"
 msgstr "frp 用戶端"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "傳遞至frp設定檔範本的作業系統環境變數，請參閱 <a href=\"https://"
-#~ "github.com/fatedier/frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:519
+msgid ""
+"frp internal wire protocol. v2 requires frps support and must be enabled "
+"explicitly."
+msgstr "frp 內部線路協定。v2 需要 frps 支援，且必須明確啟用。"

--- a/applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json
+++ b/applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json
@@ -1,6 +1,14 @@
 {
-	"admin/services/frpc": {
-		"title": "frp Client",
+	"admin/services/frp": {
+		"order": 80,
+		"title": "frp",
+		"action": {
+			"type": "firstchild"
+		}
+	},
+	"admin/services/frp/client": {
+		"order": 20,
+		"title": "Client",
 		"action": {
 			"type": "view",
 			"path": "frpc"

--- a/applications/luci-app-frpc/root/usr/share/rpcd/acl.d/luci-app-frpc.json
+++ b/applications/luci-app-frpc/root/usr/share/rpcd/acl.d/luci-app-frpc.json
@@ -3,16 +3,16 @@
 		"description": "Grant access to LuCI app frpc",
 		"read": {
 			"file": {
-				"/etc/passwd": ["read"],
-				"/etc/group": ["read"]
+				"/etc/group": [ "read" ],
+				"/etc/passwd": [ "read" ]
 			},
 			"ubus": {
 				"service": [ "list" ]
 			},
-			"uci": ["frpc"]
+			"uci": [ "frpc" ]
 		},
 		"write": {
-			"uci": ["frpc"]
+			"uci": [ "frpc" ]
 		}
 	}
 }

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -4,92 +4,913 @@
 'require rpc';
 'require tools.widgets as widgets';
 
-//	[Widget, Option, Title, Description, {Param: 'Value'}],
+/*
+ * Important:
+ *
+ * This LuCI page writes UCI options into /etc/config/frps.
+ * UCI option names must not contain ".".
+ *
+ * Therefore we keep UCI-safe option names here, then let init/generator script
+ * convert them to frp TOML keys, for example:
+ *
+ *   bind_addr             -> bindAddr
+ *   bind_port             -> bindPort
+ *   kcp_bind_port         -> kcpBindPort
+ *   quic_bind_port        -> quicBindPort
+ *   admin_port            -> webServer.port
+ *   admin_tls_cert_file   -> webServer.tls.certFile
+ *   tls_force             -> transport.tls.force
+ *   max_pool_count        -> transport.maxPoolCount
+ *   authentication_method -> auth.method
+ *   token_source_type   -> auth.tokenSource.type
+ *
+ * Do NOT use option names like "webServer.port" in LuCI form options.
+ */
+
+/*
+ * Debug-only TOML mapping. Keep these TOML: hints in the JS source for
+ * troubleshooting generated configs, but do not show them in LuCI form text
+ * and do not wrap them in _().
+ *
+ * common.bind_addr -> TOML: bindAddr
+ * common.bind_port -> TOML: bindPort
+ * common.kcp_bind_port -> TOML: kcpBindPort
+ * common.quic_bind_port -> TOML: quicBindPort
+ * common.proxy_bind_addr -> TOML: proxyBindAddr
+ * common.vhost_http_port -> TOML: vhostHTTPPort
+ * common.vhost_https_port -> TOML: vhostHTTPSPort
+ * common.vhost_http_timeout -> TOML: vhostHTTPTimeout
+ * common.tcpmux_httpconnect_port -> TOML: tcpmuxHTTPConnectPort
+ * common.tcpmux_passthrough -> TOML: tcpmuxPassthrough
+ * common.subdomain_host -> TOML: subDomainHost
+ * common.custom_404_page -> TOML: custom404Page
+ * common.udp_packet_size -> TOML: udpPacketSize
+ * common.detailed_errors_to_client -> TOML: detailedErrorsToClient
+ * common.user_conn_timeout -> TOML: userConnTimeout
+ * common.nathole_analysis_data_reserve_hours -> TOML: natholeAnalysisDataReserveHours
+ * common.authentication_method -> TOML: auth.method
+ * common.token -> TOML: auth.token
+ * common.auth_additional_scopes -> TOML: auth.additionalScopes
+ * common.token_source_type -> TOML: auth.tokenSource.type
+ * common.token_source_file_path -> TOML: auth.tokenSource.file.path
+ * common.token_source_exec_command -> TOML: auth.tokenSource.exec.command
+ * common.token_source_exec_args -> TOML: auth.tokenSource.exec.args
+ * common.token_source_exec_env -> TOML: auth.tokenSource.exec.env
+ * common.oidc_issuer -> TOML: auth.oidc.issuer
+ * common.oidc_audience -> TOML: auth.oidc.audience
+ * common.oidc_skip_expiry_check -> TOML: auth.oidc.skipExpiryCheck
+ * common.oidc_skip_issuer_check -> TOML: auth.oidc.skipIssuerCheck
+ * common.max_pool_count -> TOML: transport.maxPoolCount
+ * common.tcp_mux -> TOML: transport.tcpMux
+ * common.tcp_mux_keepalive_interval -> TOML: transport.tcpMuxKeepaliveInterval
+ * common.tcp_keepalive -> TOML: transport.tcpKeepalive
+ * common.heartbeat_timeout -> TOML: transport.heartbeatTimeout
+ * common.tls_force -> TOML: transport.tls.force
+ * common.tls_cert_file -> TOML: transport.tls.certFile
+ * common.tls_key_file -> TOML: transport.tls.keyFile
+ * common.tls_trusted_ca_file -> TOML: transport.tls.trustedCaFile
+ * common.quic_keepalive_period -> TOML: transport.quic.keepalivePeriod
+ * common.quic_max_idle_timeout -> TOML: transport.quic.maxIdleTimeout
+ * common.quic_max_incoming_streams -> TOML: transport.quic.maxIncomingStreams
+ * common.admin_addr -> TOML: webServer.addr
+ * common.admin_port -> TOML: webServer.port
+ * common.admin_user -> TOML: webServer.user
+ * common.admin_pwd -> TOML: webServer.password
+ * common.admin_tls_cert_file -> TOML: webServer.tls.certFile
+ * common.admin_tls_key_file -> TOML: webServer.tls.keyFile
+ * common.assets_dir -> TOML: webServer.assetsDir
+ * common.pprof_enable -> TOML: webServer.pprofEnable
+ * common.enable_prometheus -> TOML: enablePrometheus
+ * common.allow_ports -> TOML: allowPorts
+ * common.max_ports_per_client -> TOML: maxPortsPerClient
+ * common.ssh_tunnel_bind_port -> TOML: sshTunnelGateway.bindPort
+ * common.ssh_tunnel_private_key_file -> TOML: sshTunnelGateway.privateKeyFile
+ * common.ssh_tunnel_auto_gen_private_key_path -> TOML: sshTunnelGateway.autoGenPrivateKeyPath
+ * common.ssh_tunnel_authorized_keys_file -> TOML: sshTunnelGateway.authorizedKeysFile
+ * common.log_file -> TOML: log.to
+ * common.log_level -> TOML: log.level
+ * common.log_max_days -> TOML: log.maxDays
+ * common.disable_log_color -> TOML: log.disablePrintColor
+ * http_plugin.name -> TOML: httpPlugins[].name
+ * http_plugin.addr -> TOML: httpPlugins[].addr
+ * http_plugin.path -> TOML: httpPlugins[].path
+ * http_plugin.ops -> TOML: httpPlugins[].ops
+ * http_plugin.tls_verify -> TOML: httpPlugins[].tlsVerify
+ */
+
 const startupConf = [
-	[form.Flag, 'stdout', _('Log stdout')],
-	[form.Flag, 'stderr', _('Log stderr')],
+	[form.Flag, 'stdout', _('Log stdout'), null,
+	{
+		enabled: '1',
+		disabled: '0',
+		default: '1',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Flag, 'stderr', _('Log stderr'), null,
+	{
+		enabled: '1',
+		disabled: '0',
+		default: '1',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
 	[widgets.UserSelect, 'user', _('Run daemon as user')],
 	[widgets.GroupSelect, 'group', _('Run daemon as group')],
-	[form.Flag, 'respawn', _('Respawn when crashed')],
-	[form.DynamicList, 'env', _('Environment variable'), _('OS environments pass to frp for config file template, see %s'.format(`<a href="https://github.com/fatedier/frp#configuration-file-template">frp README</a>`)), {placeholder: 'ENV_NAME=value'}],
-	[form.DynamicList, 'conf_inc', _('Additional configs'), _('Config files include in temporary config file'), {placeholder: '/etc/frp/frps.d/frps_full.ini'}]
+
+	[form.Flag, 'respawn', _('Respawn when crashed'), null,
+	{
+		enabled: '1',
+		disabled: '0',
+		default: '1',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.DynamicList, 'env', _('Environment variable'),
+	_('OS environments passed to frp for config file template, see %s.').format('<a href="https://github.com/fatedier/frp#configuration-file-template">frp README</a>'),
+	{
+		placeholder: 'ENV_NAME=value',
+		validate: function (section_id, value) {
+			return validateEnv(value);
+		}
+	}],
+
+	[form.DynamicList, 'conf_inc', _('Additional configs'),
+	_('Extra root-level configuration fragments included before generated HTTP plugin sections. Use raw settings for table-specific extra options.'),
+	{
+		datatype: 'file',
+		placeholder: '/etc/frp/frps.d/frps_extra.toml'
+	}]
 ];
 
-const commonConf = [
-	[form.Value, 'bind_addr', _('Bind address'), _('BindAddr specifies the address that the server binds to.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
-	[form.Value, 'bind_port', _('Bind port'), _('BindPort specifies the port that the server listens on.<br />By default, this value is 7000.'), {datatype: 'port'}],
-	[form.Value, 'bind_udp_port', _('UDP bind port'), _('BindUdpPort specifies the UDP port that the server listens on. If this value is 0, the server will not listen for UDP connections.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'kcp_bind_port', _('KCP bind port'), _('BindKcpPort specifies the KCP port that the server listens on. If this value is 0, the server will not listen for KCP connections.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'quic_bind_port', _('QUIC bind port'), _('BindQuicPort specifies the QUIC port that the server listens on. If this value is 0, the server will not listen for QUIC connections.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'proxy_bind_addr', _('Proxy bind address'), _('ProxyBindAddr specifies the address that the proxy binds to. This value may be the same as BindAddr.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
-	[form.Value, 'vhost_http_port', _('Vhost HTTP port'), _('VhostHttpPort specifies the port that the server listens for HTTP Vhost requests. If this value is 0, the server will not listen for HTTP requests.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'vhost_https_port', _('Vhost HTTPS port'), _('VhostHttpsPort specifies the port that the server listens for HTTPS Vhost requests. If this value is 0, the server will not listen for HTTPS requests.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'vhost_http_timeout', _('Vhost HTTP timeout'), _('VhostHttpTimeout specifies the response header timeout for the Vhost HTTP server, in seconds.<br />By default, this value is 60.'), {datatype: 'uinteger'}],
-	[form.Value, 'dashboard_addr', _('Dashboard address'), _('DashboardAddr specifies the address that the dashboard binds to.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
-	[form.Value, 'dashboard_port', _('Dashboard port'), _('DashboardPort specifies the port that the dashboard listens on. If this value is 0, the dashboard will not be started.<br />By default, this value is 0.'), {datatype: 'port'}],
-	[form.Value, 'dashboard_user', _('Dashboard user'), _('DashboardUser specifies the username that the dashboard will use for login.<br />By default, this value is "admin".')],
-	[form.Value, 'dashboard_pwd', _('Dashboard password'), _('DashboardPwd specifies the password that the dashboard will use for login.<br />By default, this value is "admin".'), {password: true}],
-	[form.Flag, 'dashboard_tls_mode', _('Dashboard TLS mode'), _('Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is used for secure communication.'), {datatype: 'bool'}],
-	[form.Value, 'dashboard_tls_cert_file', _('Dashboard TLS certificate'), _('Dashboard TLS Cert File specifies the path to the TLS certificate file for enabling HTTPS access.<br />Required if HTTPS is enabled.'), {datatype: 'filepath'}],
-    [form.Value, 'dashboard_tls_key_file', _('Dashboard TLS private key'), _('Dashboard TLS Key File specifies the path to the TLS private key file for enabling HTTPS access.<br />Required if HTTPS is enabled.'), {datatype: 'filepath'}],
-	[form.Value, 'assets_dir', _('Assets dir'), _('AssetsDir specifies the local directory that the dashboard will load resources from. If this value is "", assets will be loaded from the bundled executable using statik.<br />By default, this value is "".')],
-	[form.Value, 'log_file', _('Log file'), _('LogFile specifies a file where logs will be written to. This value will only be used if LogWay is set appropriately.<br />By default, this value is "console".')],
-	[form.ListValue, 'log_level', _('Log level'), _('LogLevel specifies the minimum log level. Valid values are "trace", "debug", "info", "warn", and "error".<br />By default, this value is "info".'), {values: ['trace', 'debug', 'info', 'warn', 'error']}],
-	[form.Value, 'log_max_days', _('Log max days'), _('LogMaxDays specifies the maximum number of days to store log information before deletion. This is only used if LogWay == "file".<br />By default, this value is 0.'), {datatype: 'uinteger'}],
-	[form.Flag, 'disable_log_color', _('Disable log color'), _('DisableLogColor disables log colors when LogWay == "console" when set to true.<br />By default, this value is false.'), {datatype: 'bool', default: 'true'}],
-	[form.Value, 'token', _('Token'), _('Token specifies the authorization token used to authenticate keys received from clients. Clients must have a matching token to be authorized to use the server.<br />By default, this value is "".')],
-	[form.Value, 'subdomain_host', _('Subdomain host'), _('SubDomainHost specifies the domain that will be attached to sub-domains requested by the client when using Vhost proxying. For example, if this value is set to "frps.com" and the client requested the subdomain "test", the resulting URL would be "test.frps.com".<br />By default, this value is "".')],
-	[form.Flag, 'tcp_mux', _('TCP mux'), _('TcpMux toggles TCP stream multiplexing. This allows multiple requests from a client to share a single TCP connection.<br />By default, this value is true.'), {datatype: 'bool', default: 'true'}],
-	[form.Value, 'custom_404_page', _('Custom 404 page'), _('Custom404Page specifies a path to a custom 404 page to display. If this value is "", a default page will be displayed.<br />By default, this value is "".')],
-	[form.Value, 'allow_ports', _('Allow ports'), _('AllowPorts specifies a set of ports that clients are able to proxy to. If the length of this value is 0, all ports are allowed.<br />By default, this value is an empty set.')],
-	[form.Value, 'max_ports_per_client', _('Max ports per client'), _('MaxPortsPerClient specifies the maximum number of ports a single client may proxy to. If this value is 0, no limit will be applied.<br />By default, this value is 0.'), {datatype: 'uinteger'}],
-	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'), _('HeartBeatTimeout specifies the maximum time to wait for a heartbeat before terminating the connection. It is not recommended to change this value.<br />By default, this value is 90.'), {datatype: 'uinteger'}],
-	[form.DynamicList, '_', _('Additional settings'), _('This list can be used to specify some additional parameters which have not been included in this LuCI.'), {placeholder: 'Key-A=Value-A'}]
+const commonBaseConf = [
+	[form.Value, 'bind_addr', _('Bind address'),
+	_('Address that frps binds to.'),
+	{ datatype: 'host', placeholder: '0.0.0.0' }],
+
+	[form.Value, 'bind_port', _('Bind port'),
+	_('Port that frps listens on.'),
+	{ datatype: 'port', rmempty: false, placeholder: '7000' }],
+
+	[form.Value, 'kcp_bind_port', _('KCP bind port'),
+	_('UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as QUIC.'),
+	{
+		placeholder: '7000',
+		validate: function (section_id, value) {
+			const portValid = validatePortOrZero(section_id, value);
+			if (portValid !== true)
+				return portValid;
+
+			const quic = this.section.getOption('quic_bind_port');
+			const quicValue = quic ? quic.formvalue(section_id) : null;
+
+			if (value && value !== '0' && quicValue && quicValue !== '0' && value === quicValue)
+				return _('KCP bind port and QUIC bind port must be different.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'quic_bind_port', _('QUIC bind port'),
+	_('UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port as KCP.'),
+	{
+		placeholder: '7002',
+		validate: function (section_id, value) {
+			const portValid = validatePortOrZero(section_id, value);
+			if (portValid !== true)
+				return portValid;
+
+			const kcp = this.section.getOption('kcp_bind_port');
+			const kcpValue = kcp ? kcp.formvalue(section_id) : null;
+
+			if (value && value !== '0' && kcpValue && kcpValue !== '0' && value === kcpValue)
+				return _('KCP bind port and QUIC bind port must be different.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'proxy_bind_addr', _('Proxy bind address'),
+	_('Address that proxy listeners bind to.'),
+	{ datatype: 'host', placeholder: '0.0.0.0' }],
+
+	[form.Value, 'vhost_http_port', _('Vhost HTTP port'),
+	_('Port for HTTP virtual host requests. Empty or 0 disables it.'),
+	{ validate: validatePortOrZero, placeholder: '80' }],
+
+	[form.Value, 'vhost_https_port', _('Vhost HTTPS port'),
+	_('Port for HTTPS virtual host requests. Empty or 0 disables it.'),
+	{ validate: validatePortOrZero, placeholder: '443' }],
+
+	[form.Value, 'vhost_http_timeout', _('Vhost HTTP timeout'),
+	_('Response header timeout for vhost HTTP server, in seconds.'),
+	{ datatype: 'uinteger', placeholder: '60' }],
+
+	[form.Value, 'tcpmux_httpconnect_port', _('TCPMUX HTTP CONNECT port'),
+	_('Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it.'),
+	{ validate: validatePortOrZero, placeholder: '0' }],
+
+	[form.Flag, 'tcpmux_passthrough', _('TCPMUX passthrough'),
+	_('Do not update traffic when TCPMUX passthrough is enabled.'),
+	{ datatype: 'bool', default: 'false' }],
+
+	[form.Value, 'subdomain_host', _('Subdomain host'),
+	_('Domain suffix for subdomain-based HTTP/HTTPS proxies.'),
+	{ placeholder: 'frps.com' }],
+
+	[form.Value, 'custom_404_page', _('Custom 404 page'),
+	_('Path to custom 404 page for HTTP requests.'),
+	{ datatype: 'file' }],
+
+	[form.Value, 'udp_packet_size', _('UDP packet size'),
+	_('UDP packet size in bytes. Should match frpc.'),
+	{ datatype: 'uinteger', placeholder: '1500' }]
 ];
+
+const commonAuthConf = [
+	[form.ListValue, 'authentication_method', _('Authentication method'),
+	_('Authentication method used to authenticate frpc.'),
+	{ values: [['token', 'token'], ['oidc', 'oidc']], default: 'token' }],
+
+	[form.Value, 'token', _('Token'),
+	_('Token used for authentication.'),
+	{
+		depends: { authentication_method: 'token' },
+		password: true,
+		validate: function (section_id, value) {
+			const tokenSourceType = this.section.getOption('token_source_type');
+
+			if (value && tokenSourceType && tokenSourceType.formvalue(section_id))
+				return _('Token and token source are mutually exclusive.');
+
+			return true;
+		}
+	}],
+
+	[form.MultiValue, 'auth_additional_scopes', _('Additional auth scopes'),
+	_('Additional scopes to include authentication information.'),
+	{ values: ['HeartBeats', 'NewWorkConns'] }],
+
+	[form.ListValue, 'token_source_type', _('Token source type'),
+	_('Load token from an external source. File reads the token from a local file; exec runs a command and requires frp unsafe permission. Mutually exclusive with auth.token.'),
+	{
+		depends: { authentication_method: 'token' },
+		values: [['', _('Disabled')], ['file', 'file'], ['exec', 'exec']],
+		rmempty: true,
+		validate: function (section_id, value) {
+			const token = this.section.getOption('token');
+
+			if (value && token && token.formvalue(section_id))
+				return _('Token and token source are mutually exclusive.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'token_source_file_path', _('Token source file'),
+	_('Path of token file.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'file'
+		},
+		datatype: 'file',
+		rmempty: false,
+		validate: function (section_id, value) {
+			const tokenSourceType = this.section.getOption('token_source_type');
+
+			if (
+				tokenSourceType &&
+				tokenSourceType.formvalue(section_id) === 'file' &&
+				!String(value || '').trim()
+			)
+				return _('Token source file path is required when token source type is file.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'token_source_exec_command', _('Token source command'),
+	_('Command used to obtain the token. The init script adds --allow-unsafe=TokenSourceExec when this source type is used.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'exec'
+		},
+		datatype: 'file',
+		rmempty: false,
+		validate: function (section_id, value) {
+			const tokenSourceType = this.section.getOption('token_source_type');
+
+			if (
+				tokenSourceType &&
+				tokenSourceType.formvalue(section_id) === 'exec' &&
+				!String(value || '').trim()
+			)
+				return _('Token source command is required when token source type is exec.');
+
+			return true;
+		}
+	}],
+
+	[form.DynamicList, 'token_source_exec_args', _('Token source command arguments'),
+	_('Command arguments passed to token source exec.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'exec'
+		},
+		placeholder: '--format'
+	}],
+
+	[form.DynamicList, 'token_source_exec_env', _('Token source environment'),
+	_('Environment variables passed to token source exec. Use KEY=value.'),
+	{
+		depends: {
+			authentication_method: 'token',
+			token_source_type: 'exec'
+		},
+		placeholder: 'TOKEN_SERVICE=production',
+		validate: function (section_id, value) {
+			return validateEnv(value);
+		}
+	}],
+
+	[form.Value, 'oidc_issuer', _('OIDC issuer'),
+	_('OIDC issuer used to verify tokens.'),
+	{ depends: { authentication_method: 'oidc' } }],
+
+	[form.Value, 'oidc_audience', _('OIDC audience'),
+	_('Audience OIDC tokens should contain.'),
+	{ depends: { authentication_method: 'oidc' } }],
+
+	[form.Flag, 'oidc_skip_expiry_check', _('OIDC skip expiry check'),
+	_('Skip checking whether the OIDC token is expired.'),
+	{ depends: { authentication_method: 'oidc' }, datatype: 'bool', default: 'false' }],
+
+	[form.Flag, 'oidc_skip_issuer_check', _('OIDC skip issuer check'),
+	_('Skip checking whether OIDC token issuer matches configured issuer.'),
+	{ depends: { authentication_method: 'oidc' }, datatype: 'bool', default: 'false' }]
+];
+
+const commonLogConf = [
+	[form.Value, 'log_file', _('Log output'),
+	_('Log output path or console.'),
+	{ placeholder: 'console' }],
+
+	[form.ListValue, 'log_level', _('Log level'),
+	_('Configuration key: log.level.'),
+	{ values: ['trace', 'debug', 'info', 'warn', 'error'], default: 'info' }],
+
+	[form.Value, 'log_max_days', _('Log max days'),
+	_('Maximum number of days to keep logs.'),
+	{ datatype: 'uinteger', placeholder: '3' }],
+
+	[form.Flag, 'disable_log_color', _('Disable log color'),
+	_('Disable log colors when log output is console.'),
+	{ datatype: 'bool', default: 'false' }]
+];
+
+const commonWebConf = [
+	[form.Value, 'admin_addr', _('Web server address'),
+	_('Web server bind address.'),
+	{ datatype: 'host', placeholder: '127.0.0.1' }],
+
+	[form.Value, 'admin_port', _('Web server port'),
+	_('Web server port. Leave empty or set to 0 to disable the web server.'),
+	{ validate: validatePortOrZero, placeholder: '7500' }],
+
+	[form.Value, 'admin_user', _('Web server user'),
+	_('Web server username.'),
+	{
+		placeholder: 'admin'
+	}],
+
+	[form.Value, 'admin_pwd', _('Web server password'),
+	_('Web server password.'),
+	{
+		password: true,
+		placeholder: 'change_me_to_a_strong_password'
+	}],
+
+	[form.Flag, 'admin_tls_enable', _('Enable web HTTPS'),
+	_('Enable HTTPS for the frps web server. This switch controls whether webServer.tls.certFile and webServer.tls.keyFile are emitted.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'false',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'admin_tls_cert_file', _('TLS certificate path'),
+	_('Path to the certificate file used by the HTTPS web server.'),
+	{
+		datatype: 'file',
+		retain: true,
+		placeholder: '/etc/ssl/acme/example.com.fullchain.crt',
+		validate: function (section_id, value) {
+			if (
+				adminWebEnabled(this.section, section_id) &&
+				adminHttpsEnabled(this.section, section_id) &&
+				!String(value || '').trim()
+			)
+				return _('TLS certificate path is required when web HTTPS is enabled.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'admin_tls_key_file', _('TLS private key path'),
+	_('Path to the private key file used by the HTTPS web server.'),
+	{
+		datatype: 'file',
+		retain: true,
+		placeholder: '/etc/ssl/acme/example.com.key',
+		validate: function (section_id, value) {
+			if (
+				adminWebEnabled(this.section, section_id) &&
+				adminHttpsEnabled(this.section, section_id) &&
+				!String(value || '').trim()
+			)
+				return _('TLS private key path is required when web HTTPS is enabled.');
+
+			return true;
+		}
+	}],
+
+	[form.Value, 'assets_dir', _('Assets dir'),
+	_('Web server assets directory.'),
+	{ datatype: 'directory' }],
+
+	[form.Flag, 'pprof_enable', _('Enable pprof'),
+	_('Enable Go pprof debug/profiling endpoints on the web server. It only takes effect when web server port is set.'),
+	{
+		datatype: 'bool',
+		default: 'false',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Flag, 'enable_prometheus', _('Enable Prometheus'),
+	_('Export Prometheus metrics on webServer /metrics API. It only takes effect when web server port is set.'),
+	{
+		datatype: 'bool',
+		default: 'false',
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}]
+];
+
+const commonTransportConf = [
+	[form.Value, 'max_pool_count', _('Max pool count'),
+	_('Maximum pool count for each proxy.'),
+	{ datatype: 'uinteger', placeholder: '5' }],
+
+	[form.Flag, 'tcp_mux', _('TCP mux'),
+	_('Enable TCP stream multiplexing. This setting must match frpc.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}],
+
+	[form.Value, 'tcp_mux_keepalive_interval', _('TCP mux keepalive interval'),
+	_('Keepalive interval for TCP mux.'),
+	{ datatype: 'uinteger', placeholder: '30' }],
+
+	[form.Value, 'tcp_keepalive', _('TCP keepalive'),
+	_('TCP keepalive interval. Negative value disables keepalive.'),
+	{ datatype: 'integer', placeholder: '7200' }],
+
+	[form.Value, 'heartbeat_timeout', _('Heartbeat timeout'),
+	_('Heartbeat timeout in seconds.'),
+	{ datatype: 'integer', placeholder: '90' }],
+
+	[form.Value, 'user_conn_timeout', _('User connection timeout'),
+	_('Maximum time to wait for a work connection.'),
+	{ datatype: 'uinteger', placeholder: '10' }],
+
+	[form.Flag, 'detailed_errors_to_client', _('Detailed errors to client'),
+	_('Send specific error details to frpc.'),
+	{
+		enabled: 'true',
+		disabled: 'false',
+		default: 'true',
+		optional: false,
+		rmempty: false,
+		retain: true,
+		remove: writeFlagDisabled
+	}]
+];
+
+const commonTlsQuicConf = [
+	[form.Flag, 'tls_force', _('Force TLS'),
+	_('Only accept TLS-encrypted frpc connections.'),
+	{ datatype: 'bool', default: 'false' }],
+
+	[form.Value, 'tls_cert_file', _('TLS certificate path'),
+	_('Path to the TLS certificate file.'),
+	{ datatype: 'file', placeholder: '/etc/ssl/frp/server.crt' }],
+
+	[form.Value, 'tls_key_file', _('TLS private key path'),
+	_('Path to the TLS private key file.'),
+	{ datatype: 'file', placeholder: '/etc/ssl/frp/server.key' }],
+
+	[form.Value, 'tls_trusted_ca_file', _('TLS trusted CA path'),
+	_('Path to the trusted CA certificate file.'),
+	{ datatype: 'file', placeholder: '/etc/ssl/frp/ca.crt' }],
+
+	[form.Value, 'quic_keepalive_period', _('QUIC keepalive period'),
+	_('Configuration key: transport.quic.keepalivePeriod.'),
+	{ datatype: 'uinteger', placeholder: '10' }],
+
+	[form.Value, 'quic_max_idle_timeout', _('QUIC max idle timeout'),
+	_('Configuration key: transport.quic.maxIdleTimeout.'),
+	{ datatype: 'uinteger', placeholder: '30' }],
+
+	[form.Value, 'quic_max_incoming_streams', _('QUIC max incoming streams'),
+	_('Configuration key: transport.quic.maxIncomingStreams.'),
+	{ datatype: 'uinteger', placeholder: '100000' }]
+];
+
+const commonAccessConf = [
+	[form.DynamicList, 'allow_ports', _('Allow ports'),
+	_('Ports clients are allowed to bind. Use single port like 3001 or range like 2000-3000.'),
+	{
+		placeholder: '2000-3000',
+		validate: function (section_id, value) {
+			return validatePortRange(value);
+		}
+	}],
+
+	[form.Value, 'max_ports_per_client', _('Max ports per client'),
+	_('Maximum ports each client can use. 0 means no limit.'),
+	{ datatype: 'uinteger', placeholder: '0' }],
+
+	[form.Value, 'nathole_analysis_data_reserve_hours', _('NAT hole analysis reserve hours'),
+	_('Retention time for NAT hole punching strategy data.'),
+	{ datatype: 'uinteger', placeholder: '168' }]
+];
+
+const commonSshTunnelConf = [
+	[form.Value, 'ssh_tunnel_bind_port', _('SSH tunnel bind port'),
+	_('SSH tunnel gateway bind port. Empty disables this feature.'),
+	{ validate: validatePortOrZero, placeholder: '2200' }],
+
+	[form.Value, 'ssh_tunnel_private_key_file', _('SSH tunnel private key file'),
+	_('Private key file for SSH tunnel gateway.'),
+	{ datatype: 'file' }],
+
+	[form.Value, 'ssh_tunnel_auto_gen_private_key_path', _('SSH tunnel auto-generated private key path'),
+	_('Path for auto-generated private key.'),
+	{ datatype: 'file' }],
+
+	[form.Value, 'ssh_tunnel_authorized_keys_file', _('SSH tunnel authorized keys file'),
+	_('Authorized keys file for SSH tunnel gateway.'),
+	{ datatype: 'file' }]
+];
+
+const httpPluginConf = [
+	[form.Value, 'name', _('Plugin name'),
+	_('Unique HTTP plugin name.'),
+	{ rmempty: false, optional: false }],
+
+	[form.Value, 'addr', _('Plugin address'),
+	_('HTTP plugin backend address.'),
+	{
+		placeholder: '127.0.0.1:9000',
+		rmempty: false,
+		optional: false,
+		validate: function (section_id, value) {
+			return validateHttpPluginAddr(value);
+		}
+	}],
+
+	[form.Value, 'path', _('Plugin path'),
+	_('HTTP plugin request path.'),
+	{
+		placeholder: '/handler',
+		rmempty: false,
+		optional: false,
+		validate: function (section_id, value) {
+			return validateHttpPath(value);
+		}
+	}],
+
+	[form.MultiValue, 'ops', _('Plugin operations'),
+	_('frps operations handled by this HTTP plugin.'),
+	{
+		values: ['Login', 'NewProxy', 'CloseProxy', 'Ping', 'NewWorkConn', 'NewUserConn'],
+		default: ['Login'],
+		optional: false,
+		rmempty: false,
+		validate: function (section_id, value) {
+			return validateHttpPluginOp(value);
+		}
+	}],
+
+	[form.Flag, 'tls_verify', _('Verify plugin TLS'),
+	_('Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS.'),
+	{ datatype: 'bool', default: 'false' }]
+];
+
+function writeFlagDisabled(section_id) {
+	return this.write(section_id, this.disabled || 'false');
+}
+
+function removeIfPresent(section_id) {
+	const this_cfg = this.uciconfig || this.section.uciconfig || this.map.config;
+	const this_sid = this.ucisection || section_id;
+	const this_opt = this.ucioption || this.option;
+
+	for (let i = 0; i < this.section.children.length; i++) {
+		const sibling = this.section.children[i];
+
+		if (sibling === this || sibling.ucioption == null)
+			continue;
+
+		const sibling_cfg = sibling.uciconfig || sibling.section.uciconfig || sibling.map.config;
+		const sibling_sid = sibling.ucisection || section_id;
+		const sibling_opt = sibling.ucioption || sibling.option;
+
+		if (this_cfg != sibling_cfg || this_sid != sibling_sid || this_opt != sibling_opt)
+			continue;
+
+		if (typeof sibling.isActive === 'function' && sibling.isActive(section_id))
+			return Promise.resolve();
+	}
+
+	if (this.map.data.get(this_cfg, this_sid, this_opt) == null)
+		return Promise.resolve();
+
+	return this.map.data.unset(this_cfg, this_sid, this_opt);
+}
+
+function isUciDeleteNotFoundError(err) {
+	const message = err && err.message ? err.message : String(err);
+
+	return /uci\/delete/.test(message) && /ubus code 4/.test(message);
+}
+
+function guardUciDeleteNotFound(data, config) {
+	data._frpIgnoreMissingDeleteConfigs ??= {};
+	data._frpIgnoreMissingDeleteConfigs[config] = true;
+
+	if (data._frpIgnoreMissingDeleteInstalled)
+		return;
+
+	const callDelete = data.callDelete;
+
+	data.callDelete = function(conf, sid, options) {
+		const guarded = this._frpIgnoreMissingDeleteConfigs && this._frpIgnoreMissingDeleteConfigs[conf];
+
+		return callDelete.apply(this, arguments).catch(L.bind(function(err) {
+			if (!guarded || !isUciDeleteNotFoundError(err))
+				return Promise.reject(err);
+
+			if (!Array.isArray(options) || options.length <= 1)
+				return null;
+
+			return Promise.all(options.map(L.bind(function(opt) {
+				return callDelete.call(this, conf, sid, [ opt ]).catch(function(e) {
+					return isUciDeleteNotFoundError(e) ? null : Promise.reject(e);
+				});
+			}, this)));
+		}, this));
+	};
+
+	data._frpIgnoreMissingDeleteInstalled = true;
+}
+
+function adminWebEnabled(section, section_id) {
+	const port = section.getOption('admin_port');
+	const value = port ? port.formvalue(section_id) : null;
+
+	return !!(value && value !== '0');
+}
+
+function adminHttpsEnabled(section, section_id) {
+	const enable = section.getOption('admin_tls_enable');
+
+	return !!(enable && enable.formvalue(section_id) === 'true');
+}
+
+function validatePortOrZero(section_id, value) {
+	if (!value)
+		return true;
+
+	value = String(value).trim();
+
+	if (!/^\d+$/.test(value))
+		return _('Port must be a number between 0 and 65535.');
+
+	const port = Number(value);
+	if (port < 0 || port > 65535)
+		return _('Port must be between 0 and 65535.');
+
+	return true;
+}
+
+function validatePortRange(value) {
+	if (!value)
+		return true;
+
+	value = String(value).trim();
+
+	const m = value.match(/^(\d+)(?:-(\d+))?$/);
+	if (!m)
+		return _('Use a single port like 3001 or a range like 2000-3000.');
+
+	const start = Number(m[1]);
+	const end = Number(m[2] || m[1]);
+
+	if (start < 1 || start > 65535 || end < 1 || end > 65535)
+		return _('Port must be between 1 and 65535.');
+
+	if (start > end)
+		return _('Port range start must not be greater than end.');
+
+	return true;
+}
+
+function validateEnv(value) {
+	if (!value)
+		return true;
+
+	if (/\r|\n/.test(String(value)) || !/^[A-Za-z_][A-Za-z0-9_]*=.*$/.test(String(value)))
+		return _('Environment variable must use KEY=value format.');
+
+	return true;
+}
+
+function validateHttpPath(value) {
+	if (!value)
+		return true;
+
+	if (/\r|\n/.test(String(value)) || String(value).charAt(0) !== '/')
+		return _('HTTP plugin path must start with /.');
+
+	return true;
+}
+
+function validateHttpPluginAddr(value) {
+	if (!value)
+		return true;
+
+	value = String(value).trim();
+
+	if (/\r|\n/.test(value))
+		return _('HTTP plugin address must be a single address.');
+
+	if (/^https?:\/\//.test(value)) {
+		if (!/^https?:\/\/[^\s/:]+(?::\d+)?(?:\/.*)?$/.test(value) && !/^https?:\/\/\[[0-9A-Fa-f:.]+\](?::\d+)?(?:\/.*)?$/.test(value))
+			return _('HTTP plugin URL must include a host.');
+
+		return true;
+	}
+
+	if (/^[^\s/:]+:\d+$/.test(value) || /^\[[0-9A-Fa-f:.]+\]:\d+$/.test(value))
+		return true;
+
+	return _('HTTP plugin address must be host:port or an http:// or https:// URL.');
+}
+
+function validateHttpPluginOp(value) {
+	if (!value)
+		return true;
+
+	if (!/^[A-Za-z][A-Za-z0-9]*$/.test(String(value)))
+		return _('HTTP plugin operation must be a frps operation name, for example Login or NewProxy.');
+
+	return true;
+}
+
+function normalizeDepends(depends) {
+	if (depends == null)
+		return [];
+
+	return Array.isArray(depends) ? depends : [ depends ];
+}
+
+function mergeDepends(existing, next) {
+	const current = normalizeDepends(existing);
+	const incoming = normalizeDepends(next);
+
+	if (current.length === 0)
+		return incoming;
+
+	if (incoming.length === 0)
+		return current;
+
+	const merged = [];
+
+	for (let oldDep of current) {
+		for (let newDep of incoming) {
+			const dep = {};
+			let conflict = false;
+
+			for (let key in oldDep)
+				dep[key] = oldDep[key];
+
+			for (let key in newDep) {
+				if (Object.prototype.hasOwnProperty.call(dep, key) && dep[key] !== newDep[key]) {
+					conflict = true;
+					break;
+				}
+
+				dep[key] = newDep[key];
+			}
+
+			if (!conflict)
+				merged.push(dep);
+		}
+	}
+
+	return merged;
+}
 
 function setParams(o, params) {
-	if (!params) return;
+	if (!params)
+		return;
+
 	for (let key in params) {
 		let val = params[key];
+
 		if (key === 'values') {
 			for (let v of val) {
 				let args = v;
+
 				if (!Array.isArray(args))
 					args = [args];
+
 				o.value.apply(o, args);
 			}
 		} else if (key === 'depends') {
-			if (!Array.isArray(val))
-				val = [val];
-			for (let v of val) {
-				let args = v;
-				if (!Array.isArray(args))
-					args = [args];
-				o.depends.apply(o, args);
-			}
+			o.deps = mergeDepends(o.deps, val);
 		} else {
 			o[key] = params[key];
 		}
 	}
+
 	if (params['datatype'] === 'bool') {
 		o.enabled = 'true';
 		o.disabled = 'false';
 	}
 }
 
+
 function defTabOpts(s, t, opts, params) {
 	for (let opt of opts) {
 		const o = s.taboption(t, opt[0], opt[1], opt[2], opt[3]);
+
 		setParams(o, opt[4]);
 		setParams(o, params);
+
+		/*
+		 * Per-option optional must win over tab-wide optional.
+		 * This is important for form.Flag with default='true',
+		 * otherwise LuCI may treat checked state as default and call remove().
+		 */
+		if (opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'optional'))
+			o.optional = opt[4].optional;
+
+		if (
+			!(opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'remove')) &&
+			!(params && Object.prototype.hasOwnProperty.call(params, 'remove'))
+		)
+			o.remove = removeIfPresent;
 	}
 }
 
 function defOpts(s, opts, params) {
 	for (let opt of opts) {
 		const o = s.option(opt[0], opt[1], opt[2], opt[3]);
+
 		setParams(o, opt[4]);
 		setParams(o, params);
+
+		if (opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'optional'))
+			o.optional = opt[4].optional;
+
+		if (
+			!(opt[4] && Object.prototype.hasOwnProperty.call(opt[4], 'remove')) &&
+			!(params && Object.prototype.hasOwnProperty.call(params, 'remove'))
+		)
+			o.remove = removeIfPresent;
 	}
 }
 
@@ -102,25 +923,26 @@ const callServiceList = rpc.declare({
 
 function getServiceStatus() {
 	return L.resolveDefault(callServiceList('frps'), {}).then(function (res) {
-		let isRunning = false;
-		try {
-			isRunning = res['frps']['instances']['instance1']['running'];
-		} catch (e) { }
-		return isRunning;
+		const instances = res.frps && res.frps.instances;
+
+		if (!instances)
+			return false;
+
+		for (let name in instances) {
+			if (instances[name] && instances[name].running)
+				return true;
+		}
+
+		return false;
 	});
 }
 
 function renderStatus(isRunning) {
-	let renderHTML = "";
-	const spanTemp = '<em><span style="color:%s"><strong>%s %s</strong></span></em>';
+	const color = isRunning ? 'green' : 'red';
+	const status = isRunning ? _('RUNNING') : _('NOT RUNNING');
 
-	if (isRunning) {
-		renderHTML += String.format(spanTemp, 'green', _("frp Server"), _("RUNNING"));
-	} else {
-		renderHTML += String.format(spanTemp, 'red', _("frp Server"), _("NOT RUNNING"));
-	}
-
-	return renderHTML;
+	return String.format('<em><span style="color:%s"><strong>%s %s</strong></span></em>',
+		color, _('frp Server'), status);
 }
 
 return view.extend({
@@ -128,39 +950,64 @@ return view.extend({
 		let m, s, o;
 
 		m = new form.Map('frps', _('frp Server'));
+		guardUciDeleteNotFound(m.data, 'frps');
 
 		s = m.section(form.NamedSection, '_status');
 		s.anonymous = true;
 		s.render = function (section_id) {
 			L.Poll.add(function () {
-				return L.resolveDefault(getServiceStatus()).then(function(res) {
-					const view = document.getElementById("service_status");
-					view.innerHTML = renderStatus(res);
+				return L.resolveDefault(getServiceStatus()).then(function (res) {
+					const view = document.getElementById('service_status');
+
+					if (view)
+						view.innerHTML = renderStatus(res);
 				});
 			});
 
 			return E('div', { class: 'cbi-map' },
-				E('fieldset', { class: 'cbi-section'}, [
-					E('p', { id: 'service_status' },
-						_('Collecting data ...'))
+				E('fieldset', { class: 'cbi-section' }, [
+					E('p', { id: 'service_status' }, _('Collecting data ...'))
 				])
 			);
-		}
+		};
 
 		s = m.section(form.NamedSection, 'common', 'conf');
 		s.dynamic = true;
 
-		s.tab('common', _('Common settings'));
-		s.tab('init', _('Startup settings'));
+		s.tab('common', _('Common Settings'));
+		s.tab('auth', _('Authentication'));
+		s.tab('transport', _('Transport Settings'));
+		s.tab('tls_quic', _('TLS / QUIC'));
+		s.tab('web', _('Web Server'));
+		s.tab('access', _('Access Control'));
+		s.tab('ssh_tunnel', _('SSH Tunnel'));
+		s.tab('log', _('Log Settings'));
+		s.tab('init', _('Startup Settings'));
 
-		defTabOpts(s, 'common', commonConf, {optional: true});
+		defTabOpts(s, 'common', commonBaseConf, { optional: true });
+		defTabOpts(s, 'auth', commonAuthConf, { optional: true });
+		defTabOpts(s, 'transport', commonTransportConf, { optional: true });
+		defTabOpts(s, 'tls_quic', commonTlsQuicConf, { optional: true });
+		defTabOpts(s, 'web', commonWebConf, { optional: true });
+		defTabOpts(s, 'access', commonAccessConf, { optional: true });
+		defTabOpts(s, 'ssh_tunnel', commonSshTunnelConf, { optional: true });
+		defTabOpts(s, 'log', commonLogConf, { optional: true });
 
-		o = s.taboption('init', form.SectionValue, 'init', form.TypedSection, 'init', _('Startup settings'));
+		o = s.taboption('init', form.SectionValue, 'init', form.TypedSection, 'init', _('Startup Settings'));
 		s = o.subsection;
 		s.anonymous = true;
 		s.dynamic = true;
 
 		defOpts(s, startupConf);
+
+		s = m.section(form.GridSection, 'http_plugin', _('HTTP Plugin Settings'));
+		s.anonymous = true;
+		s.addremove = true;
+		s.sortable = true;
+		s.nodescriptions = true;
+		s.addbtntitle = _('Add new HTTP plugin...');
+
+		defOpts(s, httpPluginConf, { optional: true });
 
 		return m.render();
 	}

--- a/applications/luci-app-frps/po/ar/frps.po
+++ b/applications/luci-app-frps/po/ar/frps.po
@@ -11,378 +11,718 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "الاعدادات الإضافية"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "المصادقة"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "يتم جمع البيانات..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "معطل"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "ملف تسجيل"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "مستوى التسجيل"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "قيد التشغيل"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/az/frps.po
+++ b/applications/luci-app-frps/po/az/frps.po
@@ -7,378 +7,718 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/be/frps.po
+++ b/applications/luci-app-frps/po/be/frps.po
@@ -8,378 +8,718 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/bg/frps.po
+++ b/applications/luci-app-frps/po/bg/frps.po
@@ -10,378 +10,718 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Контрол на достъпа"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Допълнителни настройки"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Допълнителни настройки"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Разреши портове"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Присвоен порт"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Събиране на данни ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Общи Настройки"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Забранен"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Ниво на записи"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "НЕ СЕ ИЗПЪЛНЯВА"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "РАБОТИ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/bn_BD/frps.po
+++ b/applications/luci-app-frps/po/bn_BD/frps.po
@@ -10,389 +10,718 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.11-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "প্রবেশাধিকার নিয়ন্ত্রণ"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "অতিরিক্ত কনফিগারেশন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "অতিরিক্ত সেটিংস"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "পোর্টগুলিকে অনুমতি দিন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "অ্যাসেট ডিরেক্টরি"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "অ্যাড্রেস বাইন্ড করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "বাইন্ড পোর্ট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "তথ্য সংগ্রহ করা হচ্ছে ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "সাধারণ সেটিংস"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "কনফিগ ফাইলগুলি অস্থায়ী কনফিগ ফাইলের অন্তর্ভুক্ত"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "কাস্টম 404 পৃষ্ঠা"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "ড্যাশবোর্ড ঠিকানা"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "ড্যাশবোর্ড পাসওয়ার্ড"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "ড্যাশবোর্ড পোর্ট"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "ড্যাশবোর্ড ব্যবহারকারী"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "রঙ্গিন লগ নিষ্ক্রিয় করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "নিষ্ক্রিয়"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "এনভায়রনমেন্ট ভ্যারিয়েবল"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "luci-app-frps- এ অ্যাক্সেস মঞ্জুর করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "হার্টবিট টাইমআউট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "কেসিপি বাইন্ড পোর্ট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "লগ ফাইল"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "লগ লেভেল"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "সর্বোচ্চ দিন লগ করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "stderr লগ করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "stdout লগ করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "ক্লায়েন্টপ্রতি সর্বোচ্চ পোর্ট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "চলমান না"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "প্রক্সি বাইন্ড অ্যাড্রেস"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "চলমান"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "ক্র্যাশ করলে পুনরুজ্জীবিত করুন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "গ্রুপ হিসাবে ডেমন চালান"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "ব্যবহারকারী হিসাবে ডেমন চালান"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "স্টার্টআপ সেটিংস"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "সাবডোমেইন হোস্ট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "টিসিপি মাক্স"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"LuCI তে অন্তর্ভুক্ত হয়নি এমন কিছু অতিরিক্ত প্যারামিটার নির্দিষ্ট করতে এই তালিকাটি "
-"ব্যবহৃত হবে।"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "টোকেন"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "ইউডিপি বাইন্ড পোর্ট"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost HTTP পোর্ট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Vhost HTTP সময়সীমা"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Vhost HTTP পোর্ট"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp সার্ভার"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "কনফিগারেশন ফাইল টেমপ্লেটের জন্য ওএস এনভায়রনমেন্ট frp- এ চলে যায়, এখানে দেখুন "
-#~ "<a href=\"https://github.com/fatedier/frp#configuration-file-"
-#~ "template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""

--- a/applications/luci-app-frps/po/ca/frps.po
+++ b/applications/luci-app-frps/po/ca/frps.po
@@ -11,378 +11,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configuracions addicionals"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
-msgstr "Adreça de vinculació"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autenticació"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
+msgstr "Adreça de vinculació"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Inhabilitat"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
-msgstr ""
+msgstr "Nivell de registre"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Executa el servei com a grup"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
+msgstr "Executa el dimoni com l'usuari"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Avançat"

--- a/applications/luci-app-frps/po/cs/frps.po
+++ b/applications/luci-app-frps/po/cs/frps.po
@@ -10,480 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Řízení přístupu"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Další nastavení"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Další nastavení"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Povolit porty"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts určuje sadu portů, ke kterým klienti budou moci využít proxy. "
-"Pokud je délka této hodnota 0 (nula), jsou povolené veškeré porty.<br />Ve "
-"výchozím stavu tato hodnota není vyplněná."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Složka obsahu"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir určuje lokální složku, ze které přehled načítá prostředky. Pokud "
-"je tato hodnota „“ (nevyplněná), obsah bude načítán z přibaleného "
-"spustitelného souboru pomocí statik.<br />Ve výchozím stavu je tato hodnota "
-"nevyplněná."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Ověřování se"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Adresa, na kterou navázat"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Port, na který navázat"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr určuje, na kterou adresu má být server navázán.<br />Ve výchozím "
-"stavu je tato hodnota „0.0.0.0“ (na všechny)."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort určuje KCP port, na kterém server očekává spojení. Pokud je "
-"hodnota 0 (nula) pak server nenaslouchá KCP spojením.<br />A toto je i "
-"výchozí chování (hodnota 0)."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort určuje, port na kterém má server očekávat spojení.<br />Ve výchozím "
-"stavu je tato hodnota 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort určuje QUIC port, na kterém server očekává spojení. Pokud je "
-"tato hodnota 0 (nula), pak server nebude očekávat QUIC spojení.<br />Ve "
-"výchozím stavu je tato hodnota 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort určuje UDP port, na kterém server očekává spojení. Pokud je tato "
-"hodnota 0 (nula), pak server nebude očekávat UDP spojení.<br />Ve výchozím "
-"stavu je tato hodnota 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Shromažďování dat …"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Běžná nastavení"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
-"Které soubory s nastaveními zahrnout do dočasného souboru s nastaveními"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Společná nastavení"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Uživatelsky určená stránka 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page určuje popis umístění uživatelsky určené stránky pro zobrazení "
-"v případě chyby 404. Pokud tato hodnota je „“ (nevyplněno), bude zobrazena "
-"výchozí stránka.<br />Ve výchozím stavu je tato hodnota „“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Soubor s TLS certifikátem pro Přehled určuje popis umístění souboru s TLS "
-"certifikátem, pomocí kterého zapnout přístup přes HTTPS.<br />Vyžadováno, "
-"pokud je zapnuté HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Soubor s TLS klíčem pro Přehled určuje popis umístění souboru s TLS "
-"soukromým klíčem pro zapnutí HTTP přístupu.<br />Vyžadováno, pokud je "
-"zapnuté HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "TLS certifikát Přehledu"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Režim TLS pro Přehled"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "TLS soukromý klíč Přehledu"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Adresa přehledu"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Heslo k přehledu"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Port přehledu"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Uživatel pro přehled"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr určuje adresu, na kterou se má přehled navázat.<br />Ve "
-"výchozím stavu je tato hodnota „0.0.0.0“ (všechny)."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort určuje port, na kterém přehled očekává spojení. Pokud je tato "
-"hodnota „0“ (nula), přehled nebude spuštěn.<br />Ve výchozím stavu je tato "
-"hodnota 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd určuje heslo, které bude používáno přehledem pro přihlášení se."
-"<br />Ve výchozím stavu je tato hodnota „admin“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser určuje uživatelské jméno, které bude používáno přehledem pro "
-"přihlášení se.<br />Ve výchozím stavu je tato hodnota „admin“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Neobarvovat záznam událostí"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor, pokud nastaveno na platí, vypíná obarvování záznamu "
-"událostí pokud je LogWay == \"console\".<br />Ve výchozím stavu je tato "
-"hodnota neplatí."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Zapnout nebo vypnout TLS šifrování pro přehled. Pokud zapnuto, HTTPS je "
-"použito pro zabezpečenou komunikaci."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Proměnná prostředí"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Udělit přístup k LuCI aplikaci frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout určuje nejdelší dobu, po kterou čekat na heartbeat, než "
-"bude spojení ukončeno. Není doporučováno tuto hodnotu měnit.<br />Ve "
-"výchozím stavu je 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Časový limit kontroly stavu"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Port pro navázání KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Soubor se záznamem událostí"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Nastavení zaznamenávání událostí"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Stupeň podrobnosti záznamu událostí"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Zaznamenávat nejvýše dnů"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Zaznamenávat standardní chybový výstup"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Zaznamenávat standardní výstup"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile určuje soubor, do kterého budou zapisovány záznamy událostí. Tato "
-"hodnota bude použita pouze pokud je LogWay příslušně nastaveno.<br />Ve "
-"výchozím stavu je tato hodnota „console“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel určuje nejnižší stupeň podrobnosti záznamu událostí. Platnými "
-"hodnotami jsou „trace“, „debug“ (ladění), „info“, “warn“ (varování) a "
-"„error“ (chyba).<br />Ve výchozím stavu je tato hodnota „info“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays určuje nejvyšší počet dnů, po který ukládat informace záznamu "
-"událostí, než budou smazány. Toto je použito pouze pokud LogWay == \"file\"."
-"<br />Ve výchozím stavu je tato hodnota 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Nejvýše portů na klienta"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient určuje maximální počet portů ke kterým se každý z klientů "
-"může proxy. Pokud je tato hodnota 0 (nula), nebude uplatňován žádný limit."
-"<br />Ve výchozím stavu je tato hodnota 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NESPUŠTĚNÉ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"Proměnné prostředí operačního systému, které předávat do frp pro šablonu "
-"souboru s nastaveními – viz %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Adresa na kterou navázat proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr určuje adresu na kterou se proxy naváže. Tato hodnota může být "
-"stejná, jako u BindAddr.<br />Ve výchozím stavu je tato hodnota „0.0.0.0“ "
-"(na všechny)."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Port, na který má být navázán QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "SPUŠTĚNÉ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "V případě pádu spustit znovu"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Spustit proces služby s oprávněními skupiny"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Spustit proces služby pod uživatelskými oprávněními"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Nastavení startu"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"SubDomainHost určuje doménu která bude přidávána k požadavkům na subdomény "
-"klienty, při používání proxy pro Vhost. Například, pokud je tato hodnota "
-"nastavena na „frps.com“ a klient si vyžádal subdoménu „test“, výsledná URL "
-"by byla „test.frps.com“.<br />Ve výchozím stavu je tato hodnota \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Nastavení spouštění"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Hostitel dílčí domény"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux zapíná/vypíná multiplexování TCP proudu. To umožňuje, aby vícero "
-"požadavků od klienta sdílelo stejné TCP spojení.<br />Ve výchozím stavu je "
-"tato hodnota true (zapnuto)."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Tento seznam je možné použít pro zadání nějakých dalších parametrů, které "
-"nejsou zde v LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token určuje pověřovací token sloužící k ověřování klíčů obdržených od "
-"klientů. Je třeba, aby klient měl shodný token, aby byl pověřen k používání "
-"serveru.<br />Ve výchozím stavu je tato hodnota „“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP port pro navázání"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "HTTP port Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Časový limit HTTP Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "HTTPS port Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort určuje port na kterém server očekává požadavky na HTTP Vhost. "
-"Pokud je tato hodnota 0 (nula), server nebude naslouchat HTTP požadavkům."
-"<br />Ve výchozím stavu je tato hodnota 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout určuje časový limit hlavičky odpovědi pro Vhost HTTP server "
-"(v sekundách).<br />Ve výchozím stavu je tato hodnota 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort určuje port, na kterém server očekává požadavky HTTPS Vhost. "
-"Pokud je tato hodnota 0 (nula), server nebude naslouchat HTTP požadavkům."
-"<br />Ve výchozím stavu je tato hodnota 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp server"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Prostředí operačního systému, které předat frp pro šablonu souboru s "
-#~ "nastaveními – viz <a href=\"https://github.com/fatedier/frp#configuration-"
-#~ "file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort určuje UDP port, na kterém server očekává spojení. Pokud je "
-#~ "tato hodnota 0 (nula), pak server nenaslouchá UDP spojením.<br />Ve "
-#~ "výchozím stavu je tato hodnota 0"
+#~ msgid "Advanced"
+#~ msgstr "Pokročilé"

--- a/applications/luci-app-frps/po/da/frps.po
+++ b/applications/luci-app-frps/po/da/frps.po
@@ -10,378 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Yderligere konfigurationer"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Godkendelse"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
-msgstr "Bind port"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
+msgstr "Bind port"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Log niveau"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "KØRE IKKE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "KØRE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Kør dæmon som gruppe"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Kør dæmon som bruger"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Avanceret"

--- a/applications/luci-app-frps/po/de/frps.po
+++ b/applications/luci-app-frps/po/de/frps.po
@@ -10,478 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Zugangskontrolle"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Zusätzliche Konfiguration"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Weitere Einstellungen"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Erlaube Ports"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts gibt an, mit welchen Ports sich der Client per Proxy verbinden "
-"kann. Wenn der Wert \"length\" auf 0 gesetzt wird, sind alle Ports "
-"erlaubt<br />. Standardmäßig ist dieser Wert eine leere Liste."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Asset-Verzeichnis"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir gibt das lokale Verzeichnis an, aus dem das Dashboard Ressourcen "
-"lädt. Wenn dieser Wert „“ lautet, werden die Ressourcen über statik aus der "
-"mitgelieferten ausführbaren Datei geladen.<br/>Standardmäßig lautet dieser "
-"Wert „“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Authentifizierung"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Bind-Adresse"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Apps, die Geräteattestierung verwenden"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr gibt die Adresse an, an die sich der Server bindet.<br /"
-">Standardmäßig ist dieser Wert \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort gibt den KCP-Port an, auf dem der Server lauscht. Wenn dieser "
-"Wert 0 ist, lauscht der Server nicht auf KCP-Verbindungen.<br /"
-">Standardmäßig ist dieser Wert 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort gibt den Port an, auf dem der Server lauscht.<br />Standardmäßig "
-"ist dieser Wert 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort gibt den QUIC-Port an, an dem der Server auf Verbindungen "
-"wartet. Ist dieser Wert 0, nimmt der Server keine QUIC-Verbindungen an.<br />"
-"Standardmäßig ist dieser Wert 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort gibt den UDP-Port an, an dem der Server auf Verbindungen wartet. "
-"Ist dieser Wert 0, wartet der Server nicht auf UDP-Verbindungen.<br /"
-">Standardmäßig ist dieser Wert 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Sammeln von Daten ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Konfigurationsdateien die in temporärer Konfiguration enthalten sind"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Benutzerdefinierte 404 Fehlerseite"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page gibt einen Pfad zu einer benutzerdefinierten 404-Seite an, die "
-"angezeigt werden soll. Wenn dieser Wert \"\" ist, wird eine Standardseite "
-"angezeigt.<br />Standardmäßig ist dieser Wert \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Die Dashboard-TLS-Zertifikatsdatei gibt den Pfad zur privaten TLS-"
-"Zertifikatsdatei für die Aktivierung des HTTPS-Zugriffs an.<br />"
-"Erforderlich, wenn HTTPS aktiviert ist."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Die Dashboard-TLS-Schlüsseldatei gibt den Pfad zur privaten TLS-"
-"Schlüsseldatei für die Aktivierung des HTTPS-Zugriffs an.<br />Erforderlich, "
-"wenn HTTPS aktiviert ist."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Dashboard-TLS-Zertifikat"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Dashboard TLS Modus"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Dashboard TLS Privatschlüssel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Dashboard Adresse"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Dashboard Passwort"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Dashboard Port"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Dashboard Benutzername"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr gibt die Adresse an, an die das Dashboard gebunden ist. <br /> "
-"Standardmäßig ist dieser Wert \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort gibt den Port an, an dem das Dashboard lauscht. Wenn dieser "
-"Wert 0 ist, wird das Dashboard nicht gestartet. <br />Standardmäßig ist "
-"dieser Wert 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd gibt das Passwort an, das das Dashboard für die Anmeldung "
-"verwendet.<br/>Standardmäßig lautet dieser Wert „admin“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser gibt den Benutzernamen an, den das Dashboard für die Anmeldung "
-"verlangt. <br /> Standardmäßig lautet dieser Wert \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Deaktiviere farbiges Log"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor deaktiviert Protokollfarben, wenn LogWay == \"Konsole\" auf "
-"\"true\" gesetzt ist. <br />Standardmäßig ist dieser Wert \"false\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Aktiviert oder deaktiviert die TLS-Verschlüsselung für das Dashboard. Wenn "
-"aktiviert, wird HTTPS für die sichere Kommunikation verwendet."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Umgebungsvariable"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Zugriff auf LuCI-App frps gewähren"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout gibt die maximale Zeit an, die auf einen \"heartbeat\" "
-"gewartet werden soll, bevor die Verbindung beendet wird. Es wird nicht "
-"empfohlen, diesen Wert zu ändern.<br />Standardmäßig ist dieser Wert 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Heartbeat-Timeout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP-Bind-Port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Protokolldatei"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Protokolleinstellungen"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Protokollierungslevel"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Maximale Tage protokollieren"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Stderr protokollieren"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Stdout protokollieren"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile gibt eine Datei an, in die Protokolle geschrieben werden. Dieser "
-"Wert wird nur verwendet, wenn LogWay entsprechend eingestellt ist.<br />In "
-"der Voreinstellung ist dieser Wert \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel spezifiziert den minimalen Log-Level. Gültige Werte sind \"trace\", "
-"\"debug\", \"info\", \"warn\" und \"error\".<br />Standardwert hierfür ist "
-"\"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays gibt die maximale Anzahl von Tagen an, für die "
-"Protokollinformationen vor dem Löschen gespeichert werden sollen. Dies wird "
-"nur verwendet, wenn LogWay == „file“ ist.<br/>Standardmäßig ist dieser Wert "
-"0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Maximale Ports pro Client"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient gibt die maximale Anzahl von Ports an, an die ein "
-"einzelner Client proxyen darf. Wenn dieser Wert 0 ist, wird keine "
-"Beschränkung angewendet.<br />In der Voreinstellung ist dieser Wert 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "LÄUFT NICHT"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
-msgstr "OS-Umgebungen übergeben an frp für config Dateivorlage, siehe %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Proxy-Bind-Adresse"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr gibt die Adresse an, an die der Proxy bindet. Dieser Wert kann "
-"derselbe sein wie BindAddr.<br />Standardmäßig ist dieser Wert \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "QUIC bind port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "LÄUFT"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Starte nach Crash neu"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Daemon als Gruppe ausführen"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Daemon als Gruppe ausführen"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Start-Einstellungen"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"SubDomainHost gibt die Domäne an, die an vom Client angeforderte Subdomänen "
-"angehängt wird, wenn Vhost-Proxying verwendet wird. Wenn dieser Wert "
-"beispielsweise auf \"frps.com\" gesetzt ist und der Client die Subdomäne "
-"\"test\" angefordert hat, wäre die resultierende URL \"test.frps.com\".<br /"
-">Standardmäßig ist dieser Wert \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Startup-Einstellungen"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Subdomain-Host"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP-mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux schaltet das TCP-Stream-Multiplexing um. Dies erlaubt mehreren "
-"Anfragen von einem Client, sich eine einzige TCP-Verbindung zu teilen.<br /"
-">In der Voreinstellung ist dieser Wert wahr."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"In dieser Liste können zusätzliche Parameter angegeben werden, die in diesem "
-"LuCI nicht enthalten sind."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token gibt das Autorisierungstoken an, das zur Authentifizierung von "
-"Schlüsseln verwendet wird, die von Clients empfangen wurden. Clients müssen "
-"über ein passendes Token verfügen, um zur Benutzung des Servers berechtigt "
-"zu sein.<br />Standardmäßig ist dieser Wert \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP-Bind-Port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost-HTTP-Port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Vhost-HTTP-Timeout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Vhost HTTPS-Port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort gibt den Port an, den der Server auf HTTP-Vhost-Anfragen "
-"abhört. Wenn dieser Wert 0 ist, lauscht der Server nicht auf HTTP-Anfragen."
-"<br />Standardmäßig ist dieser Wert 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout gibt das Antwort-Header-Timeout für den Vhost-HTTP-Server "
-"an, in Sekunden.<br />Standardmäßig ist dieser Wert 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpPort gibt den Port an, den der Server auf HTTP-Vhost-Anfragen "
-"abhört. Wenn dieser Wert 0 ist, lauscht der Server nicht auf HTTP-Anfragen."
-"<br />Standardmäßig ist dieser Wert 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp-Server"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Betriebssystemumgebungsvariablen welche an frp für das Konfig-Datei-"
-#~ "Template weitergereicht werden, siehe <a href=\"https://github.com/"
-#~ "fatedier/frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindKcpPort gibt den KCP-Port an, auf dem der Server lauscht. Wenn dieser "
-#~ "Wert 0 ist, lauscht der Server nicht auf KCP-Verbindungen.<br /"
-#~ ">Standardmäßig ist dieser Wert 0"
+#~ msgid "Advanced"
+#~ msgstr "Erweitert"

--- a/applications/luci-app-frps/po/el/frps.po
+++ b/applications/luci-app-frps/po/el/frps.po
@@ -10,378 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.2\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
-msgstr "Διεύθυνση στην οποία ακούει η υπηρεσία"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Εξουσιοδότηση"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
+msgstr "Διεύθυνση στην οποία ακούει η υπηρεσία"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Απενεργοποιημένο"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Αρχείο καταγραφής"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Επίπεδο καταγραφής"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "ΕΚΤΕΛΕΙΤΕ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "προχωρημένο"

--- a/applications/luci-app-frps/po/eo/frps.po
+++ b/applications/luci-app-frps/po/eo/frps.po
@@ -7,378 +7,718 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/es/frps.po
+++ b/applications/luci-app-frps/po/es/frps.po
@@ -13,481 +13,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Control de acceso"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configuraciones adicionales"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Configuración adicional"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Permitir puertos"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts especifica un conjunto de puertos a los que los clientes pueden "
-"proxy. Si la longitud de este valor es 0, todos los puertos están permitidos."
-"<br />Por defecto, este valor es un conjunto vacío."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Directorio de activos"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir especifica el directorio local desde el que el panel cargará los "
-"recursos. Si este valor es \"\", los activos se cargarán desde el ejecutable "
-"incluido usando statik.<br />Por defecto, este valor es \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Dirección de enlace"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Puerto de enlace"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr especifica la dirección a la que se une el servidor.<br />Por "
-"defecto, este valor es «0.0.0.0»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort especifica el puerto KCP en el que escucha el servidor. Si este "
-"valor es 0, el servidor no escuchará las conexiones KCP.<br />De manera "
-"predeterminada, este valor es 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort especifica el puerto en el que escucha el servidor.<br />De manera "
-"predeterminada, este valor es 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort especifica el puerto QUIC en el que el servidor escucha. Si "
-"este valor es 0, el servidor no escuchará conexiones QUIC.<br />De forma "
-"predeterminada, este valor es 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort especifica el puerto UDP en el que el servidor escucha. Si este "
-"valor es 0, el servidor no escuchará conexiones UDP.<br />De forma "
-"predeterminada, este valor es 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Recopilando datos..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Configuraciones comunes"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
-"Los archivos de configuración incluyen en el archivo de configuración "
-"temporal"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Configuración común"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Página 404 personalizada"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page especifica una ruta a una página 404 personalizada para "
-"mostrar. Si este valor es \"\", se mostrará una página predeterminada.<br /"
-">Por defecto, este valor es \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"El archivo de certificado TLS del panel especifica la ruta al archivo de "
-"certificado TLS para activar el acceso HTTPS.<br />Obligatorio si HTTPS está "
-"activado."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"El archivo de clave TLS del panel especifica la ruta al archivo de clave "
-"privada TLS para activar el acceso HTTPS.<br />Obligatorio si HTTPS está "
-"activado."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Certificado TLS del panel de control"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Modo TLS del panel de control"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Clave privada TLS del panel de control"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Dirección del panel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Contraseña del panel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Puerto del panel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Usuario del panel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr especifica la dirección a la que se une el panel.<br />Por "
-"defecto, este valor es «0.0.0.0»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort especifica el puerto en el que escucha el panel. Si este valor "
-"es 0, el panel no se iniciará.<br />Por defecto, este valor es 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd especifica la contraseña que usará el panel para iniciar "
-"sesión.<br />De manera predeterminada, este valor es «admin»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser especifica el nombre de usuario que usará el panel para "
-"iniciar sesión.<br />Por defecto, este valor es «admin»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Desactivar color de registro"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor desactiva los colores de registro cuando LogWay == "
-"\"console\" cuando se establece en verdadero.<br />De manera predeterminada, "
-"este valor es falso."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Activar o desactivar el cifrado TLS para el panel. Al activarlo, se utiliza "
-"HTTPS para una comunicación segura."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Variable ambiental"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Conceder acceso a la aplicación frps de LuCI"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout especifica el tiempo máximo para esperar un latido antes de "
-"finalizar la conexión. No se recomienda cambiar este valor.<br />Por "
-"defecto, este valor es 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Tiempo de espera de latidos"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Puerto de enlace KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Archivo de registro"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Ajustes de registro"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Nivel de registro"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Máx. días de registro"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Registro de stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Registro de stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile especifica un archivo en el que se escribirán los registros. Este "
-"valor solo se utilizará si LogWay se configura correctamente.<br />De forma "
-"predeterminada, este valor es «console»."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel especifica el nivel mínimo de registro. Los valores válidos son «"
-"trace», «debug», «info», «warn» y «error».<br />Por defecto, este valor es «"
-"info»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays especifica el número máximo de días para almacenar información de "
-"registro antes de la eliminación. Esto solo se usa si LogWay == «archivo"
-"».<br />De forma predeterminada, este valor es 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Máx. puertos por cliente"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient especifica el número máximo de puertos a los que un solo "
-"cliente puede proxy. Si este valor es 0, no se aplicará ningún límite.<br /"
-">Por defecto, este valor es 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NO SE ESTÁ EJECUTANDO"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"Los entornos del sistema operativo pasan a frp para la plantilla del archivo "
-"de configuración, consulte %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Dirección de enlace de proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr especifica la dirección a la que se une el proxy. Este valor "
-"puede ser el mismo que BindAddr.<br />De forma predeterminada, este valor es "
-"«0.0.0.0»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Puerto de enlace QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "EJECUTÁNDOSE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Reaparecer cuando se estrelló"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Ejecutar demonio como grupo"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Ejecutar demonio como usuario"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Configuraciones de inicio"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"SubDomainHost especifica el dominio que se adjuntará a los subdominios "
-"solicitados por el cliente cuando se usa el proxy Vhost. Por ejemplo, si "
-"este valor se establece en «frps.com» y el cliente solicitó el subdominio «"
-"test», la URL resultante sería «test.frps.com».<br />De manera "
-"predeterminada, este valor es \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Configuración de inicio"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Host de subdominio"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "Multiplexación TCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux alterna la multiplexación de flujo TCP. Esto permite que múltiples "
-"solicitudes de un cliente compartan una sola conexión TCP.<br />Por defecto, "
-"este valor es verdadero."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Esta lista se puede utilizar para especificar algunos parámetros adicionales "
-"que no se han incluido en este LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"El token especifica el token de autorización utilizado para autenticar las "
-"claves recibidas de los clientes. Los clientes deben tener un token "
-"coincidente para estar autorizados a usar el servidor.<br />De manera "
-"predeterminada, este valor es \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Puerto de enlace UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Puerto HTTP Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Tiempo de espera HTTP de Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Puerto Vhost HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort especifica el puerto que el servidor escucha para las "
-"solicitudes HTTP Vhost. Si este valor es 0, el servidor no escuchará las "
-"solicitudes HTTP.<br />De manera predeterminada, este valor es 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout especifica el tiempo de espera del encabezado de respuesta "
-"para el servidor HTTP Vhost, en segundos.<br />Por defecto, este valor es 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort especifica el puerto que el servidor escucha para las "
-"solicitudes HTTPS Vhost. Si este valor es 0, el servidor no escuchará las "
-"solicitudes HTTPS.<br />Por defecto, este valor es 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Servidor frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Los entornos de SO pasan a frp para la plantilla del archivo de "
-#~ "configuración, véase <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp LEAME</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort especifica el puerto UDP en el que escucha el servidor. Si "
-#~ "este valor es 0, el servidor no escuchará las conexiones UDP.<br />Por "
-#~ "defecto, este valor es 0"
+#~ msgid "Advanced"
+#~ msgstr "Avanzado"

--- a/applications/luci-app-frps/po/et/frps.po
+++ b/applications/luci-app-frps/po/et/frps.po
@@ -7,378 +7,718 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/fa/frps.po
+++ b/applications/luci-app-frps/po/fa/frps.po
@@ -10,378 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.15.1\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "پیکربندی‌های اضافی"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "تنظیمات اضافی"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "درگاه‌های مجاز"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "شاخهٔ دارایی‌ها"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
-msgstr "نشانی اتصال"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
-msgstr "درگاه اتصال"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
+msgstr "نشانی اتصال"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
+msgstr "درگاه اتصال"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "غیرفعال"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "سطح دسترسی لاگ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
+msgstr "اجرا نمی‌شود"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-msgid "RUNNING"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
+msgid "RUNNING"
+msgstr "در حال اجرا"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "پیشرفته"

--- a/applications/luci-app-frps/po/fi/frps.po
+++ b/applications/luci-app-frps/po/fi/frps.po
@@ -10,378 +10,718 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Lisäasetukset"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Sallitut portit"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
-msgstr "Sido osoite"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Todennus"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
-msgstr "Sido portti"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Yleiset asetukset"
+msgid "Bind address"
+msgstr "Sido osoite"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
+msgstr "Sido portti"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Pois käytöstä"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Lokitiedosto"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Lokitaso"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "EI KÄYNNISSÄ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "KÄYNNISSÄ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/fr/frps.po
+++ b/applications/luci-app-frps/po/fr/frps.po
@@ -10,466 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Contrôle d'accès"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configurations supplémentaires"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Paramètres supplémentaires"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Autoriser les ports"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts spécifie un ensemble de ports vers lesquels les clients peuvent "
-"être proxy. Si la longueur de cette valeur est 0, tous les ports sont "
-"autorisés.<br />Par défaut, cette valeur est un ensemble vide."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Répertoire des actifs"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir spécifie le répertoire local à partir duquel le tableau de bord "
-"chargera les ressources. Si cette valeur est \"\", les actifs seront chargés "
-"à partir de l'exécutable fourni à l'aide de statik.<br />Par défaut, cette "
-"valeur est \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Authentification"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Lier l'adresse"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Port de liaison"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr spécifie l'adresse à laquelle le serveur se lie.<br />Par défaut, "
-"cette valeur est \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort spécifie le port KCP sur lequel le serveur écoute. Si cette "
-"valeur est 0, le serveur n'écoutera pas les connexions KCP.<br />Par défaut, "
-"cette valeur est 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort spécifie le port sur lequel le serveur écoute.<br />Par défaut, "
-"cette valeur est 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Récolte de données..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Paramètres communs"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
 msgstr ""
-"Les fichiers de configuration incluent dans le fichier de configuration "
-"temporaire"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Page 404 personnalisée"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page spécifie un chemin d'accès à une page 404 personnalisée à "
-"afficher. Si cette valeur est \"\", une page par défaut s'affiche.<br />Par "
-"défaut, cette valeur est \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Adresse du tableau de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Mot de passe du tableau de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Port de tableau de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Utilisateur du tableau de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr spécifie l'adresse à laquelle le tableau de bord se lie.<br /"
-">Par défaut, cette valeur est \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort spécifie le port sur lequel le tableau de bord écoute. Si "
-"cette valeur est 0, le tableau de bord ne sera pas démarré.<br />Par défaut, "
-"cette valeur est 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd spécifie le mot de passe que le tableau de bord utilisera pour "
-"la connexion.<br />Par défaut, cette valeur est \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser spécifie le nom d'utilisateur que le tableau de bord utilisera "
-"pour la connexion.<br />Par défaut, cette valeur est \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Désactiver la couleur du journal"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"DisableLogColor désactive les couleurs des journaux lorsque LogWay == "
-"\"console\" est défini sur true.<br />Par défaut, cette valeur est false."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Variable d'environnement"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Accorder l’accès à l’application LuCI frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout spécifie la durée maximale d'attente d'un battement de cœur "
-"avant de mettre fin à la connexion. Il n'est pas recommandé de modifier "
-"cette valeur.<br />Par défaut, cette valeur est 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Délai d'expiration du rythme cardiaque"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Port de liaison KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Fichier journal"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Niveau de journalisation"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Journal max jours"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Log stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Log stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile spécifie un fichier dans lequel les journaux seront écrits. Cette "
-"valeur ne sera utilisée que si LogWay est défini de manière appropriée.<br /"
-">Par défaut, cette valeur est \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel spécifie le niveau de journalisation minimum. Les valeurs valides "
-"sont \"trace\", \"debug\", \"info\", \"warn\" et \"error\".<br />Par défaut, "
-"cette valeur est \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays indique le nombre maximal de jours pendant lesquels les "
-"informations du journal doivent être conservées avant d'être supprimées. "
-"Cette valeur n'est utilisée que si LogWay == \"file\".<br />Par défaut, "
-"cette valeur est 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Ports max par client"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient spécifie le nombre maximal de ports qu'un seul client peut "
-"proxy. Si cette valeur est 0, aucune limite ne sera appliquée.<br />Par "
-"défaut, cette valeur est 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NON-EXÉCUTANT"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Adresse de liaison proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr spécifie l'adresse à laquelle le proxy se lie. Cette valeur "
-"peut être identique à BindAddr.<br />Par défaut, cette valeur est "
-"\"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "EXÉCUTION"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Réapparaître en cas de crash"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Exécuter le démon en tant que groupe"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Exécuter le démon en tant qu'utilisateur"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Paramètres de démarrage"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost spécifie le domaine qui sera attaché aux sous-domaines "
-"demandés par le client lors de l'utilisation du proxy Vhost. Par exemple, si "
-"cette valeur est définie sur \"frps.com\" et que le client a demandé le sous-"
-"domaine \"test\", l'URL résultante serait \"test.frps.com\".<br />Par "
-"défaut, cette valeur est \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Hôte de sous-domaine"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux bascule le multiplexage de flux TCP. Cela permet à plusieurs demandes "
-"d'un client de partager une seule connexion TCP.<br />Par défaut, cette "
-"valeur est vraie."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Cette liste peut être utilisée pour spécifier des paramètres additionnels "
-"qui n'ont pas été inclus dans ce LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token spécifie le jeton d'autorisation utilisé pour authentifier les clés "
-"reçues des clients. Les clients doivent avoir un jeton correspondant pour "
-"être autorisés à utiliser le serveur.<br />Par défaut, cette valeur est \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Port de liaison UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Port HTTP Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Délai d'expiration Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Port HTTPS Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort spécifie le port que le serveur écoute pour les requêtes HTTP "
-"Vhost. Si cette valeur est 0, le serveur n'écoutera pas les requêtes HTTP."
-"<br />Par défaut, cette valeur est 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout spécifie le délai d'expiration de l'en-tête de réponse pour "
-"le serveur HTTP Vhost, en secondes.<br />Par défaut, cette valeur est 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort spécifie le port que le serveur écoute pour les requêtes "
-"HTTPS Vhost. Si cette valeur est 0, le serveur n'écoutera pas les requêtes "
-"HTTPS.<br />Par défaut, cette valeur est 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp Server"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Les environnements de système d'exploitation passent à frp pour le modèle "
-#~ "de fichier de configuration, voir <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort spécifie le port UDP sur lequel le serveur écoute. Si cette "
-#~ "valeur est 0, le serveur n'écoutera pas les connexions UDP.<br />Par "
-#~ "défaut, cette valeur est 0"
+#~ msgid "Advanced"
+#~ msgstr "Avancé"

--- a/applications/luci-app-frps/po/ga/frps.po
+++ b/applications/luci-app-frps/po/ga/frps.po
@@ -7,484 +7,725 @@ msgstr ""
 "Language: ga\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :(n>"
-"6 && n<11) ? 3 : 4;\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 5.16-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Rialú Rochtana"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Cumraíochtaí breise"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Socruithe breise"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Ceadaigh calafoirt"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"Sonraíonn AllowPorts sraith port ar féidir le cliaint seachfhreastalaí a "
-"dhéanamh chucu. Más é fad an luacha seo ná 0, ceadaítear gach port.<br />De "
-"réir réamhshocraithe, is tacar folamh é an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Sócmhainní dir"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"Sonraíonn AssetsDir an t-eolaire áitiúil a luchtóidh an painéal acmhainní "
-"uaidh. Más é \" \"an luach seo, déanfar sócmhainní a luchtú ón inrite "
-"cuachta le staticí.<br />De réir réamhshocraithe, is \" \" é an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Fíordheimhniú"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Seoladh ceangail"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Port ceangail"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"Sonraíonn BindAddr an seoladh a nascann an freastalaí leis.<br />De réir "
-"réamhshocraithe, is é \"0.0.0.0\" an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"Sonraíonn BindKcpPort an calafort KCP a éisteann an freastalaí air. Más é 0 "
-"an luach seo, ní éistfidh an freastalaí le haghaidh naisc KCP.<br />De réir "
-"réamhshocraithe, is é 0 an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"Sonraíonn BindPort an port a n-éisteann an freastalaí air.<br />De réir "
-"réamhshocraithe, is é 7000 an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"Sonraíonn BindQuicPort an port QUIC a n-éisteann an freastalaí leis. Mura "
-"bhfuil an luach seo ach 0, ní éistfidh an freastalaí le haghaidh naisc QUIC."
-"<br />De réir réamhshocraithe, is é 0 an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"Sonraíonn BindUdpPort an port UDP a n-éisteann an freastalaí leis. Mura "
-"bhfuil an luach seo ach 0, ní éistfidh an freastalaí le haghaidh naisc UDP."
-"<br />De réir réamhshocraithe, is é 0 an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Sonraí á mbailiú ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Socruithe coitianta"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Áirítear comhaid cumraíochta sa chomhad cumraíochta sealadach"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Socruithe Coitianta"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Saincheaptha 404 leathanach"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Sonraíonn Custom404Page cosán chuig leathanach saincheaptha 404 le "
-"taispeáint. Más é \" \"an luach seo, taispeánfar leathanach réamhshocraithe."
-"<br />De réir réamhshocraithe, is \" \" é an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Sonraíonn Comhad Deimhnithe TLS an Phainéal an cosán chuig an gcomhad "
-"deimhnithe TLS chun rochtain HTTPS a chumasú.<br />Riachtanach má tá HTTPS "
-"cumasaithe."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Sonraíonn Comhad Eochrach TLS an Phainéal an cosán chuig an gcomhad eochrach "
-"príobháideach TLS chun rochtain HTTPS a chumasú.<br />Riachtanach má tá "
-"HTTPS cumasaithe."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Teastas TLS Painéil"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Mód TLS an phainéil"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Eochair phríobháideach TLS an phainéil"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Seoladh an deais"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Pasfhocal ar an painéal"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Port painéal"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Úsáideoir painéal"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"Sonraíonn DashboardAddr an seoladh a nascann an painéal leis.<br />De réir "
-"réamhshocraithe, is é an luach seo ná \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"Sonraíonn DashboardPort an port a n-éisteann an deais air. Más é 0 an luach "
-"seo, ní thosófar an deais.<br />De réir réamhshocraithe, is é 0 an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"Sonraíonn DashboardPwd an pasfhocal a úsáidfidh an painéal chun logáil "
-"isteach.<br />De réir réamhshocraithe, is é an luach seo ná \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"Sonraíonn DashboardUser an t-ainm úsáideora a úsáidfidh an painéal chun "
-"logáil isteach.<br />De réir réamhshocraithe, is é an luach seo ná \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Díchumasaigh dath an loga"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"Díchumasaíonn DisableLogColor dathanna loga nuair a bhíonn LogWay == "
-"\"consól\" socraithe go fíor.<br />De réir réamhshocraithe, tá an luach seo "
-"bréagach."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Míchumasaithe"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Cumasaigh nó díchumasaigh criptiú TLS don phainéal rialaithe. Nuair a bhíonn "
-"sé cumasaithe, úsáidtear HTTPS le haghaidh cumarsáide sláine."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Athróg timpeallachta"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Deonaigh rochtain ar frps app LuCI"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"Sonraíonn HeartBeatTimeout an t-uasmhéid ama le fanacht ar bhuille croí sula "
-"gcuirtear deireadh leis an gceangal. Ní mholtar an luach seo a athrú.<br /"
-">De réir réamhshocraithe, is é 90 an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Teorainn ama buille croí"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Port ceangail KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Comhad logála"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Socruithe Logála"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Leibhéal loga"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Íoslódáil max laethanta"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Logáil isteach stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Logáil isteach stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"Sonraíonn LogFile comhad a mbeidh logs scríofa chuige. Ní úsáidfear an luach "
-"seo ach amháin má tá LogWay socraithe go cuí.<br />De réir réamhshocraithe, "
-"is \"consól\" an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"Sonraíonn LogLevel an t-íosleibhéal logála. Is iad na luachanna bailí "
-"\"rian\", \"debug\", \"info\", \"rabhadh\", agus \"earráid\".<br />De réir "
-"réamhshocraithe, is é an luach seo \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"Sonraíonn LogMaxDays an t-uaslíon laethanta chun faisnéis logála a stóráil "
-"roimh scriosadh. Ní úsáidtear é seo ach amháin i gcás LogWay == \"comhad\"."
-"<br />De réir réamhshocraithe, is é 0 an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Uaschalafoirt in aghaidh an chliaint"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"Sonraíonn MaxPortsPerClient an t-uaslíon port ar féidir le cliant aonair "
-"seachfhreastalaí chucu. Más é 0 an luach seo, ní chuirfear teorainn ar bith "
-"i bhfeidhm.<br />De réir réamhshocraithe, is é 0 an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NÍ RÚCHÁN"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"Téann timpeallachtaí OS chuig frp le haghaidh teimpléad comhaid "
-"chumraíochta, féach %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Seoladh ceangail seachfhreastalaí"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"Sonraíonn ProxyBindAddr an seoladh a nascann an seachfhreastalaí leis. Seans "
-"go bhfuil an luach seo mar an gcéanna le BindAddr.<br />De réir "
-"réamhshocraithe, is é \"0.0.0.0\" an luach seo."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Port ceangail QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "REATHA"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Respawn nuair a tuairteála"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Rith deamhan mar ghrúpa"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Rith deamhan mar úsáideoir"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Socruithe tosaithe"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"Sonraíonn SubDomainHost an fearann a bheidh ceangailte le fo-fhearainn a "
-"iarrann an cliant agus é ag úsáid seachfhreastalaí Vhost. Mar shampla, má tá "
-"an luach seo socraithe go \"frps.com\" agus má d'iarr an cliant an "
-"fofhearann \"tástáil\", is é \"test.frps.com\" an URL a bheadh mar thoradh "
-"air.<br />De réir réamhshocraithe, is é \" \"an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Socruithe Tosaithe"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Óstach subdomain"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"Déanann TcpMux ilphléacsáil sruth TCP a scoránú. Ligeann sé seo iarratais "
-"iolracha ó chliant chun nasc TCP amháin a roinnt.<br />De réir "
-"réamhshocraithe, tá an luach seo fíor."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Is féidir an liosta seo a úsáid chun roinnt paraiméadair bhreise nach bhfuil "
-"san áireamh sa LUCI seo a shonrú."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Comhartha"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Sonraíonn Token an comhartha údaraithe a úsáidtear chun eochracha a fuarthas "
-"ó chliaint a fhíordheimhniú. Ní mór comhartha meaitseála a bheith ag cliaint "
-"chun go mbeidh siad údaraithe chun an freastalaí a úsáid.<br />De réir "
-"réamhshocraithe, is \" \"an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Port ceangail UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost calafort HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Teorainn ama Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Vhost calafort HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"Sonraíonn VhostHttpPort an port a éisteann an freastalaí le haghaidh "
-"iarratais HTTP Vhost. Más é 0 an luach seo, ní éistfidh an freastalaí le "
-"haghaidh iarratais HTTP.<br />De réir réamhshocraithe, is é 0 an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"Sonraíonn VhostHttpTimeout an t-am istigh faoin gceanntásc freagartha don "
-"fhreastalaí Vhost HTTP, i soicindí.<br />De réir réamhshocraithe, is é 60 an "
-"luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"Sonraíonn VhostHttpsPort an port a éisteann an freastalaí le haghaidh "
-"iarratais HTTPS Vhost. Más é 0 an luach seo, ní éistfidh an freastalaí le "
-"haghaidh iarratais HTTPS.<br />De réir réamhshocraithe, is é 0 an luach seo."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Freastalaí frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Gabhann timpeallachtaí OS chuig frp le haghaidh teimpléad comhaid "
-#~ "cumraíochta, féach <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "Sonraíonn BindUdpPort an port UDP a éisteann an freastalaí air. Más é 0 "
-#~ "an luach seo, ní éistfidh an freastalaí le haghaidh naisc UDP.<br />De "
-#~ "réir réamhshocraithe, is é 0 an luach seo"
+#~ msgid "Advanced"
+#~ msgstr "Ardleibhéil"

--- a/applications/luci-app-frps/po/he/frps.po
+++ b/applications/luci-app-frps/po/he/frps.po
@@ -4,378 +4,718 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "אימות"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/hi/frps.po
+++ b/applications/luci-app-frps/po/hi/frps.po
@@ -4,378 +4,718 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "पहुँच नियंत्रण"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/hu/frps.po
+++ b/applications/luci-app-frps/po/hu/frps.po
@@ -10,381 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Hozzáférés-vezérlés"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "További konfigurációk"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "További beállítások"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Hitelesítés"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Cím kötése"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Adatgyűjtés..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Gyakori beállítások"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-#, fuzzy
-msgid "Config files include in temporary config file"
-msgstr "A konfig fájlok ideiglenes konfigurációs fájlban találhatók"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Általános Beállítások"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Saját 404 oldal"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"A saját 404 oldal útvonala. Ha az értéke \"\", egy alapértelmezett oldal "
-"jelenik meg.<br />Alapértelmezésben az értéke \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Színek kikapcsolása a naplóban"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Környezeti változó"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Hozzáférés engedélyezése az <em>frps</em> LuCI alkalmazáshoz"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Naplófájl"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Naplózás szintje"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NEM FUT"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "FUT"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Démon futtatása csoportként"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Démon futtatása felhasználóként"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Indulási beállítások"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp szerver"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Speciális"

--- a/applications/luci-app-frps/po/it/frps.po
+++ b/applications/luci-app-frps/po/it/frps.po
@@ -10,405 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Controllo Accessi"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configurazioni aggiuntive"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Altre impostazioni"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Consenti porte"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"Consenti porte specifica un insieme di porte a cui i client possono eseguire "
-"il proxy. Se la lunghezza di questo valore è 0, tutte le porte sono "
-"consentite.<br />Per impostazione predefinita, questo valore è un set vuoto."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Attività dir"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"Attività dir specifica la directory locale da cui verrà caricato il "
-"dashboard. Se questo valore è \"\", le risorse verranno caricate "
-"dall'eseguibile in bundle utilizzando statik. <br />Per impostazione "
-"predefinita, questo valore è \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autenticazione"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Associa indirizzo"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "collega porta"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr specifica l'indirizzo a cui il server si lega.<br />Per "
-"impostazione predefinita, questo valore è \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort specifica la porta KCP su cui il server è in ascolto. Se questo "
-"valore è 0, il server non ascolterà le connessioni KCP.<br />Per "
-"impostazione predefinita, questo valore è 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort specifica la porta su cui il server è in ascolto.<br />Per "
-"impostazione predefinita, questo valore è 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Caricamento dei dati in corso..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Impostazioni comuni"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
-"I file di configurazione sono inclusi nel file di configurazione temporaneo"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Impostazioni Comuni"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Pagina 404 personalizzata"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page specifica un percorso a una pagina 404 personalizzata da "
-"visualizzare. Se questo valore è \"\", verrà visualizzata una pagina "
-"predefinita.<br />Per impostazione predefinita, questo valore è \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Disattivato"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "File registro eventi"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Impostazioni log"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Livello dei log"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NON IN ESECUZIONE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "IN ESECUZIONE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Esegui il demone come utente"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort specifica la porta UDP su cui il server è in ascolto. Se "
-#~ "questo valore è 0, il server non ascolterà le connessioni UDP.<br />Per "
-#~ "impostazione predefinita, questo valore è 0"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Avanzato"

--- a/applications/luci-app-frps/po/ja/frps.po
+++ b/applications/luci-app-frps/po/ja/frps.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "PO-Revision-Date: 2025-11-08 14:47+0000\n"
-"Last-Translator: Monarch <monarch.scrap-0p@users.noreply.hosted.weblate.org>"
-"\n"
+"Last-Translator: Monarch "
+"<monarch.scrap-0p@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsfrps/ja/>\n"
 "Language: ja\n"
@@ -11,378 +11,721 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "アクセス制御"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "追加の構成"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "追加設定"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
-msgstr "バインドするIPアドレス"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "認証"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
-msgstr "バインドするポート"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "共通設定"
+msgid "Bind address"
+msgstr "バインドするIPアドレス"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
+msgstr "バインドするポート"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "共通設定"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "ログの色を無効にする"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "無効"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "環境変数"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "ハートビート・タイムアウト"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "ログファイル"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "ログレベル"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "クライアントごとの最大ポート数"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "停止中"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "実行中"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "デーモンをグループとして実行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "デーモンをユーザーとして実行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "トークン"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "詳細設定"

--- a/applications/luci-app-frps/po/ko/frps.po
+++ b/applications/luci-app-frps/po/ko/frps.po
@@ -10,378 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "접근 제어"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "추가 설정"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "추가 설정"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "인증"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "바인드 주소"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "바인드 포트"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "데이터 수집 중 ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "일반 설정"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "일반 설정"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "사용자 정의 404 페이지"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "대시보드 TLS 인증서"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "대시보드 TLS 모드"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "대시보드 TLS 개인 키"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "대시보드 주소"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "대시보드 암호"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "대시보드 포트"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "대시보드 사용자"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "비활성화"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "환경 변수"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "LuCI 앱 frps에 접근 권한 부여"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP 바인드 포트"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "로그 파일"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "로그 설정"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "로그 수준"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "표준 오류(stderr) 기록"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "표준 출력(stdout) 기록"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "중지됨"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "프록시 바인드 주소"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "QUIC 바인드 포트"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "실행 중"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "충돌 시 자동 재시작"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "데몬 실행 그룹"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "데몬 실행 사용자"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "시작 설정"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "시작 설정"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "토큰"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP 바인드 포트"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp 서버"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "고급"

--- a/applications/luci-app-frps/po/lo/frps.po
+++ b/applications/luci-app-frps/po/lo/frps.po
@@ -10,434 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "ການຄວບຄຸມການເຂົ້າເຖິງ"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "ການຕັ້ງຄ່າເພີ່ມເຕີມ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "ການຕັ້ງຄ່າເພີ່ມເຕີມ"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "ອະນຸຍາດພອດ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts ກຳນົດຊຸດຂອງພອດທີ່ລູກຄ້າສາມາດພຣັອກຊີໄປຫາໄດ້. ຖ້າຄວາມຍາວຂອງຄ່ານີ້ເປັນ 0, ທຸກພອດຈະຖືກ"
-"ອະນຸຍາດ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ເປັນຊຸດວ່າງ."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "ໄດເຣັກທໍຣີຊັບສິນ (Assets)"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir ກຳນົດໄດເຣັກທໍຣີພາຍໃນເຄື່ອງທີ່ dashboard ຈະໂຫຼດຊັບພະຍາກອນມາໃຊ້. ຖ້າຄ່ານີ້ເປັນ \"\", "
-"ຊັບພະຍາກອນຈະຖືກໂຫຼດຈາກໄຟລ໌ executable ທີ່ລວມໄວ້ໂດຍໃຊ້ statik.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ຈະເ"
-"ປັນ \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "ການຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "ທີ່ຢູ່ການເຊື່ອມຕໍ່ (Bind address)"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "ພອດການເຊື່ອມຕໍ່ (Bind port)"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr ກຳນົດທີ່ຢູ່ທີ່ເຊີບເວີຈະຜູກມັດນຳ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort ກຳນົດພອດ KCP ທີ່ເຊີບເວີຈະຮັບຟັງ. ຖ້າຄ່ານີ້ເປັນ 0, ເຊີບເວີຈະບໍ່ຮັບຟັງການເຊື່ອມຕໍ່ "
-"KCP.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort ກຳນົດພອດທີ່ເຊີບເວີຈະຮັບຟັງ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort ກຳນົດພອດ QUIC ທີ່ເຊີບເວີຈະຮັບຟັງ. ຖ້າຄ່ານີ້ເປັນ 0, ເຊີບເວີຈະບໍ່ຮັບຟັງການເຊື່ອມຕໍ່ "
-"QUIC.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort ກຳນົດພອດ UDP ທີ່ເຊີບເວີຈະຮັບຟັງ. ຖ້າຄ່ານີ້ເປັນ 0, ເຊີບເວີຈະບໍ່ຮັບຟັງການເຊື່ອມຕໍ່ "
-"UDP.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "ກຳລັງເກັບຂໍ້ມູນ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "ໄຟລ໌ຕັ້ງຄ່າທີ່ລວມຢູ່ໃນໄຟລ໌ຕັ້ງຄ່າຊົ່ວຄາວ"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "ໜ້າ 404 ແບບກຳນົດເອງ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page ກຳນົດເສັ້ນທາງໄປຫາໜ້າ 404 ແບບກຳນົດເອງເພື່ອສະແດງຜົນ. ຖ້າຄ່ານີ້ເປັນ \"\", ໜ້າເລີ່ມ"
-"ຕົ້ນຈະຖືກສະແດງ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Dashboard TLS Cert File ກຳນົດເສັ້ນທາງໄປຫາໄຟລ໌ໃບຢັ້ງຢືນ TLS ເພື່ອເປີດໃຊ້ງານການເຂົ້າເຖິງ "
-"HTTPS.<br />ຈຳເປັນຕ້ອງມີຫາກເປີດໃຊ້ HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Dashboard TLS Key File ກຳນົດເສັ້ນທາງໄປຫາໄຟລ໌ລະຫັດສ່ວນຕົວ TLS ເພື່ອເປີດໃຊ້ງານການເຂົ້າເຖິງ "
-"HTTPS.<br />ຈຳເປັນຕ້ອງມີຫາກເປີດໃຊ້ HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "ໃບຢັ້ງຢືນ TLS ສຳລັບແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "ໂໝດ TLS ສຳລັບແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "ລະຫັດສ່ວນຕົວ TLS ສຳລັບແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "ທີ່ຢູ່ແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "ລະຫັດຜ່ານແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "ພອດແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "ຜູ້ໃຊ້ແຜງຄວບຄຸມ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr ກຳນົດທີ່ຢູ່ທີ່ແຜງຄວບຄຸມຈະຜູກມັດນຳ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort ກຳນົດພອດທີ່ແຜງຄວບຄຸມຈະຮັບຟັງ. ຖ້າຄ່ານີ້ເປັນ 0, ແຜງຄວບຄຸມຈະບໍ່ຖືກເລີ່ມຕົ້ນ.<br />ໂດ"
-"ຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd ກຳນົດລະຫັດຜ່ານທີ່ແຜງຄວບຄຸມຈະໃຊ້ເຂົ້າສູ່ລະບົບ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ "
-"\"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser ກຳນົດຊື່ຜູ້ໃຊ້ທີ່ແຜງຄວບຄຸມຈະໃຊ້ເຂົ້າສູ່ລະບົບ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ "
-"\"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "ປິດການໃຊ້ງານສີໃນ Log"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor ປິດການໃຊ້ງານສີໃນບົດບັນທຶກ ເມື່ອ LogWay == \"console\" ເມື່ອຕັ້ງຄ່າເປັນ "
-"true.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ຈະເປັນ false."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "ປິດໃຊ້ງານ"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"ເປີດ ຫຼື ປິດການເຂົ້າລະຫັດ TLS ສຳລັບແຜງຄວບຄຸມ. ເມື່ອເປີດໃຊ້, HTTPS ຈະຖືກໃຊ້ເພື່ອການສື່ສານທີ່ປອດໄພ."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "ຕົວແປສະພາບແວດລ້ອມ (Environment variable)"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "ໃຫ້ສິດເຂົ້າເຖິງແອັບ LuCI frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout ກຳນົດເວລາສູງສຸດທີ່ຕ້ອງລໍຖ້າການຕອບຮັບ (heartbeat) ກ່ອນຈະຕັດການເຊື່ອມຕໍ່. ບໍ່ແນ"
-"ະນຳໃຫ້ປ່ຽນຄ່ານີ້.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "ເວລາໝົດກຳນົດ Heartbeat"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "ພອດ KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "ໄຟລ໌ບັນທຶກ (Log)"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "ການຕັ້ງຄ່າບັນທຶກ"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "ລະດັບການບັນທຶກ (Log)"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "ຈຳນວນມື້ສູງສຸດຂອງ Log"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Log stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Log stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile ກຳນົດໄຟລ໌ທີ່ຈະໃຊ້ຂຽນ Log. ຄ່ານີ້ຈະຖືກໃຊ້ກໍຕໍ່ເມື່ອ LogWay ຖືກຕັ້ງຄ່າຢ່າງເໝາະສົມ.<br />ໂດຍຄ່"
-"າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel ກຳນົດລະດັບ Log ຕໍ່າສຸດ. ຄ່າທີ່ໃຊ້ໄດ້ຄື \"trace\", \"debug\", \"info\", "
-"\"warn\", ແລະ \"error\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays ກຳນົດຈຳນວນມື້ສູງສຸດໃນການເກັບຂໍ້ມູນ Log ກ່ອນທີ່ຈະຖືກລຶບ. ຄ່ານີ້ຈະຖືກໃຊ້ກໍຕໍ່ເມື່ອ LogWay "
-"== \"file\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "ຈຳນວນພອດສູງສຸດຕໍ່ລູກຄ້າ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient ກຳນົດຈຳນວນພອດສູງສຸດທີ່ລູກຄ້າໜຶ່ງລາຍສາມາດພຣັອກຊີໄປຫາໄດ້. ຖ້າຄ່ານີ້ເປັນ 0, ຈະບໍ່"
-"ມີການຈຳກັດ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "ບໍ່ໄດ້ເຮັດວຽກ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"ສະພາບແວດລ້ອມລະບົບປະຕິບັດການທີ່ສົ່ງໃຫ້ frp ສຳລັບເທມເພລດໄຟລ໌ຕັ້ງຄ່າ, ເບິ່ງ %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "ທີ່ຢູ່ການເຊື່ອມຕໍ່ Proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr ກຳນົດທີ່ຢູ່ທີ່ພຣັອກຊີຈະຜູກມັດນຳ. ຄ່ານີ້ອາດຈະຄືກັນກັບ BindAddr.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, "
-"ຄ່ານີ້ແມ່ນ \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "ພອດ QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "ກຳລັງເຮັດວຽກ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "ເລີ່ມການເຮັດວຽກໃໝ່ເມື່ອຂັດຂ້ອງ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "ແລ່ນ daemon ໃນຖານະກຸ່ມ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "ແລ່ນ daemon ໃນຖານະຜູ້ໃຊ້"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "ການຕັ້ງຄ່າການເລີ່ມຕົ້ນລະບົບ"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"SubDomainHost ກຳນົດໂດເມນທີ່ຈະຖືກຕໍ່ທ້າຍກັບຊັບໂດເມນທີ່ລູກຄ້າຮ້ອງຂໍເມື່ອໃຊ້ Vhost proxying. ຕົວຢ່າ"
-"ງ, ຖ້າຄ່ານີ້ຖືກຕັ້ງເປັນ \"frps.com\" ແລະລູກຄ້າຮ້ອງຂໍຊັບໂດເມນ \"test\", URL ທີ່ໄດ້ຈະເປັນ "
-"\"test.frps.com\".<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "ການຕັ້ງຄ່າເລີ່ມຕົ້ນລະບົບ"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "ໂຮສຊັບໂດເມນ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux ເປີດໃຊ້ງານການລວມຊ່ອງທາງ TCP (TCP stream multiplexing). ອັນນີ້ເຮັດໃຫ້ຫຼາຍຄຳຮ້ອງຂໍຈ"
-"າກລູກຂ່າຍສາມາດໃຊ້ງານການເຊື່ອມຕໍ່ TCP ດຽວກັນໄດ້.<br />ໂດຍປົກກະຕິແລ້ວ, ຄ່ານີ້ແມ່ນ true."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"ລາຍການນີ້ສາມາດໃຊ້ເພື່ອລະບຸພາຣາມິເຕີເພີ່ມເຕີມບາງຢ່າງທີ່ຍັງບໍ່ໄດ້ລວມຢູ່ໃນ LuCI ນີ້."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "ໂທເຄັນ (Token)"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token ລະບຸ token ການຢັ້ງຢືນສິດທີ່ໃຊ້ເພື່ອພິສູດຢືນຢັນຄີທີ່ໄດ້ຮັບຈາກລູກຂ່າຍ. ລູກຂ່າຍຕ້ອງມີ token ທີ່ກົງກັນເພື່"
-"ອໃຫ້ໄດ້ຮັບອະນຸຍາດນຳໃຊ້ເຊີບເວີ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "ພອດ UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "ພອດ Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "ເວລາໝົດກຳນົດ Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "ພອດ Vhost HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort ກຳນົດພອດທີ່ເຊີບເວີຈະຮັບຟັງຄຳຮ້ອງຂໍ HTTP Vhost. ຖ້າຄ່ານີ້ເປັນ 0, ເຊີບເວີຈະບໍ່ຮັບຟັງຄ"
-"ຳຮ້ອງຂໍ HTTP.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout ກຳນົດເວລາໝົດກຳນົດຂອງຮີເດີການຕອບສະໜອງສຳລັບເຊີບເວີ Vhost HTTP, ມີຫົວໜ່ວຍເ"
-"ປັນວິນາທີ.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort ກຳນົດພອດທີ່ເຊີບເວີຈະຮັບຟັງຄຳຮ້ອງຂໍ HTTPS Vhost. ຖ້າຄ່ານີ້ເປັນ 0, ເຊີບເວີຈະບໍ່ຮັບຟັ"
-"ງຄຳຮ້ອງຂໍ HTTPS.<br />ໂດຍຄ່າເລີ່ມຕົ້ນ, ຄ່ານີ້ແມ່ນ 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "ເຊີບເວີ frp"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "ຂັ້ນສູງ"

--- a/applications/luci-app-frps/po/lt/frps.po
+++ b/applications/luci-app-frps/po/lt/frps.po
@@ -11,504 +11,723 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Weblate 2026.9.dev0\n"
+"X-Generator: Weblate 5.16-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Prieigos valdymas"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Papildomi konfigūravimai"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Papildomi nustatymai"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Leisti prievadus"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"„Leisti prievadus“ („AllowPorts“) – nurodo prievadų rinkinį, kuriuo klientai "
-"gali įgalioti į. Jei šios reikšmės ilgis yra – 0-is, tada visi prievadai yra "
-"leidžiami.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – tuščias "
-"rinkinys."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "„Assets“ katalogas/vietovė"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"„„Assets“ katalogas/vietovė“ („AssetsDir“) – nurodo vietinį/-ę katalogą/"
-"vietovę, prie kurio ataskaitų skydelis įkels išteklius. Jei ši reikšmė yra – "
-"„\"\"“, ištekliai bus įkeliami iš vykdomojo failo paketo naudojant – "
-"„statik“.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „\"\"“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autentifikavimas"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Pririšti adresą"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Pririšti prievadą"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"„Pririšti adresą“ („BindAddr“) – nurodo adresą, prie kurio prisiriša "
-"serveris.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „0.0.0.0“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"„Pririšti „KCP“ prievadą“ („BindKcpPort“) – nurodo „KCP“ prievadą, prie "
-"kurio serveris lauks prisijungimo/jungties ryšio. Jei ši reikšmė yra – 0-is, "
-"tada serveris nelauks prisijungimo/jungties ryšio, skirta „KCP“ ryšiams.<br /"
-">Pagal numatytuosius nustatymus, ši reikšmė yra – 0-is."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"„Pririšti prievadą“ („BindPort“) – nurodo prievadą, prie kurio serveris "
-"lauks prisijungimo/jungties ryšio.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – 7000-čiai."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"„BindQuicPort“ nurodo „QUIC“ prievadą, kuriuo serveris lauks prisijungimo/"
-"jungties ryšio ant. Jei ši reikšmė yra – 0-is, serveris nelauks „QUIC“ "
-"prisijungimo jungties ryšių. <br />Pagal numatytuosius nustatymus ši reikšmė "
-"yra – 0-is."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"„BindQuicPort“ nurodo „UDP“ prievadą, kuriuo serveris lauks prisijungimo/"
-"jungties ryšio ant. Jei ši reikšmė yra – 0-is, serveris nelauks „UDP“ "
-"prisijungimo jungties ryšių. <br />Pagal numatytuosius nustatymus ši reikšmė "
-"yra – 0-is."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Renkami duomenys..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Dažni nustatymai"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Konfigūracijos failai įtraukti į laikinąjį konfigūracijos failą"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Tipiniai nustatymai"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Pasirinktinis „404“ puslapis"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"„Pasirinktinis „404“ puslapis“ („Custom404Page“) – nurodo kelią į "
-"pasirinktinį „404“ puslapį, kurį reikia rodyti. Jei ši reikšmė yra – „\"\"“, "
-"tada bus rodomas numatytasis puslapis.<br />Pagal numatytuosius nustatymus, "
-"ši reikšmė yra – „\"\"“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"„TLS“ sertifikato ataskaitų skydelio failas nurodo kelią į - „TLS“ "
-"sertifikato failą, skirtas įjungiant/įgalinant „HTTPS“ prieigą. <br /"
-">Reikalingas, jei „HTTPS“ yra įjungtas/įgalintas."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"„TLS“ sertifikato ataskaitų skydelio raktas nurodo kelią į - privatų „TLS“ "
-"rakto failą , skirtas įjungiant/įgalinant „HTTPS“ prieigą. <br /"
-">Reikalingas, jei „HTTPS“ yra įjungtas/įgalintas."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "„TLS“ ataskaitų skydelio sertifikatas"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "„TLS“ ataskaitų skydelio veiksena"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "„TLS“ ataskaitų skydelio privatusis raktas"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Ataskaitų skydelio adresas"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Ataskaitų skydelio slaptažodis"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Ataskaitų skydelio prievadas"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Ataskaitų skydelio naudotojas/vartotojas"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"„Ataskaitų skydelio adresas“ („DashboardAddr“) – nurodo adresą, prie kurio "
-"ataskaitų skydelis yra pririštas į.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – „0.0.0.0“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"„Ataskaitų skydelio prievadas“ („DashboardPort“) – nurodo prievadą, prie "
-"kurio ataskaitų skydelis lauks prisijungimo/jungties ryšio. Jei ši reikšmė "
-"yra – 0-is, ataskaitų skydelis nebus paleistas.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – 0-is."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"„Ataskaitų skydelio slaptažodis“ („DashboardPwd“) – nurodo slaptažodį, kurį "
-"prietaisų skydelis naudos prisijungimui.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – „admin“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"„Ataskaitų skydelio naudotojas/vartotojas („DashboardUser“) – nurodo "
-"naudotojo/vartotojo vardą (t.y slapyvardį), prie kurio ataskaitų skydelis "
-"naudos prisijungimui.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – "
-"„admin“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Išjungti žurnalo spalvą"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"„Išjungti/Išgalinti žurnalo spalva/-ą“ („DisableLogColor“) – išjungia/"
-"išgalina žurnalo spalvas, kai – „LogWay == „console“, kai nustatyta į – "
-"„true“.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „false“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Išjungta/Neįgalinta (-s/-i)"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Įjungti/Įgalinti┃Išjungti/Išgalinti „TLS“ šifravimą ataskaitų skydelyje. Kai "
-"įjungtas/įgalintas, saugiam ryšiui yra naudojamas – „HTTPS“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Aplinkybių kintamumas"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Duoti prieigą prie „LuCI app frps“"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"„Širdies ritmo“ pasibaigusios užklausos laikas („HeartBeatTimeout“) – nurodo "
-"maksimalų laiką, per kurį reikia laukti „širdies plakimo“, prieš nutraukiant "
-"ryšį. Keisti šios reikšmės nėra rekomenduojama.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – 90-imt."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "„Širdies ritmo“ pasibaigusios užklausos laikas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Pririšti „KCP“ prievadą"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Žurnalo failas"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Žurnalo nustatymai"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Žurnalo lygis"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Maksimalus dienų žurnalinimas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Žurnalinti „stderr“"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Žurnalinti „stdout“"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"„Žurnalo failas“ („LogFile“) – nurodo failą, kuriame bus rašomi žurnalai. Ši "
-"reikšmė bus naudojama tik tada, jei – „LogWay“ bus nustatytas tinkamai.<br /"
-">Pagal numatytuosius nustatymus, ši reikšmė yra –„console“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"„Žurnalo lygis“ („LogLevel“) – nurodo minimalų žurnalo lygį. Tinkamos "
-"reikšmės yra – „trace“, „debug“, „info“, „warn“ ir „error“.<br />Pagal "
-"numatytuosius nustatymus, ši reikšmė yra – \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"„Žurnalo maksimalios dienos“ („LogMaxDays“) – nurodo žurnalo maksimalų dienų "
-"skaičių, kiek dienų reikia saugoti žurnalo informaciją prieš ištrinant. Tai "
-"yra naudojama tik tada, jei – „LogWay“ == „failas“.<br />Pagal numatytuosius "
-"nustatymus, ši reikšmė yra – 0-is."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Maksimalus prievadų skaičius klientui"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"„Maksimalūs prievadai, kiekvienam klientui“ („MaxPortsPerClient“) – nurodo "
-"maksimalų prievadų skaičių, į kurį vienas klientas gali įgalioti į. Jei ši "
-"vertė yra – 0-is, apribojimas nebus taikomas.<br />Pagal numatytuosius "
-"nustatymus ši, reikšmė yra – 0-is."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NEVEIKIA"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"„OS“ aplinkybės perduodamos „frp“ konfigūracijos failo šablonui, žr. %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Pririšti įgaliotojo adresą"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"„Įgaliotojo pririštas adresas“ („ProxyBindAddr“) – nurodo adresą, prie kurio "
-"įgaliotasis yra pririštas į. Ši reikšmė gali būti tokia pati kaip – "
-"„BindAddr“.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „0.0.0.0“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "„QUIC“ pririšimo prievadas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "VEIKIA"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Atkurti/Perjungti (vardžiuojamai: „Atgimti“), kai užstringa"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Vykdyti „daemon“ kaip grupę"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Vykdyti paslaugų teikimo sistema kaip naudotojas/vartotojas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Paleidimo nustatymai"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"„Subdomeno-srities skleidėjas/vedėjas“ („SubDomainHost) – nurodo domeną-"
-"sritį, kuris bus prijungtas prie subdomenų-sričių, kurių paprašė klientas, "
-"kai naudojamas – „Vhost“ įgaliojimas. Pavyzdžiui, jei ši vertė nustatyta į – "
-"„frps.com“, o klientas paprašė subdomeno-srities – „test“, gautas „URL“ – "
-"saitas, bus – „test.frps.com“.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – „\"\"“."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Subdomeno-srities skleidėjas/vedėjas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "„TCP“ tankintuvas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"„„TCP“ tankintuvas/-imas“ („TcpMux“) perjungia „TCP“ srauto tankinimą. Tai "
-"leidžia kelioms kliento užklausoms bendrinti vieną „TCP“ ryšį.<br />Pagal "
-"numatytuosius nustatymus, ši reikšmė yra – „true“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Šis sąrašas gali būti naudojamas nurodyti kai kuriuos papildomus parametrus, "
-"kurie nebuvo įtraukti į šį – „LuCI“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Žetonas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"„Žetonas“ (angl. „Token“) – nurodo prieigos teisių suteikiamą žetoną, kuris "
-"yra naudojamas autentifikuojant raktus, gautus iš klientų. Klientai turi "
-"turėti atitinkamą prieigos teisių suteikiamąjį žetoną, kad galėtų naudoti "
-"serverį.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – „\"\"“."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "„UDP“ pririštas prievadas"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "„Vhost HTTP“ prievadas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "„Vhost HTTP“ pasibaigusios užklausos laikas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "„Vhost HTTPS“ prievadas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"„„Vhost“, „HTTP“ prievadas“ („VhostHttpPort“) – nurodo prievadą, prie kurio "
-"serveris lauks prisijungimo/jungties ryšio, skirtoms „HTTP“, „Vhost“ "
-"užklausoms. Jei ši reikšmė yra – 0-is, serveris nelauks prisijungimo/"
-"jungties ryšio, „HTTP“ užklausų.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – 0-is."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"„„Vhost“, „HTTP“ pasibaigusios užklausos laikas“ („VhostHttpTimeout“) – "
-"nurodo „Vhost“, „HTTP“ serverio atsako antraštės pasibaigusios užklausos "
-"laiką, sekundėmis.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – 60-"
-"imt."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"„„Vhost“, „HTTPS“ prievadas“ – („VhostHttpsPort“) – nurodo prievadą, prie "
-"kurio serveris lauks prisijungimo/jungties ryšio , skirtoms „HTTPS“, „Vhost“ "
-"užklausoms. Jei ši reikšmė yra – 0-is, serveris nelauks prisijungimo/"
-"jungties ryšio, „HTTPS“ užklausų.<br />Pagal numatytuosius nustatymus, ši "
-"reikšmė yra – 0-is."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "„frp“ serveris"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "„OS“ aplinkybės yra perduodamos į – „frp“, skirtos konfigūracijos failo "
-#~ "šablonui, žr.: <a href=\"https://github.com/fatedier/frp#configuration-"
-#~ "file-template\">„frp README“</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "„Pririšti „UDP“ prievadą“ („BindUdpPort“) – nurodo „UDP“ prievadą, prie "
-#~ "kurio serveris lauks prisijungimo/jungties ryšio. Jei ši reikšmė yra – 0-"
-#~ "is, tada serveris nelauks prisijungimo/jungties ryšio, skirta „UDP“ "
-#~ "ryšiams.<br />Pagal numatytuosius nustatymus, ši reikšmė yra – 0-is"
+#~ msgid "Advanced"
+#~ msgstr "Pažangūs"

--- a/applications/luci-app-frps/po/mr/frps.po
+++ b/applications/luci-app-frps/po/mr/frps.po
@@ -10,378 +10,718 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "अतिरिक्त कॉन्फिगरेशन"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "अक्षम"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/ms/frps.po
+++ b/applications/luci-app-frps/po/ms/frps.po
@@ -10,378 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Konfig tambahan"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Authentifizierung"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Lanjutan"

--- a/applications/luci-app-frps/po/nb_NO/frps.po
+++ b/applications/luci-app-frps/po/nb_NO/frps.po
@@ -10,379 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.11-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Ytterligere oppsett"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Ytterligere innstillinger"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-#, fuzzy
-msgid "Allow ports"
-msgstr "Tillat porter"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
+msgid "Allow ports"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Godkjenning"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Bind-adresse"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Bind-port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Samler data …"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Avskrudd"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Loggingsnivå"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "Kjører ikke"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "KJØRER"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Kjør nisse som gruppe"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Kjør nisse som bruker"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Oppstartsinnstillinger"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Symbol"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Avansert"

--- a/applications/luci-app-frps/po/nl/frps.po
+++ b/applications/luci-app-frps/po/nl/frps.po
@@ -12,378 +12,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.15.1\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Toegangsbeheer"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Additionele configuraties"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Aanvullende instellingen"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Poorten toestaan"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Authenticatie"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
+msgstr "Bind poort"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr "Verzamelen gegevens ..."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Logboek instellingen"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
-msgstr ""
+msgstr "Logboek niveau"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
+msgstr "NIET ACTIEF"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-msgid "RUNNING"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
+msgid "RUNNING"
+msgstr "ACTIEF"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
-msgstr ""
+msgstr "Voer daemon uit als groep"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
+msgstr "Voer daemon uit als gebruiker"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
+msgstr "Token"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Geavanceerd"

--- a/applications/luci-app-frps/po/pl/frps.po
+++ b/applications/luci-app-frps/po/pl/frps.po
@@ -11,475 +11,721 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Kontrola dostępu"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Dodatkowe konfiguracje"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Dodatkowe ustawienia"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Zezwalaj na porty"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts określa zestaw portów, do których klienty są w stanie się "
-"zwracać. Jeśli długość tej wartości wynosi 0, wszystkie porty są dozwolone."
-"<br />Domyślnie jest to pusty zestaw."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Katalog zasobów"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir określa katalog lokalny, z którego serwer administracyjny będzie "
-"ładował zasoby. Jeśli ta wartość to \"\", zasoby zostaną załadowane z "
-"pakietu wykonywalnego przy użyciu statik. <br />Domyślnie ta wartość to \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Uwierzytelnienie"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Adres wiązania"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Port wiązania"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr określa adres, z którym serwer powinien zostać powiązany.<br /"
-">Domyślnie jest to wartość \"127.0.0.1\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort określa port KCP, na którym nasłuchuje serwer. Jeśli ta wartość "
-"wynosi 0, serwer nie będzie nasłuchiwał połączeń KCP.<br />Domyślnie ta "
-"wartość wynosi 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort określa port, na którym nasłuchuje serwer.<br />Domyślnie ta "
-"wartość to 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort określa port QUIC, na którym nasłuchuje serwer. Jeśli ta "
-"wartość wynosi 0, serwer nie będzie nasłuchiwał połączeń QUIC.<br /"
-">Domyślnie ta wartość to 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort określa port UDP, na którym nasłuchuje serwer. Jeśli ta wartość "
-"wynosi 0, serwer nie będzie nasłuchiwał połączeń UDP.<br />Domyślnie ta "
-"wartość to 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Zbieranie danych..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Wspólne ustawienia"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Pliki konfiguracyjne znajdują się w tymczasowym pliku konfiguracyjnym"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Niestandardowa strona 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page określa ścieżkę do niestandardowej strony 404 do wyświetlenia. "
-"Jeśli ta wartość to \"\", zostanie wyświetlona strona domyślna.<br /"
-">Domyślnie ta wartość to \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Plik certyfikatu TLS pulpitu nawigacyjnego określa ścieżkę do pliku "
-"certyfikatu TLS umożliwiającego dostęp HTTPS.<br />Wymagane, jeśli włączono "
-"protokół HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Plik klucza TLS pulpitu nawigacyjnego określa ścieżkę do pliku prywatnego "
-"klucza TLS umożliwiającego dostęp HTTPS.<br />Wymagane, jeśli włączono "
-"protokół HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Certyfikat TLS pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Tryb TLS pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Klucz prywatny TLS pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Adres pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Hasło pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Port pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Użytkownik pulpitu nawigacyjnego"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr określa adres, z którym łączy się pulpit nawigacyjny.<br /"
-">Domyślnie ta wartość to \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort określa port, na którym nasłuchuje pulpit nawigacyjny. Jeśli "
-"ta wartość wynosi 0, pulpit nawigacyjny nie zostanie uruchomiony. <br /"
-">Domyślnie ta wartość wynosi 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd określa hasło, które będzie używane przez pulpit nawigacyjny do "
-"logowania.<br />Domyślnie ta wartość to \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser określa nazwę użytkownika, którą pulpit nawigacyjny będzie "
-"używał do logowania.<br />Domyślnie ta wartość to \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Wyłącz kolor dziennika"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor wyłącza kolory dzienników, gdy LogWay == \"console\" jest "
-"ustawiona na \"true\".<br />Domyślnie jest to wartość \"false\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Włącz lub wyłącz szyfrowanie TLS dla pulpitu nawigacyjnego. Po włączeniu "
-"protokół HTTPS będzie używany do bezpiecznej komunikacji."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Zmienna środowiskowa"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Udziel dostępu do aplikacji LuCI frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout określa maksymalne dozwolone opóźnienie odpowiedzi przed "
-"zakończeniem połączenia. Nie zaleca się zmiany tej wartości. <br />Domyśl ta "
-"wartość wynosi 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Limit czasu pulsu"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Port wiązania KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Plik dziennika"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Ustawienia dziennika"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Poziom rejestrowania"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Maks. dni logowania"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Dziennik stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Dziennik stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile określa plik, w którym będą zapisywane dzienniki. Ta wartość będzie "
-"używana tylko wtedy, gdy LogWay zostanie odpowiednio ustawiony.<br /"
-">Domyślnie ta wartość to \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel określa minimalny poziom dziennika. Poprawne wartości to \"trace\", "
-"\"debug\", \"info\", \"warn\" i \"error\".<br />Domyślnie jest to \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays określa maksymalną liczbę dni przechowywania informacji dziennika "
-"przed usunięciem. Jest używana tylko wtedy, gdy LogWay == \"file\".<br /"
-">Domyślnie ta wartość wynosi 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Maksymalna liczba portów na klienta"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient określa maksymalną liczbę portów, do których pojedynczy "
-"klient może się podłączyć. Jeśli ta wartość wynosi 0, nie zostanie "
-"zastosowany żaden limit. <br />Domyślnie ta wartość wynosi 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NIEURUCHOMIONE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"Przekazanie środowiska systemu operacyjnego do frp w celu uzyskania szablonu "
-"pliku konfiguracyjnego, zobacz %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Adres powiązania proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr określa adres, z którym łączy się serwer proxy. Ta wartość "
-"może być taka sama jak BindAddr.<br />Domyślnie ta wartość to \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Port wiązania QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "URUCHOMIONE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Odradzaj się po awarii"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Uruchom demona jako grupę"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Uruchom demona jako użytkownik"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Ustawienia uruchamiania"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost określa domenę, która zostanie dołączona do subdomen żądanych "
-"przez klienta podczas korzystania z proxy Vhost. Na przykład jeśli ta "
-"wartość jest ustawiona na \"frps.com\", a klient zażąda poddomeny \"test\", "
-"wynikowy adres URL to \"test.frps.com\".<br />Domyślnie ta wartość to \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Host subdomeny"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "Mux TCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux przełącza multipleksowanie strumienia TCP. Pozwala to na "
-"współdzielenie wielu żądań od klienta na jedno połączenie TCP.<br /"
-">Domyślnie wartość to \"true\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Ta lista może służyć do określenia dodatkowych parametrów, które nie zostały "
-"uwzględnione w tym LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token określa token autoryzacji używany do uwierzytelniania kluczy "
-"otrzymanych od klientów. Klienty muszą mieć pasujący token, aby móc "
-"korzystać z serwera.<br />Domyślnie ta wartość to \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Port wiązania UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Port Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Limit czasu Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Port Vhost HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort określa port, na którym serwer nasłuchuje żądań Vhost HTTP. "
-"Jeśli ta wartość wynosi 0, serwer nie będzie nasłuchiwał żądań HTTP.<br /"
-">Domyślnie ta wartość wynosi 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout określa limit czasu nagłówka odpowiedzi dla serwera Vhost "
-"HTTP, w sekundach.<br />Domyślnie ta wartość wynosi 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort określa port, na którym serwer nasłuchuje żądań Vhost HTTPS. "
-"Jeśli ta wartość wynosi 0, serwer nie będzie nasłuchiwał żądań HTTPS.<br /"
-">Domyślnie ta wartość wynosi 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Serwer frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Środowiska systemu operacyjnego przechodzą do frp w celu uzyskania "
-#~ "szablonu pliku konfiguracyjnego, patrz <a href=\"https://github.com/"
-#~ "fatedier/frp#configuration-file-template\"> frp README </a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort określa port UDP, na którym nasłuchuje serwer. Jeśli ta "
-#~ "wartość wynosi 0, serwer nie będzie nasłuchiwał połączeń UDP. <br /> "
-#~ "Domyślnie ta wartość wynosi 0"
+#~ msgid "Advanced"
+#~ msgstr "Zaawansowane"

--- a/applications/luci-app-frps/po/pt/frps.po
+++ b/applications/luci-app-frps/po/pt/frps.po
@@ -10,477 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.5.dev0\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Controle de Acesso"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Configurações adicionais"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Permitir portas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"O AllowPorts determina um conjunto de portas às quais os clientes podem "
-"fazer proxy. Se o comprimento deste valor for 0, todas as portas serão "
-"permitidas. <br />O valor predefinido é um conjunto vazio."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Diretório de ativos"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir determina um diretório local de onde o painel carregará recursos. "
-"Se o valor for \"\", os ativos serão carregados do que estiver embutido no "
-"executável usando o statik. <br />O valor predefinido é \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Endereço de ligação"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Porta do BIND"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr determina o endereço ao qual o servidor se ligará. <br />O valor "
-"predefinido é \"0,0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort determina a porta KCP na qual o servidor escuta. Se esse valor "
-"for 0, o servidor não atenderá às conexões KCP. <br /> O valor predefinido é "
-"0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort determina a porta no qual o servidor escuta.<br />O valor "
-"predefinido é 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort determina a porta QUIC na qual o servidor escuta. Se este valor "
-"for 0, o servidor não atenderá às conexões QUIC. <br /> O valor predefinido "
-"é 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort determina a porta UDP em que o servidor atende. Se este valor "
-"for 0, o servidor não atenderá às conexões UDP. <br />O valor predefinido é "
-"0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "A coletar dados..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Configurações Comuns"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
 msgstr ""
-"Ficheiros de configuração incluídos no ficheiro de configuração temporário"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Página personalizada de 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page determina um caminho para uma página 404 personalizada. Se "
-"esse valor for \"\", uma página predefinida será exibida. <br /> O valor "
-"predefinido é \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"O ficheiro do cert TLS do painel de controlo especifica o caminho ao "
-"ficheiro de certificado TLS para ativar o acesso por HTTPS.<br />Requerido "
-"se o HTTPS estiver ativado."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"O ficheiro da chave TLS do painel de controlo especifica o caminho ao "
-"ficheiro da chave privada do TLS para ativar o acesso por HTTPS.<br />"
-"Requerido se o HTTPS estiver ativado."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Certificado de painel TLS"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Modo TLS de painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Chave privada do TLS de painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Endereço do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Palavra-passe do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Porta do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Utilizador do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr determina o endereço que será ligado ao painel. <br /> O valor "
-"predefinido é \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort determina a porta que o painel atende. Se esse valor for 0, o "
-"painel não será iniciado. <br /> O valor predefinido é 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd determina a palavra-passe que o painel usará para se "
-"autenticar. <br />O valor predefinido é \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"O DashboardUser determina o nome de ustilizador que o painel usará para se "
-"autenticar. <br />O valor predefinido é \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Desativar cores nos registos"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor desativa as cores no registo quando logWay == \"console\" "
-"quando for definido como verdadeiro. <br />O valor predefinido é falso."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Desativado"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Ativar ou desativar a criptografia TLS para o painel. Quando ativado, HTTPS "
-"é usado para comunicação segura."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Variável de ambiente"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Conceder acesso à app frps do LuCI"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout determina o tempo máximo para esperar heartbeat antes de "
-"encerrar a conexão. Não é recomendável alterar este valor. <br />O valor "
-"predefinido é 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Tempo limite do heartbeat"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Porta de ligação KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Ficheiro de registo"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Configurações do registo"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Nível de registo"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Máximo de dias de registo"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Regisro do stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Registo do stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"O LogFile especifica um ficheiro onde os registos serão escritos. Este valor "
-"só será usado se o LogWay for definido apropriadamente.<br />Por "
-"predefinição, este valor é \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"O LogLevel determina o nível mínimo de registo. Valores válidos são "
-"\"trace\", \"debug\", \"info\", \"warn\" e \"error\". <br />O valor "
-"predefinido é \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays especifica a quantidade máxima de dias para armazenar informações "
-"de registo antes de apagar. Isto só é usado se LogWay == \"file\".<br />Por "
-"predefinição, este valor é 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Máximo de portas por cliente"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient especifica o quantidade máxima de portas para as quais um "
-"único cliente pode ser proxz. Se este valor for 0, nenhum limite será "
-"aplicado.<br />Por defeito, este valor é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NÃO EM EXECUÇÃO"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"Os ambientes do sistema operativo passam para frp para o modelo de ficheiros "
-"de configuração, veja %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Endereço de ligação proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr determina o endereço onde o proxy será ligado. Este valor pode "
-"ser o mesmo que BindAddr. <br />O valor predefinido é \"0,0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Porta de ligação QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "EXECUTADO"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Reiniciar caso travado"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Executar daemon como grupo"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Executar serviço como utilizador"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Configurações de inicialização"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost determina o domínio que será anexado aos subdomínios "
-"solicitados pelo cliente durante ligações proxy Vhost. Por exemplo, se este "
-"valor for definido como \"frps.com\" e o cliente solicitou o \"teste\" do "
-"subdomínio, a URL resultante será \"test.frps.com\". <br />O valor "
-"predefinido é \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Host de subdomínio"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux alterna a multiplexação do fluxo TCP. Isso permite que várias "
-"solicitações de um cliente compartilhem uma única ligação TCP.<br />O valor "
-"predefinido é verdadeiro."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Esta lista pode ser usada para definir parâmetros adicionais que não estavam "
-"incluídos neste LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Chave eletrónica"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"O token determina o token de autorização usado para autenticar as chaves "
-"recebidas dos clientes. Os clientes devem ter um token correspondente que "
-"autorize o uso no servidor.<br />O valor predefinido é \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Ligação de porta UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Porta Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Tempo limite Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Porta Vhost HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort determina a porta no qual o servidor escuta por solicitações "
-"HTTP Vhost. Se esse valor for 0, o servidor não atenderá solicitações http. "
-"<br />O valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout determina o tempo em segundos do intervalo do cabeçalho de "
-"resposta para o servidor Vhost HTTP. <br />O valor predefinido é 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort determina a porta na qual o servidor escuta por solicitações "
-"HTTPS Vhost. Se esse valor for 0, o servidor não atenderá solicitações "
-"https. <br />O valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Servidor frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "As variáveis de ambiente do sistema operacional passam para o frp como "
-#~ "modelo de configuração, veja <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort determina a porta UDP em que o servidor atende. Se esse valor "
-#~ "for 0, o servidor não atenderá às conexões UDP. <br />O valor predefinido "
-#~ "é 0"
+#~ msgid "Advanced"
+#~ msgstr "Avançado"

--- a/applications/luci-app-frps/po/pt_BR/frps.po
+++ b/applications/luci-app-frps/po/pt_BR/frps.po
@@ -10,461 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Controle de acesso"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Configurações adicionais"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Permitir portas"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"O AllowPorts determina um conjunto de portas às quais os clientes podem "
-"fazer proxy. Se o comprimento deste valor for 0, todas as portas serão "
-"permitidas. <br />O valor predefinido é um conjunto vazio."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Diretório de ativos"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir determina um diretório local de onde o painel carregará recursos. "
-"Se o valor for \"\", os ativos serão carregados do que estiver embutido no "
-"executável usando o statik. <br />O valor predefinido é \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Vincular endereço"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Porta Bind"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr determina o endereço ao qual o servidor se vinculará. <br />O valor "
-"predefinido é \"0,0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort determina a porta KCP na qual o servidor escuta. Se esse valor "
-"for 0, o servidor não atenderá às conexões KCP.<br />O valor predefinido é 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort determina a porta em que o servidor atende.<br />O valor "
-"predefinido é 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Coletando dados..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Configurações Comuns"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
 msgstr ""
-"Arquivos de configuração incluídos no arquivo de configuração temporário"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Página personalizada de 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page determina um caminho para uma página 404 personalizada. Se "
-"esse valor for \"\", uma página padrão será exibida.<br />Por padrão, esse "
-"valor é \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Endereço do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Senha do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Porta do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Usuário do painel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr determina o endereço que será vinculado ao painel.<br />Por "
-"padrão, esse valor é \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort determina a porta que o painel atende. Se esse valor for 0, o "
-"painel não será iniciado.<br />Por padrão, esse valor é 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd determina a senha que o painel usará para se autenticar. <br /"
-">O valor predefinido é \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"O DashboardUser determina o nome de usuário que o painel usará para se "
-"autenticar. <br />O valor predefinido é \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Desativar cores nos registros de log"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"DisableLogColor desativa as cores no registro log quando logWay == "
-"\"console\" quando for definido como verdadeiro. <br />O valor predefinido é "
-"falso."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Desativado"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Variável de ambiente"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Conceda acesso UCI ao aplicativo LuCI frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout determina o tempo máximo para esperar heartbeat antes de "
-"encerrar a conexão. Não é recomendável alterar este valor. <br />O valor "
-"predefinido é 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Tempo limite do heartbeat"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Porta de vinculação KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Arquivo log"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Configurações do registro"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Nível do registro"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Registro máximo de dias"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Registro log do stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Registro log do stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"O LogFile especifica um arquivo onde os registro logs serão gravados. Este "
-"valor só será usado se o LogWay estiver configurado adequadamente.<br />Por "
-"padrão, esse valor é \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"O LogLevel determina o nível mínimo de registro no log. Valores válidos são "
-"\"trace\", \"debug\", \"info\", \"warn\" e \"error\". <br />O valor "
-"predefinido é \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays especifica a quantidade máxima de dias para armazenar informações "
-"do registro log antes da exclusão. Isso só é usado se LogWay == \"arquivo\"."
-"<br />Por padrão, este valor é 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Máximo de portas por cliente"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient determina o número máximo de portas que um único cliente "
-"pode se conectar. Se esse valor for 0, nenhum limite será imposto. <br />O "
-"valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NÃO ESTÁ EM EXECUÇÃO"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Endereço de vinculação proxy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr determina o endereço onde o proxy será vinculado. Este valor "
-"pode ser o mesmo que BindAddr. <br />O valor predefinido é \"0,0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Reiniciar caso entre em colapso"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Executar serviço como usuário"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Executar serviço como usuário"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Configurações de inicialização"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost determina o domínio que será anexado aos subdomínios "
-"solicitados pelo cliente durante conexões Vhost. Por exemplo, se este valor "
-"for definido como \"frps.com\" e o cliente solicitou o \"teste\" do "
-"subdomínio, a URL resultante será \"test.frps.com\". <br />O valor "
-"predefinido é \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Host de subdomínio"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux alterna a multiplexação do fluxo TCP. Isso permite que várias "
-"solicitações de um cliente compartilhem uma única conexão TCP.<br />O valor "
-"predefinido é verdadeiro."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Esta lista pode ser usada para definir alguns parâmetros adicionais que não "
-"foram incluídos neste LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"O token determina o token de autorização usado para autenticar as chaves "
-"recebidas dos clientes. Os clientes devem ter um token correspondente que "
-"autorize o uso no servidor.<br />O valor predefinido é \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Vinculação de porta UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Porta Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Tempo limite Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Porta Vhost HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort determina a porta que o servidor atende solicitações HTTP "
-"Vhost. Se esse valor for 0, o servidor não atenderá solicitações http. <br /"
-">O valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout determina o tempo em segundos do intervalo do cabeçalho de "
-"resposta para o servidor Vhost HTTP. <br />O valor predefinido é 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort determina a porta que o servidor atende solicitações HTTPS "
-"Vhost. Se esse valor for 0, o servidor não atenderá solicitações https. <br /"
-">O valor predefinido é 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Servidor frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "As variáveis de ambiente do sistema operacional passam para o frp como "
-#~ "modelo de configuração, veja <a href=\"https://github.com/fatedier/"
-#~ "frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort determina a porta UDP em que o servidor atende. Se esse valor "
-#~ "for 0, o servidor não atenderá às conexões UDP. <br />O valor predefinido "
-#~ "é 0"
+#~ msgid "Advanced"
+#~ msgstr "Avançada"

--- a/applications/luci-app-frps/po/ro/frps.po
+++ b/applications/luci-app-frps/po/ro/frps.po
@@ -7,470 +7,725 @@ msgstr ""
 "Language: ro\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : "
-"(n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 "X-Generator: Weblate 5.15-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Controlul Accesului"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Configurații suplimentare"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Setări adiționale"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Permite porturi"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"PermitePorturile specifică un set de porturi la care clienții se pot lega de "
-"la distanță. Dacă dimensiunea acestei valori este 0, toate porturile sunt "
-"permise.<br />Implicit, această valoare este o mulțime goală."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Directorul de resurse"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"DirectorulDeResurse specifică un director local din care tabloul de bord va "
-"încărca resurse. Dacă valoarea este \"\", resursele vor fi încărcate din "
-"executabilul împachetat cu statik.<br />Implicit, valoarea este \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autentificare"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Adresa de legătură"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Legați portul"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr specifică adresa la care se leagă serverul.<br />În mod implicit, "
-"această valoare este \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort specifică portul KCP pe care serverul ascultă. Dacă această "
-"valoare este 0, serverul nu va asculta conexiunile KCP.<br />În mod "
-"implicit, această valoare este 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort specifică portul pe care serverul ascultă.<br />În mod implicit, "
-"această valoare este 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Colectare date ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Setări comune"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Fișiere de configurare incluse în fișierul de configurare temporar"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Setări Comune"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Pagina 404 personalizată"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page specifică o cale către o pagină 404 personalizată care urmează "
-"să fie afișată. Dacă această valoare este \"\", va fi afișată o pagină "
-"implicită.<br />Din mod implicit, această valoare este \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Adresa tabloului de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Parola tabloului de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Port pentru tabloul de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Utilizatorul tabloului de bord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr specifică adresa la care se leagă tabloul de bord.<br />În mod "
-"implicit, această valoare este \"0.0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort specifică portul pe care ascultă tabloul de bord. Dacă această "
-"valoare este 0, tabloul de bord nu va fi pornit.<br />În mod implicit, "
-"această valoare este 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd specifică parola pe care tabloul de bord o va utiliza pentru "
-"autentificare.<br />În mod implicit, această valoare este \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser specifică numele de utilizator pe care tabloul de bord îl va "
-"utiliza pentru autentificare.<br />În mod implicit, această valoare este "
-"\"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Dezactivați culoarea jurnalului"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"DisableLogColor dezactivează culorile jurnalului atunci când LogWay == "
-"\"console\" este setat la true.<br />Prin definiția implicită, această "
-"valoare este falsă."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Variabila de mediu"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Acordarea accesului la aplicația LuCI frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout specifică timpul maxim de așteptare a unei bătăi de inimă "
-"înainte de a încheia conexiunea. Nu se recomandă modificarea acestei valori."
-"<br />În mod implicit, această valoare este 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Timpul limită a bătăilor inimii"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Port de legătură KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Fișier jurnal"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Setări jurnal"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Nivel de jurnal"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Jurnal maxim zile"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Jurnal stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Jurnal stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile specifică un fișier în care vor fi scrise jurnalele. Această valoare "
-"va fi utilizată numai dacă LogWay este setat în mod corespunzător.<br />În "
-"mod implicit, această valoare este \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel specifică nivelul minim al jurnalului. Valorile valabile sunt "
-"\"trace\", \"debug\", \"info\", \"warn\" și \"error\".<br />Prin definiție, "
-"această valoare este \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays specifică numărul maxim de zile de stocare a informațiilor din "
-"jurnal înainte de ștergere . Acest lucru se utilizează numai dacă LogWay == "
-"\"file\".<br />În mod implicit, această valoare este 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Porturi maxime pe client"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient specifică numărul maxim de porturi pe care un singur "
-"client le poate accesa prin proxy. Dacă această valoare este 0, nu se va "
-"aplica nicio limită.<br />În mod implicit, această valoare este 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "NU FUNCȚIONEAZĂ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Adresa de legare a proxy-ului"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr specifică adresa la care se leagă proxy-ul. Această valoare "
-"poate fi aceeași cu BindAddr.<br />În mod implicit, această valoare este "
-"\"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "Funcţionare"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Respawn când crapă"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Rularea daemonului ca grup"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Rulați daemonul ca utilizator"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Setări de pornire"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost specifică domeniul care va fi atașat la subdomeniile "
-"solicitate de client atunci când se utilizează proxy Vhost. De exemplu, dacă "
-"această valoare este setată la \"frps.com\", iar clientul a solicitat "
-"subdomeniul \"test\", URL-ul rezultat va fi \"test.frps.com\".<br />În mod "
-"implicit, această valoare este \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Gazda subdomeniului"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "Mux TCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux comută multiplexarea fluxurilor TCP. Acest lucru permite ca mai multe "
-"cereri de la un client să partajeze o singură conexiune TCP.<br />În mod "
-"implicit, această valoare este adevărată."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Această listă poate fi utilizată pentru a specifica anumiți parametri "
-"suplimentari care nu au fost incluși în acest LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token specifică tokenul de autorizare utilizat pentru a autentifica cheile "
-"primite de la clienți. Clienții trebuie să aibă un token corespunzător "
-"pentru a fi autorizați să utilizeze serverul.<br />În mod implicit, această "
-"valoare este \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Port de legătură UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Port HTTP Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Timpul de expirare HTTP Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Port HTTPS Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort specifică portul pe care serverul îl ascultă pentru cererile "
-"HTTP Vhost. Dacă această valoare este 0, serverul nu va asculta cererile "
-"HTTP.<br />În mod implicit, această valoare este 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout specifică timpul de așteptare al antetului de răspuns "
-"pentru serverul HTTP Vhost, în secunde.<br />Prin definiție, această valoare "
-"este 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort specifică portul pe care serverul îl ascultă pentru cererile "
-"HTTPS Vhost. Dacă această valoare este 0, serverul nu va asculta "
-"solicitările HTTPS.<br />În mod implicit, această valoare este 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Server frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Mediile sistemului de operare trec la frp pentru șablonul fișierului de "
-#~ "configurare, vezi <a href=\"https://github.com/fatedier/frp#configuration-"
-#~ "file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort specifică portul UDP pe care serverul ascultă. Dacă această "
-#~ "valoare este 0, serverul nu va asculta conexiuni UDP.<br />În mod "
-#~ "implicit, această valoare este 0"
+#~ msgid "Advanced"
+#~ msgstr "Avansat"

--- a/applications/luci-app-frps/po/ru/frps.po
+++ b/applications/luci-app-frps/po/ru/frps.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "PO-Revision-Date: 2026-04-22 23:36+0000\n"
-"Last-Translator: SnIPeRSnIPeR <snipersniper@users.noreply.hosted.weblate.org>"
-"\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsfrps/ru/>\n"
 "Language: ru\n"
@@ -12,474 +12,721 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Контроль доступа"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Дополнительные конфигурации"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Дополнительные настройки"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Разрешить порты"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts указывает набор портов, к которым клиенты могут подключаться "
-"через прокси. Если длина этого значения равна 0, все порты разрешены.<br /"
-">По умолчанию это значение - пустой набор."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Каталог ресурсов"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir указывает локальный каталог, из которого панель управления будет "
-"загружать ресурсы. Если это значение равно \"\", то ресурсы будут "
-"загружаться из исполняемого файла fprc с помощью statik (библиотека на Go "
-"для встраивания ресурсов).<br />По умолчанию это значение равно \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Аутентификация"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Адрес сервера"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Порт сервера"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr указывает адрес, к которому привязывается сервер.<br />По умолчанию "
-"это значение \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort указывает порт KCP, который прослушивает сервер. Если это "
-"значение равно 0, сервер не будет прослушивать KCP-соединения.<br />По "
-"умолчанию это значение равно 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort указывает порт, к которому привязывается сервер.<br />По умолчанию "
-"7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"Указывает порт для прослушивания QUIC-соединений. Если установлено 0, сервер "
-"не будет принимать QUIC-соединения.<br />По умолчанию: 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"Указывает порт для прослушивания UDP-соединений. Если установлено 0, сервер "
-"не будет принимать UDP-соединения.<br />По умолчанию: 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Сбор данных ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Конфигурационные настройки записаны во временный конфигурационный файл"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Своя страница 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page задаёт путь, к странице, которая будет показана вместе с кодом "
-"ответа 404. Если это значение равно \"\", будет показана страница по "
-"умолчанию.<br />По умолчанию это значение равно \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Путь к файлу TLS-сертификата для включения HTTPS-доступа к панели управления."
-"<br />Требуется при включении HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Путь к файлу приватного ключа TLS для включения HTTPS-доступа к панели "
-"управления.<br />Требуется при включении HTTPS."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "TLS-сертификат панели управления"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Режим TLS панели управления"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Приватный ключ TLS панели управления"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Адрес дашборда"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Пароль дашборда"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Порт дашборда"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Пользователь дашборда"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr указывает адрес, к которому привязывается дашборд.<br />По "
-"умолчанию это значение равно \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort указывает порт, к которому привязывается дашборд. Если это "
-"значение равно 0, дашборд не будет запущен.<br />По умолчанию это значение "
-"равно 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd указывает пароль, который необходимо ввести для доступа к "
-"дашборду.<br />По умолчанию это \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser указывает логин, который необходимо ввести для доступа к "
-"дашборду.<br />По умолчанию это \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Отключить цвета в журнале"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor отключает вывод цвета в журнале, если LogWay == \"console\"."
-"<br />По умолчанию флажок снят."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Отключено"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Включить шифрование TLS для панели управления. При включении используется "
-"безопасное HTTPS-соединение."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Переменные окружения"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Предоставить доступ к LuCI-приложению frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout указывает максимальное время ожидания пульса перед разрывом "
-"соединения. Не рекомендуется изменять это значение.<br />По умолчанию это "
-"значение равно 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Heartbeat тайм-аут"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Порт привязки KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Файл журнала"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Настройки журнала"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Уровень журналирования"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Хранить журнал (дней)"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Сохранять вывод stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Сохранять вывод stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile указывает файл, в который будут записываться журналы. Это значение "
-"будет использоваться только в том случае, если LogWay установлен "
-"соответствующим образом.<br />По умолчанию это значение равно \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel задаёт минимальный уровень журнала. Допустимые значения: \"trace\", "
-"\"debug\", \"info\", \"warn\" и \"error\".<br />По умолчанию это значение "
-"равно \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays определяет максимальное количество дней хранения информации "
-"журнала перед удалением. Это значение используется, только если LogWay == "
-"\"file\".<br />По умолчанию это значение равно 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Максимальное количество портов для одного клиента"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient определяет максимальное количество портов, к которым может "
-"проксировать один клиент. Если это значение равно 0, ограничение не "
-"применяется.<br />По умолчанию это значение равно 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
-msgstr "НЕ ЗАПУЩЕН"
+msgstr "НЕ ЗАПУЩЕНО"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
-msgstr "Переменные окружения ОС для шаблона конфигурации frp, см. %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Адрес привязки прокси-сервера"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr указывает адрес, к которому привязывается прокси. Это значение "
-"может быть таким же, как BindAddr.<br />По умолчанию это значение равно "
-"\"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Порт QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "ЗАПУЩЕН"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Перезапускаться после вылета"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Запуск демона от имени группы"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Запуск демона от имени пользователя"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Настройки запуска"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost определяет домен, который будет присоединен к поддоменам, "
-"запрашиваемым клиентом при использовании проксирования Vhost. Например, если "
-"это значение установлено в \"frps.com\", а клиент запросил поддомен "
-"\"test\", результирующий URL будет \"test.frps.com\".<br />По умолчанию это "
-"значение равно \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Зона для поддоменов"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP мультиплексор"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux включает мультиплексирование потока TCP. Это позволяет нескольким "
-"запросам от клиента использовать одно TCP-соединение.<br />По умолчанию это "
-"значение равно true."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Этот список может быть использован для указания некоторых дополнительных "
-"параметров, которые не были включены в данный LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Токен"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token указывает маркер авторизации, используемый для проверки подлинности "
-"ключей, полученных от клиентов. Клиенты должны иметь соответствующий токен, "
-"чтобы иметь право использовать сервер.<br />По умолчанию это значение равно "
-"\"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Порт привязки UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "HTTP-порт виртуального хоста"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Тайм-аут виртуального хоста HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "HTTPS-порт виртуального хоста"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort указывает порт, который сервер прослушивает для HTTP-запросов "
-"Vhost. Если это значение равно 0, сервер не будет прослушивать HTTP-запросы."
-"<br />По умолчанию это значение равно 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout указывает тайм-аут заголовка ответа для HTTP-сервера Vhost, "
-"в секундах.<br />По умолчанию это значение равно 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort указывает порт, который сервер прослушивает для запросов "
-"HTTPS Vhost. Если это значение равно 0, сервер не будет прослушивать запросы "
-"HTTPS.<br />По умолчанию это значение равно 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp сервер"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Переменные среды, передаваемые frp, используются для подстановки в "
-#~ "шаблоны в файле конфигурации. Подробнее читай в <a href=\"https://"
-#~ "github.com/fatedier/frp#using-environment-variables\">справке frp</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort указывает UDP-порт, к которому привязывается сервер. Если "
-#~ "значение равно 0, сервер не будет слушать UDP-соединения.<br />По "
-#~ "умолчанию это значение равно 0"
+#~ msgid "Advanced"
+#~ msgstr "Дополнительно"

--- a/applications/luci-app-frps/po/sk/frps.po
+++ b/applications/luci-app-frps/po/sk/frps.po
@@ -10,378 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Ďalšie konfigurácie"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Overenie totožnosti"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Zakázané"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Úroveň záznamu"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Pokročilé"

--- a/applications/luci-app-frps/po/sv/frps.po
+++ b/applications/luci-app-frps/po/sv/frps.po
@@ -8,451 +8,750 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.9.dev0\n"
+"X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Åtkomstkontroll"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Ytterligare konfigurationer"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Extra inställningar"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Tillåt portar"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts anger en uppsättning portar som klienter får proxyansluta till. "
-"Om värdets längd är 0 tillåts alla portar.<br />Som standard är värdet en "
-"tom uppsättning."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
-msgstr "Resurskatalog"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
 msgstr ""
-"AssetsDir anger den lokala katalog som instrumentpanelen läser in resurser "
-"från. Om värdet är ”” läses resurserna från den medföljande körbara filen "
-"med statik.<br />Som standard är värdet ””."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Autentisering"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Bindningsadress"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Bindningsport"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr "Samlar in data ..."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
 msgstr ""
 "BindAddr anger adressen som servern binds till.<br />Som standard är värdet ”"
 "0.0.0.0”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
 msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
 msgstr ""
 "BindKcpPort anger KCP-porten som servern lyssnar på. Om värdet är 0 lyssnar "
 "servern inte efter KCP-anslutningar.<br />Som standard är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Vanliga inställningar"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
 msgstr ""
 "BindPort anger porten som servern lyssnar på.<br />Som standard är värdet "
 "7000."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
 msgstr ""
 "BindQuicPort anger QUIC-porten som servern lyssnar på. Om värdet är 0 "
 "lyssnar servern inte efter QUIC-anslutningar.<br />Som standard är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
 msgstr ""
 "BindUdpPort anger UDP-porten som servern lyssnar på. Om värdet är 0 lyssnar "
 "servern inte efter UDP-anslutningar.<br />Som standard är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
-msgstr "Samlar in data ..."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Gemensamma inställningar"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
 msgstr ""
 "Konfigurationsfiler som inkluderas i den tillfälliga konfigurationsfilen"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
-msgstr "Anpassad 404-sida"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
 msgstr ""
-"Custom404Page anger sökvägen till en anpassad 404-sida som ska visas. Om "
-"värdet är ”” visas en standardsida.<br />Som standard är värdet ””."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Dashboard TLS Cert File anger sökvägen till TLS-certifikatfilen för att "
-"aktivera HTTPS-åtkomst.<br />Krävs om HTTPS är aktiverat."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
+msgid "Disable log color"
+msgstr "Inaktivera logg-färg"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
 "Dashboard TLS Key File anger sökvägen till filen med den privata TLS-nyckeln "
 "för att aktivera HTTPS-åtkomst.<br />Krävs om HTTPS är aktiverat."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Instrumentpanelens TLS-certifikat"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Instrumentpanelens TLS-läge"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Instrumentpanelens privata TLS-nyckel"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Instrumentpanelens adress"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Instrumentpanelens lösenord"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Instrumentpanelens port"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Instrumentpanelens användare"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
 msgstr ""
-"DashboardAddr anger adressen som instrumentpanelen binds till.<br />Som "
-"standard är värdet ”0.0.0.0”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
 msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
+msgid "Environment variable"
+msgstr "Miljövariabel"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
 msgstr ""
 "DashboardPort anger porten som instrumentpanelen lyssnar på. Om värdet är 0 "
 "startas inte instrumentpanelen.<br />Som standard är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
 msgstr ""
 "DashboardPwd anger lösenordet som instrumentpanelen använder för "
 "inloggning.<br />Som standard är värdet ”admin”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
 msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
 msgstr ""
 "DashboardUser anger användarnamnet som instrumentpanelen använder för "
 "inloggning.<br />Som standard är värdet ”admin”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid "Disable log color"
-msgstr "Inaktivera loggfärger"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
 msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
 msgstr ""
 "DisableLogColor inaktiverar loggfärger när LogWay == ”console” om värdet är "
 "true.<br />Som standard är värdet false."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
-"Aktivera eller inaktivera TLS-kryptering för instrumentpanelen. När den är "
-"aktiverad används HTTPS för säker kommunikation."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "Environment variable"
-msgstr "Miljövariabel"
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
-msgstr "Ge LuCI-appen frps åtkomst"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
 msgstr ""
-"HeartBeatTimeout anger den längsta tiden att vänta på ett heartbeat innan "
-"anslutningen avslutas. Det rekommenderas inte att ändra värdet.<br />Som "
-"standard är värdet 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
-msgstr "Tidsgräns för heartbeat"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP-bindningsport"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Loggfil"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Loggnivå"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
-msgstr "Högsta antal loggdagar"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Logga stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Logga stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile anger filen som loggar skrivs till. Värdet används endast om LogWay "
-"är korrekt inställt.<br />Som standard är värdet ”console”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
+msgid "Max ports per client"
 msgstr ""
-"LogLevel anger den lägsta loggningsnivån. Giltiga värden är ”trace”, ”debug"
-"”, ”info”, ”warn” och ”error”.<br />Som standard är värdet ”info”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
 msgstr ""
 "LogMaxDays anger det högsta antalet dagar som logginformation lagras innan "
 "den tas bort. Detta används endast om LogWay == ”file”.<br />Som standard är "
 "värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid "Max ports per client"
-msgstr "Högsta antal portar per klient"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
 msgstr ""
 "MaxPortsPerClient anger det högsta antalet portar som en enskild klient får "
 "proxyansluta till. Om värdet är 0 tillämpas ingen gräns.<br />Som standard "
 "är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "KÖRS INTE"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"OS-miljövariabler som skickas till frp för konfigurationsfilsmallen, se %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid "Proxy bind address"
-msgstr "Proxyns bindningsadress"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
 msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
 msgstr ""
-"ProxyBindAddr anger adressen som proxyn binds till. Värdet kan vara samma "
-"som BindAddr.<br />Som standard är värdet ”0.0.0.0”."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
+msgid "Proxy bind address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
-msgstr "QUIC-bindningsport"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "KÖRS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
-msgstr "Starta om efter krasch"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Kör demonen som grupp"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Kör demonen som användare"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Uppstartsinställningar"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"SubDomainHost anger domänen som läggs till underdomäner som klienten begär "
-"vid Vhost-proxying. Om värdet exempelvis är ”frps.com” och klienten begär "
-"underdomänen ”test” blir URL:en ”test.frps.com”.<br />Som standard är värdet "
-"””."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Inställningar för uppstart"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
-msgstr "Värd för underdomän"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
-msgstr "TCP-multiplexering"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
 msgstr ""
-"TcpMux aktiverar eller inaktiverar multiplexering av TCP-strömmar. Det gör "
-"att flera begäranden från en klient kan dela en enda TCP-anslutning.<br />"
-"Som standard är värdet true."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"Den här listan kan användas för att ange ytterligare parametrar som inte har "
-"tagits med i LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
-msgstr "Token"
+msgstr "Tecken"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Token anger den auktoriseringstoken som används för att autentisera nycklar "
-"från klienter. Klienterna måste ha en matchande token för att få använda "
-"servern.<br />Som standard är värdet ””."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP-bindningsport"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
-msgstr "Vhost HTTP-port"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
-msgstr "Tidsgräns för Vhost HTTP"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
-msgstr "Vhost HTTPS-port"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
 msgstr ""
-"VhostHttpPort anger porten som servern lyssnar på för HTTP Vhost-begäranden. "
-"Om värdet är 0 lyssnar servern inte efter HTTP-begäranden.<br />Som standard "
-"är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpTimeout anger tidsgränsen i sekunder för svarsrubriker från Vhost "
-"HTTP-servern.<br />Som standard är värdet 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpsPort anger porten som servern lyssnar på för HTTPS Vhost-"
-"begäranden. Om värdet är 0 lyssnar servern inte efter HTTPS-begäranden.<br />"
-"Som standard är värdet 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
-msgstr "frp-server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
+
+#~ msgid "Advanced"
+#~ msgstr "Avancerat"

--- a/applications/luci-app-frps/po/ta/frps.po
+++ b/applications/luci-app-frps/po/ta/frps.po
@@ -10,459 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "நுழைவு கட்டுப்பாடு"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "கூடுதல் உள்ளமைவுகள்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "கூடுதல் அமைப்புகள்"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "துறைமுகங்களை அனுமதிக்கவும்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"வாடிக்கையாளர்கள் பதிலாள் செய்யக்கூடிய துறைமுகங்களின் தொகுப்பைக் குறிப்பிடுகிறது. இந்த "
-"மதிப்பின் நீளம் 0 ஆக இருந்தால், அனைத்து துறைமுகங்களும் அனுமதிக்கப்படுகின்றன. <br /"
-">இயல்பாக, இந்த மதிப்பு வெற்று தொகுப்பு."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "சொத்துக்கள் டிர்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"டாச்போர்டு வளங்களை ஏற்றும் உள்ளக கோப்பகத்தை ASSETSDIR குறிப்பிடுகிறது. இந்த மதிப்பு "
-"\"\" என்றால், ச்டேட்டிக் பயன்படுத்தி தொகுக்கப்பட்ட இயங்கக்கூடியவற்றிலிருந்து சொத்துக்கள் "
-"ஏற்றப்படும். <br /> இயல்பாக, இந்த மதிப்பு \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "ஏற்பு"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "முகவரியை பிணைக்கவும்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "துறைமுகம் பிணைப்பு"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"சேவையகம் பிணைக்கும் முகவரியை BINDADDR குறிப்பிடுகிறது. <br /> இயல்பாக, இந்த மதிப்பு "
-"\"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"சேவையகம் கேட்கும் KCP போர்ட்டை BINDKCPPORT குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக "
-"இருந்தால், சேவையகம் KCP இணைப்புகளைக் கேட்காது. <br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"சேவையகம் கேட்கும் துறைமுகத்தை பிண்ட்போர்ட் குறிப்பிடுகிறது. <br /> இயல்பாக, இந்த மதிப்பு "
-"7000 ஆகும்."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "தரவு சேகரித்தல் ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "பொதுவான அமைப்புகள்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "கட்டமைப்பு கோப்புகள் தற்காலிக கட்டமைப்பு கோப்பில் அடங்கும்"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "தனிப்பயன் 404 பக்கம்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404 Page காண்பிக்க தனிப்பயன் 404 பக்கத்திற்கான பாதையை குறிப்பிடுகிறது. இந்த "
-"மதிப்பு \"\" என்றால், இயல்புநிலை பக்கம் காண்பிக்கப்படும். <br /> இயல்பாக, இந்த மதிப்பு "
-"\"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "டாச்போர்டு முகவரி"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "டாச்போர்டு கடவுச்சொல்"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "டாச்போர்டு துறைமுகம்"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "டாச்போர்டு பயனர்"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"டாச்போர்டுஆட்ர் டாச்போர்டு பிணைக்கும் முகவரியைக் குறிப்பிடுகிறார். <br /> இயல்பாக, இந்த "
-"மதிப்பு \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"டாச்போர்ட்போர்ட் டாச்போர்டு கேட்கும் துறைமுகத்தைக் குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக "
-"இருந்தால், டாச்போர்டு தொடங்கப்படாது. <br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"டாச்போர்டு பி.டபிள்யூ.டி உள்நுழைவுக்கு டாச்போர்டு பயன்படுத்தும் கடவுச்சொல்லைக் "
-"குறிப்பிடுகிறது. <br /> இயல்பாக, இந்த மதிப்பு \"நிர்வாகி\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"டாச்போர்டு யூசர் உள்நுழைவுக்கு டாச்போர்டு பயன்படுத்தும் பயனர்பெயரைக் குறிப்பிடுகிறது. "
-"<br /> இயல்பாக, இந்த மதிப்பு \"நிர்வாகி\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "பதிவு வண்ணத்தை முடக்கு"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"LOGCOLOR ஐ முடக்கு லாங்வே == \"கன்சோல்\" உண்மைக்கு அமைக்கும்போது வண்ணங்களை முடக்கு. "
-"<br /> இயல்பாக, இந்த மதிப்பு தவறானது."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "முடக்கப்பட்டது"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "சுற்றுச்சூழல் மாறி"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "லூசி பயன்பாட்டு FRP களுக்கு அணுகலை வழங்கவும்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"ஆர்ட் பீட் டைம்அவுட் இணைப்பை நிறுத்துவதற்கு முன்பு இதய துடிப்புக்காக காத்திருக்க அதிகபட்ச "
-"நேரத்தைக் குறிப்பிடுகிறது. இந்த மதிப்பை மாற்ற பரிந்துரைக்கப்படவில்லை. <br /> இயல்பாக, "
-"இந்த மதிப்பு 90 ஆகும்."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "இதய துடிப்பு நேரம் முடிந்தது"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP பிணைப்பு துறைமுகம்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "பதிவு கோப்பு"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "பதிவு அமைப்புகள்"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "பதிவு நிலை"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "பதிவு அதிகபட்ச நாட்கள்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "பதிவு நிலைபிழை"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "பதிவு நிலைவெளி"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"பதிவுகள் எழுதப்படும் ஒரு கோப்பை logfile குறிப்பிடுகிறது. உள்நுழைவு சரியான முறையில் "
-"அமைக்கப்பட்டால் மட்டுமே இந்த மதிப்பு பயன்படுத்தப்படும். <br /> இயல்பாக, இந்த மதிப்பு "
-"\"கன்சோல்\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"லோக்லெவல் குறைந்தபட்ச பதிவு அளவைக் குறிப்பிடுகிறது. செல்லுபடியாகும் மதிப்புகள் "
-"\"சுவடு\", \"பிழைத்திருத்த\", \"தகவல்\", \"எச்சரிக்கை\" மற்றும் \"பிழை\". <br /> "
-"இயல்பாக, இந்த மதிப்பு \"தகவல்\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"நீக்குவதற்கு முன் பதிவு தகவல்களை சேமிக்க அதிகபட்ச நாட்களின் எண்ணிக்கையை logmaxdays "
-"குறிப்பிடுகிறது. உள்நுழைவு == \"கோப்பு\" என்றால் மட்டுமே இது பயன்படுத்தப்படுகிறது. "
-"<br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "ஒரு வாடிக்கையாளருக்கு அதிகபட்ச துறைமுகங்கள்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"ஒரு கிளையன்ட் பதிலாள் செய்யக்கூடிய அதிகபட்ச துறைமுகங்களின் அதிகபட்ச எண்ணிக்கையைக் "
-"குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக இருந்தால், எந்த வரம்பும் பயன்படுத்தப்படாது. <br /> "
-"இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "ஓடவில்லை"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "பதிலாள் பிணைப்பு முகவரி"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"பதிலாள் பிண்டாட்.டி.ஆர் பதிலாள் பிணைக்கும் முகவரியைக் குறிப்பிடுகிறது. இந்த மதிப்பு "
-"பிண்டாட்ரைப் போலவே இருக்கலாம். <br /> இயல்பாக, இந்த மதிப்பு \"0.0.0.0\" ஆகும்."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "இயங்கும்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "செயலிழந்தபோது ரெச்பான்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "டீமனை குழுவாக இயக்கவும்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "டீமனை பயனராக இயக்கவும்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "தொடக்க அமைப்புகள்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"VHOST ப்ராக்சிங்கைப் பயன்படுத்தும்போது கிளையன்ட் கோரிய துணை களங்களுடன் இணைக்கப்படும் "
-"டொமைனை SUBDOMAINHOST குறிப்பிடுகிறது. எடுத்துக்காட்டாக, இந்த மதிப்பு \"frps.com\" "
-"என அமைக்கப்பட்டால், வாடிக்கையாளர் துணை டொமைன் \"சோதனை\" என்று கோரியால், இதன் விளைவாக "
-"வரும் முகவரி \"Test.frps.com\" ஆக இருக்கும். <br />இயல்பாக, இந்த மதிப்பு \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "துணை டொமைன் புரவலன்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP MUX"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TCPMUX TCP ச்ட்ரீம் மல்டிபிளெக்சிங்கை மாற்றுகிறது. இது ஒரு வாடிக்கையாளரிடமிருந்து பல "
-"கோரிக்கைகளை ஒற்றை TCP இணைப்பைப் பகிர அனுமதிக்கிறது. <br /> இயல்பாக, இந்த மதிப்பு "
-"உண்மை."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"இந்த லூசியில் சேர்க்கப்படாத சில கூடுதல் அளவுருக்களைக் குறிப்பிட இந்த பட்டியல் "
-"பயன்படுத்தப்படலாம்."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "கிள்ளாக்கு"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"வாடிக்கையாளர்களிடமிருந்து பெறப்பட்ட விசைகளை அங்கீகரிக்க பயன்படுத்தப்படும் அங்கீகார "
-"கிள்ளாக்கை கிள்ளாக்கு குறிப்பிடுகிறது. சேவையகத்தைப் பயன்படுத்த ஏற்பு பெற "
-"வாடிக்கையாளர்களுக்கு பொருந்தக்கூடிய கிள்ளாக்கு இருக்க வேண்டும். <br /> இயல்பாக, இந்த "
-"மதிப்பு \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "யுடிபி பிணைப்பு துறைமுகம்"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost http துறைமுகம்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Vhost http நேரம் முடிந்தது"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Vhost https துறைமுகம்"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"HTTP VHOST கோரிக்கைகளுக்கு சேவையகம் கேட்கும் துறைமுகத்தை vhosthttpport "
-"குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக இருந்தால், சேவையகம் HTTP கோரிக்கைகளை கேட்காது. "
-"<br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VHOSTHTTPTIMEOUT, VHOST HTTP சேவையகத்திற்கான மறுமொழி தலைப்பு நேரத்தை நொடிகளில் "
-"குறிப்பிடுகிறது. <br /> இயல்பாக, இந்த மதிப்பு 60 ஆகும்."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"HTTPS VHOST கோரிக்கைகளுக்கு சேவையகம் கேட்கும் துறைமுகத்தை vhosthttpsport "
-"குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக இருந்தால், சேவையகம் HTTPS கோரிக்கைகளை கேட்காது. "
-"<br /> இயல்பாக, இந்த மதிப்பு 0 ஆகும்."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "FRP சேவையகம்"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "OS சூழல்கள் கட்டமைப்பு கோப்பு வார்ப்புருவுக்கு FRP க்கு அனுப்பப்படுகின்றன, <a href = "
-#~ "\"https://github.com/fatedier/frp#configuration-file-template\"> frp "
-#~ "ReadMe </a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "சேவையகம் கேட்கும் யுடிபி போர்ட்டை பிண்டுட்போர்ட் குறிப்பிடுகிறது. இந்த மதிப்பு 0 ஆக "
-#~ "இருந்தால், சேவையகம் யுடிபி இணைப்புகளைக் கேட்காது. <br /> இயல்பாக, இந்த மதிப்பு 0 "
-#~ "ஆகும்"
+#~ msgid "Advanced"
+#~ msgstr "மேம்பட்ட"

--- a/applications/luci-app-frps/po/templates/frps.pot
+++ b/applications/luci-app-frps/po/templates/frps.pot
@@ -1,378 +1,718 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid "Bind address"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid "Bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
-msgid "Collecting data ..."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
 msgstr ""
 
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+msgid "Bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
+msgid "Bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
+msgid "Collecting data ..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
 msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
 msgstr ""

--- a/applications/luci-app-frps/po/tr/frps.po
+++ b/applications/luci-app-frps/po/tr/frps.po
@@ -10,463 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Erişim Kontrolü"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Ek yapılandırmalar"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Ek ayarlar"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Bağlantı noktalarına izin ver"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts, istemcilerin proxy yapabildiği bir dizi bağlantı noktasını "
-"belirtir. Bu değerin uzunluğu 0 ise, tüm bağlantı noktalarına izin verilir. "
-"<br /> Varsayılan olarak, bu değer boş bir kümedir."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Varlıklar dizini"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir, panonun kaynakları yükleyeceği yerel dizini belirtir. Bu değer "
-"\"\" ise, varlıklar statik kullanılarak paketlenmiş yürütülebilir dosyadan "
-"yüklenecektir. <br /> Varsayılan olarak bu değer \"\" şeklindedir."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Kimlik Doğrulama"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Bağlantı adresi"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Porta bağla"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr, sunucunun bağlandığı adresi belirtir. <br /> Varsayılan olarak bu "
-"değer \"0.0.0.0\" dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort, sunucunun dinlediği KCP bağlantı noktasını belirtir. Bu değer 0 "
-"ise, sunucu KCP bağlantılarını dinlemez. <br /> Varsayılan olarak bu değer "
-"0'dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort, sunucunun dinlediği bağlantı noktasını belirtir. <br /> Varsayılan "
-"olarak bu değer 7000'dir."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Veri toplama ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Genel Ayarlar"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Yapılandırma dosyaları, geçici yapılandırma dosyasına dahil edilir"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Ortak Ayarlar"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Özel 404 sayfası"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page, görüntülenecek özel bir 404 sayfasına giden yolu belirtir. Bu "
-"değer \"\" ise, varsayılan bir sayfa görüntülenecektir. <br /> Varsayılan "
-"olarak bu değer \"\" dir."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Kontrol paneli adresi"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Kontrol paneli şifresi"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Kontrol paneli bağlantı noktası"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Kontrol paneli kullanıcısı"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr, panonun bağlandığı adresi belirtir. <br /> Varsayılan olarak "
-"bu değer \"0.0.0.0\" dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort, panonun dinlediği bağlantı noktasını belirtir. Bu değer 0 "
-"ise, gösterge tablosu başlatılmayacaktır. <br /> Varsayılan olarak bu değer "
-"0'dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd, kontrol panelinin oturum açmak için kullanacağı parolayı "
-"belirtir. <br /> Varsayılan olarak bu değer \"admin\" dir."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser, kontrol panelinin oturum açmak için kullanacağı kullanıcı "
-"adını belirtir. <br /> Varsayılan olarak bu değer \"admin\" dir."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Günlük renklerini devre dışı bırak"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"DisableLogColor, doğru olarak ayarlandığında LogWay == \"console\" olduğunda "
-"günlük renklerini devre dışı bırakır. <br /> Varsayılan olarak bu değer "
-"yanlıştır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Çevre değişkeni"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "LuCI uygulaması frps'ye erişim izni verin"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout, bağlantıyı sonlandırmadan önce bir kalp atışı için "
-"beklenecek maksimum süreyi belirtir. Bu değerin değiştirilmesi önerilmez. "
-"<br /> Varsayılan olarak bu değer 90'dır."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Heartbeat zaman aşımı"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP bağlama bağlantı noktası"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Günlük dosyası"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Günlük Ayarları"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Günlük seviyesi"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Maksimum günleri günlüğe kaydet"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Stderr'i günlüğe kaydet"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Stdout'u günlüğe kaydet"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile günlüklerin yazılacağı dosyayı belirtir. Bu değer yalnızca LogWay "
-"doğru bir şekilde ayarlanmışsa kullanılacaktır.<br />Varsayılan olarak bu "
-"değer \"console\" şeklindedir."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel, minimum günlük seviyesini belirtir. Geçerli değerler \"trace\", "
-"\"debug\", \"info\", \"warn\" ve \"error\" dir.<br />Varsayılan olarak bu "
-"değer \"info\" dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays, günlük bilgilerinin silinmeden önce saklanacağı maksimum gün "
-"sayısını belirtir. Bu yalnızca LogWay == \"file\" ise kullanılır.<br /"
-">Varsayılan olarak bu değer 0'dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "İstemci başına maksimum bağlantı noktası"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient, tek bir istemcinin proxy yapabileceği maksimum bağlantı "
-"noktası sayısını belirtir. Bu değer 0 ise sınır uygulanmaz. <br /> "
-"Varsayılan olarak bu değer 0'dır."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "ÇALIŞMIYOR"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Proxy bağlama adresi"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr, proxy'nin bağlandığı adresi belirtir. Bu değer BindAddr ile "
-"aynı olabilir. <br /> Varsayılan olarak bu değer \"0.0.0.0\" dır."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "ÇALIŞIYOR"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Çöktüğünde yeniden çıkart"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Arka plan programı grup olarak çalıştır"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Arka plan programı kullanıcı olarak çalıştır"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
-msgstr "Başlangıç ayarları"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
 msgstr ""
-"SubDomainHost, Vhost proxy kullanılırken istemci tarafından talep edilen alt "
-"etki alanlarına eklenecek etki alanını belirtir. Örneğin, bu değer "
-"\"frps.com\" olarak ayarlanırsa ve müşteri alt alan adı \"test\" isterse, "
-"sonuçta ortaya çıkan URL \"test.frps.com\" olur. <br /> Varsayılan olarak bu "
-"değer \"\" olur."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
+msgstr "Başlangıç Ayarları"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Alt alan adı barındırıcısı"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux, TCP akış çoklamasını değiştirir. Bu, bir istemciden gelen birden çok "
-"isteğin tek bir TCP bağlantısını paylaşmasına izin verir. <br /> Varsayılan "
-"olarak bu değer doğrudur."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Bu liste, bu LuCI'ye dahil edilmemiş bazı ek parametreleri belirtmek için "
-"kullanılabilir."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Belirteç, istemcilerden alınan anahtarların kimliğini doğrulamak için "
-"kullanılan yetkilendirme jetonunu belirtir. İstemcilerin sunucuyu kullanma "
-"yetkisine sahip olmaları için eşleşen bir jetona sahip olmaları gerekir. "
-"<br /> Varsayılan olarak bu değer \"\" şeklindedir."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP bağlama bağlantı noktası"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost HTTP bağlantı noktası"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Vhost HTTP zaman aşımı"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Vhost HTTPS bağlantı noktası"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort, sunucunun HTTP Vhost isteklerini dinlediği bağlantı noktasını "
-"belirtir. Bu değer 0 ise, sunucu HTTP isteklerini dinlemeyecektir. <br /> "
-"Varsayılan olarak bu değer 0'dır."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout, Vhost HTTP sunucusu için saniye cinsinden yanıt başlığı "
-"zaman aşımını belirtir. <br /> Varsayılan olarak bu değer 60'tır."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort, sunucunun HTTPS Vhost isteklerini dinlediği bağlantı "
-"noktasını belirtir. Bu değer 0 ise, sunucu HTTPS isteklerini dinlemez. <br /"
-"> Varsayılan olarak bu değer 0'dır."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp Sunucusu"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "İşletim sistemi ortamları, yapılandırma dosyası şablonu için frp'ye "
-#~ "geçer, bkz. <a href=\"https://github.com/fatedier/frp#configuration-file-"
-#~ "template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort, sunucunun dinlediği UDP bağlantı noktasını belirtir. Bu "
-#~ "değer 0 ise, sunucu UDP bağlantılarını dinlemez. <br /> Varsayılan olarak "
-#~ "bu değer 0'dır"
+#~ msgid "Advanced"
+#~ msgstr "Gelişmiş"

--- a/applications/luci-app-frps/po/uk/frps.po
+++ b/applications/luci-app-frps/po/uk/frps.po
@@ -11,474 +11,721 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.5-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Контроль доступу"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Додаткові параметри"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Додаткові налаштування"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Дозволені порти"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts визначає набір портів, до яких клієнти можуть використовувати "
-"проксі. Якщо довжина цього значення дорівнює 0, усі порти дозволені.<br />"
-"Типово це значення — порожній набір."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Каталог ресурсів"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir визначає локальний каталог, з якого інформаційна панель "
-"завантажуватиме ресурси. Якщо це значення дорівнює \"\", ресурси будуть "
-"завантажені з пакетного виконуваного файлу за допомогою statik.<br />Типово "
-"це значення — \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Автентифікація"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "Адреса привʼязки"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Порт привʼязки"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr визначає адресу, до якої привʼязується сервер.<br />Типово це "
-"значення — «0.0.0.0»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort визначає порт KCP, який прослуховує сервер. Якщо це значення "
-"дорівнює 0, сервер не прослуховуватиме підключення KCP.<br />Типово це "
-"значення — 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort визначає порт, який прослуховує сервер.<br />Типово це значення — "
-"7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort визначає порт QUIC, який прослуховує сервер. Якщо це значення "
-"дорівнює 0, сервер не прослуховуватиме зʼєднання QUIC.<br />Типово це "
-"значення — 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort визначає порт UDP, який прослуховує сервер. Якщо це значення "
-"дорівнює 0, сервер не прослуховуватиме UDP-зʼєднання.<br />Типово це "
-"значення — 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Збір даних…"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "Загальні налаштування"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Долучити файли конфігурації до тимчасового файлу конфігурації"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Користувацька сторінка 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
-"Custom404Page визначає шлях до користувацької сторінки 404 для відображення. "
-"Якщо це значення дорівнює \"\", відображатиметься типова сторінка.<br />"
-"Типово це значення — \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Файл сертифіката TLS інформаційної панелі вказує шлях до файлу сертифіката "
-"TLS для увімкнення доступу HTTPS.<br />Обовʼязково, якщо HTTPS увімкнено."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Файл ключа TLS інформаційної панелі вказує шлях до файлу закритого ключа TLS "
-"для увімкнення доступу HTTPS.<br />Обовʼязково, якщо HTTPS увімкнено."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "Сертифікат TLS для інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "Режим TLS інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "Закритий ключ TLS інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Адреса інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Пароль інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Порт інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Користувач інформаційної панелі"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr вказує адресу, до якої привʼязується інформаційна панель.<br />"
-"Типово це значення — \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort визначає порт, який прослуховує інформаційна панель. Якщо це "
-"значення дорівнює 0, інформаційна панель не буде запущена.<br />Типово це "
-"значення — 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd визначає пароль, який інформаційна панель використовуватиме для "
-"входу.<br />Типово це значення — «admin»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardUser визначає імʼя користувача, яке інформаційна панель "
-"використовуватиме для входу.<br />Типово це значення — «admin»."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Вимкнути колір журналу"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
-"DisableLogColor вимикає кольори журналу, коли LogWay == \"console\" "
-"встановлено як true.<br />Типово це значення — false."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
 msgstr ""
-"Увімкнути або вимкнути шифрування TLS для інформаційної панелі. Якщо "
-"увімкнено, HTTPS використовується для безпечного звʼязку."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Змінна середовища"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Надати доступ до програми LuCI frps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout визначає максимальний час очікування контрольного сигналу "
-"перед розривом зʼєднання. Не рекомендується змінювати це значення.<br />"
-"Типово це значення — 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Час очікування контрольного сигналу"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "Порт привʼязки KCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Файл журналу"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Налаштування журналу"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Рівень журналювання"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Максимальна кількість днів журналу"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Журнал stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Журнал stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile визначає файл, куди будуть записуватися журнали. Це значення "
-"використовуватиметься, лише якщо LogWay встановлено належним чином.<br />"
-"Типово це значення — \"console\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel визначає мінімальний рівень журналювання. Дійсні значення: "
-"\"trace\", \"debug\", \"info\", \"warn\" і \"error\".<br />Типово це "
-"значення — \"info\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays визначає максимальну кількість днів для зберігання інформації "
-"журналу перед видаленням. Це використовується, лише якщо LogWay == "
-"\"file\".<br />Типово це значення — 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Максимальна кількість портів на клієнта"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient визначає максимальну кількість портів, до яких може "
-"проксіювати один клієнт. Якщо це значення дорівнює 0, обмеження не "
-"застосовуватимуться.<br />Типово це значення — 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "НЕ ПРАЦЮЄ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
-"Змінні середовища ОС, що передаються frp як шаблон для файлу конфігурації, "
-"див. %s"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Адреса привʼязки проксі"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr визначає адресу, до якої привʼязується проксі. Це значення "
-"може бути таким же, як BindAddr.<br />Типово це значення — \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "Порт привʼязки QUIC"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "ЗАПУЩЕНО"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Перезапускати після збою"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Запускати службу від імені групи"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Запускати службу від імені користувача"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Параметри запуску"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost визначає домен, який буде приєднано до субдоменів, запитуваних "
-"клієнтом під час використання проксі-сервера Vhost. Наприклад, якщо це "
-"значення встановлено як \"frps.com\", а клієнт запитав субдомен \"test\", "
-"кінцева URL-адреса буде \"test.frps.com\".<br />Типово це значення — \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Вузол субдомену"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "Мультиплексування TCP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux вмикає мультиплексування потоку TCP. Це дозволяє кільком запитам від "
-"клієнта використовувати одне TCP-зʼєднання.<br />Типово це значення — true."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Цей список можна використовувати для визначення деяких додаткових "
-"параметрів, які не були включені в цей LuCI."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Токен"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Токен визначає токен авторизації, який використовується для автентифікації "
-"ключів, отриманих від клієнтів. Клієнти повинні мати відповідний токен, щоб "
-"отримати дозвіл на використання сервера.<br />Типово це значення — \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "Порт привʼязки UDP"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Порт HTTP Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Час очікування Vhost HTTP"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Порт HTTPS Vhost"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort визначає порт, на якому сервер прослуховує запити HTTP Vhost. "
-"Якщо це значення дорівнює 0, сервер не прослуховуватиме запити HTTP.<br />"
-"Типово це значення — 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout визначає час очікування заголовка відповіді для HTTP-"
-"сервера Vhost у секундах.<br />Типово це значення — 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort визначає порт, на якому сервер прослуховує запити HTTPS "
-"Vhost. Якщо це значення дорівнює 0, сервер не прослуховуватиме запити "
-"HTTPS.<br />Типово це значення — 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "сервер frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Середовища ОС передають до frp для шаблону файлу конфігурації, див. <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort визначає порт UDP, який прослуховує сервер. Якщо це значення "
-#~ "дорівнює 0, сервер не прослуховуватиме з’єднання UDP.<br />За "
-#~ "замовчуванням це значення дорівнює 0"
+#~ msgid "Advanced"
+#~ msgstr "Розширені"

--- a/applications/luci-app-frps/po/vi/frps.po
+++ b/applications/luci-app-frps/po/vi/frps.po
@@ -10,459 +10,721 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "Quản lý quyền kiểm soát"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "Cấu hình thêm"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "Cài đặt mở rộng"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "Cho phép cổng"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts chỉ định một tập hợp các cổng mà máy khách có thể ủy quyền. Nếu "
-"độ dài của giá trị này là 0, thì tất cả các cổng đều được phép.<br />Theo "
-"mặc định, giá trị này là một tập hợp trống."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "Assets dir"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
 msgstr ""
-"AssetsDir chỉ định thư mục cục bộ mà bảng điều khiển sẽ tải tài nguyên từ "
-"đó. Nếu giá trị này là \"\", thì nội dung sẽ được tải từ tệp thực thi đi kèm "
-"bằng cách sử dụng thống kê.<br />Theo mặc định, giá trị này là \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "Xác thực"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
-msgstr "Địa chỉ ràng buộc (Bind address)"
+msgstr "Gán địa chỉ"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "Cổng Bind"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr ""
-"BindAddr chỉ định địa chỉ mà máy chủ liên kết tới.<br />Theo mặc định, giá "
-"trị này là \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort chỉ định cổng KCP mà máy chủ lắng nghe. Nếu giá trị này là 0, "
-"thì máy chủ sẽ không lắng nghe các kết nối KCP.<br />Theo mặc định, giá trị "
-"này là 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr ""
-"BindPort chỉ định cổng mà máy chủ lắng nghe.<br />Theo mặc định, giá trị này "
-"là 7000."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "Đang thu thập dữ liệu ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
-msgstr "Cài đặt chung"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "Tệp cấu hình bao gồm trong tệp cấu hình tạm thời"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
+msgstr "Thiết lập chung"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "Tùy chỉnh trang 404"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page chỉ định đường dẫn đến trang 404 tùy chỉnh để hiển thị. Nếu "
-"giá trị này là \"\", một trang mặc định sẽ được hiển thị.<br />Theo mặc "
-"định, giá trị này là \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr ""
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "Địa chỉ Dashboard"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "Mật khẩu Dashboard"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "Cổng Dashboard"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "Người dùng Dashboard"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr ""
-"DashboardAddr chỉ định địa chỉ mà trang tổng quan liên kết đến.<br />Theo "
-"mặc định, giá trị này là \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort chỉ định cổng mà bảng điều khiển lắng nghe. Nếu giá trị này là "
-"0, thì trang tổng quan sẽ không được khởi động.<br />Theo mặc định, giá trị "
-"này là 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"DashboardPwd chỉ định mật khẩu mà trang tổng quan sẽ sử dụng để đăng nhập."
-"<br />Theo mặc định, giá trị này là \"admin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr ""
-"Người dùng bảng điều khiển chỉ định tên người dùng mà bảng điều khiển sẽ sử "
-"dụng để đăng nhập.<br />Theo mặc định, giá trị này là \"quản trị viên\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "Disable log color"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"DisableLogColor sẽ tắt màu nhật ký khi LogWay == \"bảng điều khiển\" được "
-"đặt thành true.<br />Theo mặc định, giá trị này là false."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "Vô hiệu hoá"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "Environment variable"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr ""
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "Cấp quyền truy cập vào ứng dụng LuCI fps"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
 msgstr ""
-"HeartBeatTimeout chỉ định thời gian tối đa để đợi nhịp tim trước khi ngắt "
-"kết nối. Bạn không nên thay đổi giá trị này.<br />Theo mặc định, giá trị này "
-"là 90."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "Heartbeat timeout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP bind port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "Tệp nhật ký"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "Cài đặt Log"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "Mức độ nhật ký"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "Log max days"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "Log stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "Log stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
 msgstr ""
-"LogFile chỉ định một tệp mà nhật ký sẽ được ghi vào. Giá trị này sẽ chỉ được "
-"sử dụng nếu LogWay được đặt phù hợp.<br />Theo mặc định, giá trị này là "
-"\"bảng điều khiển\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel chỉ định mức nhật ký tối thiểu. Các giá trị hợp lệ là \"dấu vết\", "
-"\"gỡ lỗi\", \"thông tin\", \"cảnh báo\" và \"lỗi\".<br />Theo mặc định, giá "
-"trị này là \"thông tin\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays chỉ định số ngày tối đa để lưu trữ thông tin nhật ký trước khi "
-"xóa. Giá trị này chỉ được sử dụng nếu LogWay == \"file\".<br />Theo mặc "
-"định, giá trị này là 0."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "Cổng tối đa cho mỗi khách hàng"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
 msgstr ""
-"MaxPortsPerClient chỉ định số lượng cổng tối đa mà một máy khách có thể ủy "
-"quyền. Nếu giá trị này là 0, thì sẽ không có giới hạn nào được áp dụng.<br /"
-">Theo mặc định, giá trị này là 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "Không chạy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "Proxy bind address"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr chỉ định địa chỉ mà proxy liên kết tới. Giá trị này có thể "
-"giống với BindAddr.<br />Theo mặc định, giá trị này là \"0.0.0.0\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "Đang chạy"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "Respawn khi bị lỗi"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "Chạy daemon theo nhóm"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "Chạy daemon với tư cách người dùng"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "Cài đặt khởi động"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost chỉ định tên miền sẽ được gắn vào tên miền phụ do khách hàng "
-"yêu cầu khi sử dụng ủy quyền Vhost. Ví dụ: nếu giá trị này được đặt thành "
-"\"frps.com\" và ứng dụng khách đã yêu cầu tên miền phụ \"test\", URL kết quả "
-"sẽ là \"test.frps.com\".<br />Theo mặc định, giá trị này là \"\"."
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "Subdomain host"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP mux"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
 msgstr ""
-"TcpMux chuyển đổi ghép kênh luồng TCP. Điều này cho phép nhiều yêu cầu từ "
-"máy khách chia sẻ một kết nối TCP.<br />Theo mặc định, giá trị này là đúng."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
 msgstr ""
-"Danh sách này có thể được sử dụng để chỉ định một số tham số bổ sung chưa "
-"được đưa vào LuCI này."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "Token"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
-msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
 msgstr ""
-"Mã thông báo chỉ định mã thông báo ủy quyền được sử dụng để xác thực các "
-"khóa nhận được từ máy khách. Khách hàng phải có mã thông báo phù hợp để được "
-"phép sử dụng máy chủ.<br />Theo mặc định, giá trị này là \"\"."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP bind port"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr ""
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
+msgid ""
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost HTTP port"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Vhost HTTP timeout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Cổng Vhost HTTPS"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
 msgstr ""
-"VhostHttpPort chỉ định cổng mà máy chủ lắng nghe các yêu cầu HTTP Vhost. Nếu "
-"giá trị này bằng 0 thì máy chủ sẽ không lắng nghe các yêu cầu HTTP.<br /"
-">Theo mặc định, giá trị này bằng 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
 msgstr ""
-"VhostHttpTimeout chỉ định thời gian chờ tiêu đề phản hồi cho máy chủ HTTP "
-"Vhost, tính bằng giây.<br />Theo mặc định, giá trị này là 60."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
 msgstr ""
-"VhostHttpsPort chỉ định cổng mà máy chủ lắng nghe các yêu cầu HTTPS Vhost. "
-"Nếu giá trị này bằng 0 thì máy chủ sẽ không lắng nghe các yêu cầu HTTPS.<br /"
-">Theo mặc định, giá trị này bằng 0."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr ""
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr ""
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "Máy chủ frp"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "Môi trường hệ điều hành chuyển sang frp cho mẫu tệp cấu hình, xem <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr ""
 
-#~ msgid ""
-#~ "BindUdpPort specifies the UDP port that the server listens on. If this "
-#~ "value is 0, the server will not listen for UDP connections.<br />By "
-#~ "default, this value is 0"
-#~ msgstr ""
-#~ "BindUdpPort chỉ định cổng UDP mà máy chủ lắng nghe. Nếu giá trị này là 0, "
-#~ "thì máy chủ sẽ không lắng nghe các kết nối UDP.<br />Theo mặc định, giá "
-#~ "trị này là 0"
+#~ msgid "Advanced"
+#~ msgstr "Nâng cao"

--- a/applications/luci-app-frps/po/zh_Hans/frps.po
+++ b/applications/luci-app-frps/po/zh_Hans/frps.po
@@ -1,442 +1,744 @@
 msgid ""
 msgstr ""
 "PO-Revision-Date: 2026-02-25 10:58+0000\n"
+"Project-Id-Version: luci-app-frps\n"
 "Last-Translator: nKsyn <e.nksyn@gmail.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
 "projects/openwrt/luciapplicationsfrps/zh_Hans/>\n"
 "Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.16.1-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "访问控制"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr "添加新的 HTTP 插件..."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr "额外认证范围"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
 msgstr "额外配置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "其他设置"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr "包含认证信息的附加作用域。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr "frps 绑定的地址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr "代理监听器绑定的地址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "允许的端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts 指定客户端能够代理的一组端口。如果此值的长度为 0，则允许所有端口。"
-"<br />默认情况下，此集合为空。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "资源目录"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir指定仪表板从哪个本地目录加载资源。如果此值为\"\"，将用statik从打包的"
-"可执行文件加载资源。<br />默认值为\"\"。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
+msgstr "OIDC 令牌应包含的受众。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "认证"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr "认证方式"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr "用于认证 frpc 的认证方式。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr "SSH 隧道网关的 authorized_keys 文件。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "绑定地址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "绑定端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr "BindAddr 指定服务器绑定到的地址。<br />默认值为 \"0.0.0.0\"。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort 指定服务器侦听的 KCP 端口。如果此值为 0，则服务器将不会侦听 KCP "
-"连接。<br />默认值为 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr "BindPort 指定服务器侦听的端口。<br />默认值为 7000。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort 指定服务器侦听的 QUIC 端口。如果此值为 0，则服务器将不会侦听 "
-"QUIC 连接。<br />默认值为 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort 指定服务器侦听的 UDP 端口。如果此值为 0，则服务器将不会侦听 UDP "
-"连接。<br />默认值为 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "正在收集数据…"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr "传递给令牌来源执行命令的参数。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+"用于获取令牌的命令。使用此来源类型时，init 脚本会添加 --allow-"
+"unsafe=TokenSourceExec。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "配置文件包含在临时配置文件中"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr "配置键：log.level。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr "配置键：transport.quic.keepalivePeriod。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr "配置键：transport.quic.maxIdleTimeout。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr "配置键：transport.quic.maxIncomingStreams。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "自定义 404 页面"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page 指定要显示的自定义 404 页面的路径。如果此值为\"\"，将显示默认页"
-"面。<br />默认值为\"\"。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
+msgstr "向客户端发送详细错误"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Dashboard TLS Cert File 指定启用 HTTPS 访问的 TLS 证书文件的路径，<br />若启"
-"用 HTTPS 则必须配置此文件。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Dashboard TLS Key File 指定启用 HTTPS 访问的 TLS 私钥文件的路径。<br />若启"
-"用 HTTPS 则必须配置此文件。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "仪表板 TLS 证书"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "仪表板 TLS 模式"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "仪表板 TLS 私钥"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "仪表板地址"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "仪表板密码"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "仪表板端口"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "仪表板用户"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr "DashboardAddr 指定仪表板绑定到的地址。<br />默认值为“0.0.0.0”。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort 指定仪表板侦听的端口。如果此值为 0，则不会启动仪表板。<br />默"
-"认值为 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr "DashboardPwd 指定仪表板将用于登录的密码。<br />默认值为“admin”。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr "DashboardUser 指定登录仪表板所用的用户名。<br />默认值为“admin”。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
 msgstr "禁用日志的颜色"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
-msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
-msgstr ""
-"当 LogWay == \"console\" 设置为 true 时，DisableLogColor 禁用日志颜色 。<br /"
-">默认值为 false。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
+msgstr "当日志输出到控制台时禁用日志颜色。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
-msgstr ""
-"启用或禁用仪表板的 TLS 加密功能。启用后，仪表板将通过 HTTPS 协议进行安全通"
-"信。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "已禁用"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr "启用 TCPMUX 透传时不更新流量。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr "基于子域名的 HTTP/HTTPS 代理的域名后缀。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
+msgid ""
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
+msgstr ""
+"在 Web 服务器上启用 Go pprof 调试/性能分析端点。仅在设置 Web 服务器端口时生"
+"效。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
+msgid ""
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
+msgstr ""
+"为 frps Web 服务器启用 HTTPS。此开关控制是否生成 webServer.tls.certFile 和 "
+"webServer.tls.keyFile。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr "启用 Prometheus"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr "启用 TCP 流多路复用。此设置必须与 frpc 一致。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr "启用 pprof"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr "启用 Web HTTPS"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "环境变量"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr "环境变量必须使用 KEY=value 格式。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr "传递给令牌来源执行命令的环境变量。使用 KEY=value。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+"在 webServer /metrics API 上导出 Prometheus 指标。仅在设置 Web 服务器端口时生"
+"效。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+"在生成的 HTTP 插件段之前包含额外的根级配置片段。表相关的额外选项请使用原始设"
+"置。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr "强制 TLS"
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "授予访问 LuCI 应用 frps 的权限"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
-msgstr ""
-"HeartBeatTimeout 指定在终止连接前等待检测心跳包的最长时间。不建议更改此值。"
-"<br />默认值为 90。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
+msgstr "HTTP 插件设置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr "HTTP 插件 URL 必须包含主机。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr "HTTP 插件地址必须是单个地址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr "HTTP 插件后端地址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr "HTTP 插件操作必须是 frps 操作名称，例如 Login 或 NewProxy。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr "HTTP 插件路径必须以 / 开头。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr "HTTP 插件请求路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "心跳包超时"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr "心跳超时时间，单位为秒。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP 绑定端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "日志文件"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr "KCP 绑定端口和 QUIC 绑定端口必须不同。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr "TCP 多路复用保活间隔。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+"从外部来源加载令牌。file 从本地文件读取令牌；exec 运行命令并需要 frp unsafe "
+"权限。与 auth.token 互斥。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "日志设置"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "日志级别"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "日志最大天数"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr "日志输出"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr "日志输出路径或 console。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "错误日志"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "普通日志"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
-msgstr ""
-"LogFile 指定写入日志的文件。仅当正确设置 LogWay 时，才会使用此值。<br />默认"
-"值为“console”。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
+msgstr "最大连接池数量"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel 指定最小的日志级别。有效值为\"trace\", \"debug\", \"info\", "
-"\"warn\"和\"error\"。<br />默认情况下，此值为\"info\"。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays 指定删除前存储日志信息的最长天数。仅当 LogWay == \"file\" 时才使"
-"用。<br />默认值为 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "每客户端的最大端口数"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
-msgstr ""
-"MaxPortsPerClient 指定单个客户端可以代理的最大端口数。如果此值为 0，则不作任"
-"何限制。<br />默认值为 0。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
+msgstr "保留日志的最大天数。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr "每个代理的最大连接池数量。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr "每个客户端可使用的最大端口数。0 表示不限制。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr "等待工作连接的最长时间。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr "NAT 打洞分析保留小时数"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "未在运行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
-msgstr "操作系统环境变量传递到 frp 用于配置文件模板，见 %s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
+msgstr "OIDC 受众"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr "OIDC 签发者"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr "用于验证令牌的 OIDC 颁发者。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr "OIDC 跳过过期检查"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr "OIDC 跳过签发者检查"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr "传递给 frp 配置文件模板的 OS 环境变量，请参见 %s。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr "仅接受 TLS 加密的 frpc 连接。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr "自动生成私钥的路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr "令牌来源文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr "HTTP 请求自定义 404 页面的路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr "TLS 证书文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr "TLS 私钥文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr "HTTPS Web 服务器使用的证书文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr "HTTPS Web 服务器使用的私钥文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr "受信任 CA 证书文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr "插件地址"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr "插件名称"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr "插件操作"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr "插件路径"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr "HTTP 虚拟主机请求端口。留空或设为 0 表示禁用。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr "HTTPS 虚拟主机请求端口。留空或设为 0 表示禁用。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr "TCPMUX HTTP CONNECT 请求端口。留空或设为 0 表示禁用。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr "端口必须是 0 到 65535 之间的数字。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr "端口必须介于 0 到 65535 之间。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr "端口必须介于 1 到 65535 之间。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr "端口范围起始值不能大于结束值。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr "frps 监听的端口。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+"允许客户端绑定的端口。可使用单个端口（如 3001）或范围（如 2000-3000）。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr "SSH 隧道网关的私钥文件。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "代理绑定地址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr 指定代理绑定到的地址。此值可能与 BindAddr 相同。<br />默认值"
-"为“0.0.0.0”。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "QUIC 绑定端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr "QUIC 保活周期"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr "QUIC 最大空闲超时"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr "QUIC 最大传入流数"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "运行中"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "崩溃时重启"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr "虚拟主机 HTTP 服务器响应头超时时间，单位为秒。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr "NAT 打洞策略数据保留时间。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "以此组权限运行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "以此用户权限运行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr "SSH 隧道"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr "SSH 隧道 authorized_keys 文件"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr "SSH 隧道自动生成私钥路径"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr "SSH 隧道绑定端口"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr "SSH 隧道网关绑定端口。留空表示禁用此功能。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr "SSH 隧道私钥文件"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr "向 frpc 发送具体错误详情。"
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr "服务端"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr "跳过检查 OIDC 令牌颁发者是否匹配配置的颁发者。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr "跳过检查 OIDC 令牌是否过期。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "启动设置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost 指定使用 Vhost 代理时附加到客户端请求的子域的域名。例如：如果此"
-"值设置为“frps.com”，并且客户端请求子域“test”，则生成的 URL 将是“test.frps.com"
-"”。<br />默认值为\"\"。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "子域主机"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr "TCP 保活"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr "TCP 保活间隔。负值表示禁用保活。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP 多路复用"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
-msgstr ""
-"TcpMux切换TCP流复用。这允许来自一个客户端的多个请求共享一个TCP连接。<br />该"
-"值默认为true。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
+msgstr "TCP mux 保活间隔"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
-msgstr "此列表可用于指定此LuCI中未包括的一些其他参数。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
+msgstr "TCPMUX HTTP CONNECT 端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr "TCPMUX 透传"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr "TLS / QUIC"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr "TLS 证书路径"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr "启用 Web HTTPS 时必须填写 TLS 证书路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr "TLS 私钥路径"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr "启用 Web HTTPS 时必须填写 TLS 私钥路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr "TLS 受信任 CA 路径"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "令牌"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr "令牌和令牌来源互斥。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr "令牌来源命令"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr "令牌来源命令参数"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr "令牌来源类型为 exec 时必须填写令牌来源命令。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr "令牌来源环境变量"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr "令牌来源文件"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr "令牌来源类型为文件时必须填写令牌来源文件路径。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr "令牌来源类型"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr "用于认证的令牌。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr "传输设置"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr "UDP 数据包大小"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr "UDP 数据包大小，单位为字节。应与 frpc 匹配。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
-"令牌指定用于对从客户端接收的密钥进行验证的授权令牌。客户端必须有匹配的令牌才"
-"能被授权使用服务器。<br />该值默认为 \"\"。"
+"KCP 使用的 UDP 端口。留空表示禁用 KCP。请勿与 QUIC 复用同一个 UDP 端口。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP 绑定端口"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+"QUIC 使用的 UDP 端口。留空表示禁用 QUIC。请勿与 KCP 复用同一个 UDP 端口。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr "唯一的 HTTP 插件名称。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr "请使用单个端口（如 3001）或端口范围（如 2000-3000）。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr "用户连接超时"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr "验证插件 TLS"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr "当插件地址使用 HTTPS 时验证 HTTP 插件的 TLS 证书。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "Vhost HTTP 端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "Vhost HTTP 超时"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "Vhost HTTPS 端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
-msgstr ""
-"VhostHttpPort指定服务器侦听HTTP Vhost请求的端口。如果该值为0，服务器将不侦听"
-"HTTP请求。<br />该值默认为0。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
+msgstr "Web 服务器"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
-msgstr ""
-"VhostHttpTimeout指定Vhost HTTP服务器的响应头超时，单位为秒。<br />该值默认为 "
-"60。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
+msgstr "Web 服务器地址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
-msgstr ""
-"VhostHttpsPort指定服务器侦听HTTPS Vhost请求的端口。如果该值为0，服务器将不侦"
-"听HTTPS请求。<br />该值默认为 0。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
+msgstr "Web 服务器资源目录。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr "Web 服务器绑定地址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr "Web 服务器密码"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr "Web 服务器密码。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr "Web 服务器端口"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr "Web 服务器端口。留空或设为 0 表示禁用 Web 服务器。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr "Web 服务器用户"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr "Web 服务器用户名。"
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr "frp"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp 服务器"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "操作系统环境传递给 frp。配置模板请参阅 <a href=\"https://github.com/"
-#~ "fatedier/frp#configuration-file-template\">frp文档</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr "此 HTTP 插件处理的 frps 操作。"

--- a/applications/luci-app-frps/po/zh_Hant/frps.po
+++ b/applications/luci-app-frps/po/zh_Hant/frps.po
@@ -1,441 +1,744 @@
 msgid ""
 msgstr ""
 "PO-Revision-Date: 2026-04-16 07:27+0000\n"
+"Project-Id-Version: luci-app-frps\n"
 "Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
 "projects/openwrt/luciapplicationsfrps/zh_Hant/>\n"
 "Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:982
+msgid "Access Control"
+msgstr "存取控制"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1008
+msgid "Add new HTTP plugin..."
+msgstr "新增新的 HTTP 外掛..."
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:256
+msgid "Additional auth scopes"
+msgstr "額外認證範圍"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:144
 msgid "Additional configs"
-msgstr "額外配置"
+msgstr "額外設定"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid "Additional settings"
-msgstr "進階設定"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:257
+msgid "Additional scopes to include authentication information."
+msgstr "包含驗證資訊的附加作用域。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
+msgid "Address that frps binds to."
+msgstr "frps 繫結的位址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:200
+msgid "Address that proxy listeners bind to."
+msgstr "代理監聽器繫結的位址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:551
 msgid "Allow ports"
 msgstr "允許連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
-msgid ""
-"AllowPorts specifies a set of ports that clients are able to proxy to. If "
-"the length of this value is 0, all ports are allowed.<br />By default, this "
-"value is an empty set."
-msgstr ""
-"AllowPorts 指定用戶端能夠代理到的一組連接埠。若此值的長度為 0，則允許所有連接"
-"埠。<br />預設情況下，此值為空集合。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:449
 msgid "Assets dir"
 msgstr "資產目錄"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
-msgid ""
-"AssetsDir specifies the local directory that the dashboard will load "
-"resources from. If this value is \"\", assets will be loaded from the "
-"bundled executable using statik.<br />By default, this value is \"\"."
-msgstr ""
-"AssetsDir 指定本地目錄讓儀表板從其載入資源。若此值為空，則將使用 statik 從組"
-"合執行檔中載入資產。<br />此值預設為空。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:350
+msgid "Audience OIDC tokens should contain."
+msgstr "OIDC 權杖應包含的受眾。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:978
+msgid "Authentication"
+msgstr "認證"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:237
+msgid "Authentication method"
+msgstr "認證方式"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:238
+msgid "Authentication method used to authenticate frpc."
+msgstr "用於驗證 frpc 的驗證方式。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:583
+msgid "Authorized keys file for SSH tunnel gateway."
+msgstr "SSH 隧道閘道的 authorized_keys 檔案。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
 msgid "Bind address"
 msgstr "繫結位址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:157
 msgid "Bind port"
 msgstr "繫結連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
-msgid ""
-"BindAddr specifies the address that the server binds to.<br />By default, "
-"this value is \"0.0.0.0\"."
-msgstr "BindAddr 指定伺服器繫結位址。<br />此值預設為「0.0.0.0」。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
-msgid ""
-"BindKcpPort specifies the KCP port that the server listens on. If this value "
-"is 0, the server will not listen for KCP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindKcpPort 指定伺服器監聽的 KCP 連接埠. 若此值為 0，則伺服器將不會監聽 KCP "
-"連線。<br />預設情況下，此值為 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
-msgid ""
-"BindPort specifies the port that the server listens on.<br />By default, "
-"this value is 7000."
-msgstr "BindPort 指定伺服器監聽的連接埠。<br />預設情況下，此值為 7000。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
-msgid ""
-"BindQuicPort specifies the QUIC port that the server listens on. If this "
-"value is 0, the server will not listen for QUIC connections.<br />By "
-"default, this value is 0."
-msgstr ""
-"BindQuicPort 指定伺服器監聽的 QUIC 連接埠. 若此值為 0，則伺服器將不會監聽 "
-"QUIC 連線。<br />預設情況下，此值為 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid ""
-"BindUdpPort specifies the UDP port that the server listens on. If this value "
-"is 0, the server will not listen for UDP connections.<br />By default, this "
-"value is 0."
-msgstr ""
-"BindUdpPort 指定伺服器監聽的 UDP 連接埠。若此值為 0，伺服器將不會監聽 UDP 連"
-"線。<br />預設值為 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:969
 msgid "Collecting data ..."
 msgstr "收集資料中..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:153
-msgid "Common settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:323
+msgid "Command arguments passed to token source exec."
+msgstr "傳遞給權杖來源執行命令的參數。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:300
+msgid ""
+"Command used to obtain the token. The init script adds --allow-"
+"unsafe=TokenSourceExec when this source type is used."
+msgstr ""
+"用於獲取權杖的命令。使用此來源類型時，init 指令碼會新增 --allow-"
+"unsafe=TokenSourceExec。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:977
+msgid "Common Settings"
 msgstr "通用設定"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
-msgid "Config files include in temporary config file"
-msgstr "配置檔包含在臨時配置檔案中"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:368
+msgid "Configuration key: log.level."
+msgstr "設定鍵：log.level。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:538
+msgid "Configuration key: transport.quic.keepalivePeriod."
+msgstr "設定鍵：transport.quic.keepalivePeriod。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:542
+msgid "Configuration key: transport.quic.maxIdleTimeout."
+msgstr "設定鍵：transport.quic.maxIdleTimeout。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:546
+msgid "Configuration key: transport.quic.maxIncomingStreams."
+msgstr "設定鍵：transport.quic.maxIncomingStreams。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:227
 msgid "Custom 404 page"
 msgstr "自訂 404 頁面"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
-msgid ""
-"Custom404Page specifies a path to a custom 404 page to display. If this "
-"value is \"\", a default page will be displayed.<br />By default, this value "
-"is \"\"."
-msgstr ""
-"Custom404Page 指定要顯示的自訂 404 頁面的路徑。若此值為空，將顯示預設頁面"
-"。<br />此值預設為空。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:507
+msgid "Detailed errors to client"
+msgstr "向用戶端傳送詳細錯誤"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid ""
-"Dashboard TLS Cert File specifies the path to the TLS certificate file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Dashboard TLS Cert File 用於指定啟用 HTTPS 存取所需的 TLS 憑證文件路徑"
-"。<br />若啟用 HTTPS 則必須設定此文件。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid ""
-"Dashboard TLS Key File specifies the path to the TLS private key file for "
-"enabling HTTPS access.<br />Required if HTTPS is enabled."
-msgstr ""
-"Dashboard TLS Key File 用於指定啟用 HTTPS 存取所需的 TLS 私鑰檔案路徑。<br />"
-"若啟用 HTTPS 則需要。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
-msgid "Dashboard TLS certificate"
-msgstr "儀表板 TLS 證書"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
-msgid "Dashboard TLS mode"
-msgstr "儀表板 TLS 模式"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
-msgid "Dashboard TLS private key"
-msgstr "儀表板 TLS 私鑰"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid "Dashboard address"
-msgstr "儀表板位址"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid "Dashboard password"
-msgstr "儀表板密碼"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid "Dashboard port"
-msgstr "儀表板連接埠"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid "Dashboard user"
-msgstr "儀表板使用者"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
-msgid ""
-"DashboardAddr specifies the address that the dashboard binds to.<br />By "
-"default, this value is \"0.0.0.0\"."
-msgstr "DashboardAddr 指定儀表板繫結位址。<br />此值預設為「0.0.0.0」。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
-msgid ""
-"DashboardPort specifies the port that the dashboard listens on. If this "
-"value is 0, the dashboard will not be started.<br />By default, this value "
-"is 0."
-msgstr ""
-"DashboardPort 指定儀表板監聽的連接埠。若該值為 0，則不會啟動儀表板。<br />預"
-"設情況下，此值為0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
-msgid ""
-"DashboardPwd specifies the password that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr "DashboardPwd 指定儀表板登入密碼。<br />此值預設為「admin」。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
-msgid ""
-"DashboardUser specifies the username that the dashboard will use for login."
-"<br />By default, this value is \"admin\"."
-msgstr "DashboardUser 指定儀表板登入用戶名稱。<br />此值預設為「admin」。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:375
 msgid "Disable log color"
-msgstr "禁用紀錄顏色"
+msgstr "停用紀錄顏色"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:376
+msgid "Disable log colors when log output is console."
+msgstr "當日誌輸出到主控台時停用日誌顏色。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:264
+msgid "Disabled"
+msgstr "已停用"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:220
+msgid "Do not update traffic when TCPMUX passthrough is enabled."
+msgstr "啟用 TCPMUX 透傳時不更新流量。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:224
+msgid "Domain suffix for subdomain-based HTTP/HTTPS proxies."
+msgstr "基於子域名的 HTTP/HTTPS 代理的域名字尾。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:454
 msgid ""
-"DisableLogColor disables log colors when LogWay == \"console\" when set to "
-"true.<br />By default, this value is false."
+"Enable Go pprof debug/profiling endpoints on the web server. It only takes "
+"effect when web server port is set."
 msgstr ""
-"當 LogWay ==「console」設定為 true 時，DisableLogColor 會停用紀錄顏色。<br />"
-"此值預設為 false。"
+"在 Web 伺服器上啟用 Go pprof 除錯/效能分析端點。僅在設定 Web 伺服器連接埠時生"
+"效。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:403
 msgid ""
-"Enable or disable TLS encryption for the dashboard. When enabled, HTTPS is "
-"used for secure communication."
+"Enable HTTPS for the frps web server. This switch controls whether "
+"webServer.tls.certFile and webServer.tls.keyFile are emitted."
 msgstr ""
-"啟用或停用儀表板的 TLS 加密功能。啟用後，將透過 HTTPS 協定進行安全通訊。"
+"為 frps Web 伺服器啟用 HTTPS。此開關控制是否產生 webServer.tls.certFile 和 "
+"webServer.tls.keyFile。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:463
+msgid "Enable Prometheus"
+msgstr "啟用 Prometheus"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:480
+msgid "Enable TCP stream multiplexing. This setting must match frpc."
+msgstr "啟用 TCP 流多路複用。此設定必須與 frpc 一致。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:453
+msgid "Enable pprof"
+msgstr "啟用 pprof"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:402
+msgid "Enable web HTTPS"
+msgstr "啟用 Web HTTPS"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:135
 msgid "Environment variable"
 msgstr "環境變數"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:755
+msgid "Environment variable must use KEY=value format."
+msgstr "環境變數必須使用 KEY=value 格式。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:333
+msgid "Environment variables passed to token source exec. Use KEY=value."
+msgstr "傳遞給權杖來源執行命令的環境變數。使用 KEY=value。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:464
+msgid ""
+"Export Prometheus metrics on webServer /metrics API. It only takes effect "
+"when web server port is set."
+msgstr ""
+"在 webServer /metrics API 上匯出 Prometheus 指標。僅在設定 Web 伺服器連接埠時"
+"生效。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:145
+msgid ""
+"Extra root-level configuration fragments included before generated HTTP "
+"plugin sections. Use raw settings for table-specific extra options."
+msgstr ""
+"在產生的 HTTP 外掛段之前包含額外的根層級設定片段。表相關的額外選項請使用原始"
+"設定。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:521
+msgid "Force TLS"
+msgstr "強制 TLS"
 
 #: applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json:3
 msgid "Grant access to LuCI app frps"
 msgstr "授予存取 luci-app-frps 的權限"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
-msgid ""
-"HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
-"terminating the connection. It is not recommended to change this value.<br /"
-">By default, this value is 90."
-msgstr ""
-"HeartBeatTimeout 指定在終止連線之前等待心跳的最長時間。不建議更改此值。<br />"
-"預設情況下，此值為 90。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:1003
+msgid "HTTP Plugin Settings"
+msgstr "HTTP 外掛設定"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:46
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:781
+msgid "HTTP plugin URL must include a host."
+msgstr "HTTP 外掛 URL 必須包含主機。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:777
+msgid "HTTP plugin address must be a single address."
+msgstr "HTTP 外掛位址必須是單一位址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:593
+msgid "HTTP plugin backend address."
+msgstr "HTTP 外掛後端位址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:797
+msgid ""
+"HTTP plugin operation must be a frps operation name, for example Login or "
+"NewProxy."
+msgstr "HTTP 外掛操作必須是 frps 操作名稱，例如 Login 或 NewProxy。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:765
+msgid "HTTP plugin path must start with /."
+msgstr "HTTP 外掛路徑必須以 / 開頭。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:604
+msgid "HTTP plugin request path."
+msgstr "HTTP 外掛請求路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:499
 msgid "Heartbeat timeout"
 msgstr "心跳逾時"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:500
+msgid "Heartbeat timeout in seconds."
+msgstr "心跳逾時時間，單位為秒。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:161
 msgid "KCP bind port"
 msgstr "KCP 繫結連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid "Log file"
-msgstr "紀錄檔案"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:174
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:193
+msgid "KCP bind port and QUIC bind port must be different."
+msgstr "KCP 繫結連接埠和 QUIC 繫結連接埠必須不同。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:492
+msgid "Keepalive interval for TCP mux."
+msgstr "TCP 多路複用保活間隔。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:261
+msgid ""
+"Load token from an external source. File reads the token from a local file; "
+"exec runs a command and requires frp unsafe permission. Mutually exclusive "
+"with auth.token."
+msgstr ""
+"從外部來源載入權杖。file 從本地檔案讀取權杖；exec 執行命令並需要 frp unsafe "
+"權限。與 auth.token 互斥。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:984
+msgid "Log Settings"
+msgstr "日誌設定"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:367
 msgid "Log level"
 msgstr "紀錄等級"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:371
 msgid "Log max days"
 msgstr "紀錄最大天數"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:10
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:363
+msgid "Log output"
+msgstr "日誌輸出"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:364
+msgid "Log output path or console."
+msgstr "日誌輸出路徑或 console。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:112
 msgid "Log stderr"
 msgstr "紀錄 stderr"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:9
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:102
 msgid "Log stdout"
 msgstr "紀錄 stdout"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
-msgid ""
-"LogFile specifies a file where logs will be written to. This value will only "
-"be used if LogWay is set appropriately.<br />By default, this value is "
-"\"console\"."
-msgstr ""
-"LogFile 指定寫入紀錄的檔案。僅當正確設定 LogWay 時，才會使用此值。<br />預設"
-"值為「console」。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:475
+msgid "Max pool count"
+msgstr "最大連線池數量"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
-msgid ""
-"LogLevel specifies the minimum log level. Valid values are \"trace\", "
-"\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
-"\"info\"."
-msgstr ""
-"LogLevel 指定最低紀錄等級。有效值為「trace」,「debug」,「info」,「warn」和「"
-"error」。<br />預設情況下，此值為「info」。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
-msgid ""
-"LogMaxDays specifies the maximum number of days to store log information "
-"before deletion. This is only used if LogWay == \"file\".<br />By default, "
-"this value is 0."
-msgstr ""
-"LogMaxDays 指定刪除前儲存紀錄資訊的最長天數。僅當 LogWay ==「file」時才使用"
-"。<br />預設值為 0。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:560
 msgid "Max ports per client"
 msgstr "每個用戶端最大連接埠數"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:45
-msgid ""
-"MaxPortsPerClient specifies the maximum number of ports a single client may "
-"proxy to. If this value is 0, no limit will be applied.<br />By default, "
-"this value is 0."
-msgstr ""
-"MaxPortsPerClient 指定單個用戶端可以代理的最大埠數。若此值為 0，則不會應用任"
-"何限制。<br />預設情況下，此值為0。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:372
+msgid "Maximum number of days to keep logs."
+msgstr "保留日誌的最大天數。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:476
+msgid "Maximum pool count for each proxy."
+msgstr "每個代理的最大連線池數量。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:561
+msgid "Maximum ports each client can use. 0 means no limit."
+msgstr "每個用戶端可使用的最大連接埠數。0 表示不限制。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:504
+msgid "Maximum time to wait for a work connection."
+msgstr "等待工作連線的最長時間。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:564
+msgid "NAT hole analysis reserve hours"
+msgstr "NAT 打洞分析保留小時數"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "NOT RUNNING"
 msgstr "未執行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:14
-msgid "OS environments pass to frp for config file template, see %s"
-msgstr "傳遞作業系統環境至frp以取得配置檔模板，請參閱%s"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:349
+msgid "OIDC audience"
+msgstr "OIDC 受眾"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:345
+msgid "OIDC issuer"
+msgstr "OIDC 簽發者"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:346
+msgid "OIDC issuer used to verify tokens."
+msgstr "用於驗證權杖的 OIDC 頒發者。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:353
+msgid "OIDC skip expiry check"
+msgstr "OIDC 跳過過期檢查"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:357
+msgid "OIDC skip issuer check"
+msgstr "OIDC 跳過簽發者檢查"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:136
+msgid "OS environments passed to frp for config file template, see %s."
+msgstr "傳遞給 frp 設定檔案模板的 OS 環境變數，請參見 %s。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:522
+msgid "Only accept TLS-encrypted frpc connections."
+msgstr "僅接受 TLS 加密的 frpc 連線。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:579
+msgid "Path for auto-generated private key."
+msgstr "自動生成私鑰的路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:277
+msgid "Path of token file."
+msgstr "權杖來源檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:228
+msgid "Path to custom 404 page for HTTP requests."
+msgstr "HTTP 請求自訂 404 頁面的路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:526
+msgid "Path to the TLS certificate file."
+msgstr "TLS 憑證檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:530
+msgid "Path to the TLS private key file."
+msgstr "TLS 私鑰檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:414
+msgid "Path to the certificate file used by the HTTPS web server."
+msgstr "HTTPS Web 伺服器使用的憑證檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:432
+msgid "Path to the private key file used by the HTTPS web server."
+msgstr "HTTPS Web 伺服器使用的私鑰檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:534
+msgid "Path to the trusted CA certificate file."
+msgstr "受信任 CA 憑證檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:592
+msgid "Plugin address"
+msgstr "外掛位址"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:588
+msgid "Plugin name"
+msgstr "外掛名稱"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:614
+msgid "Plugin operations"
+msgstr "外掛操作"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:603
+msgid "Plugin path"
+msgstr "外掛路徑"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:204
+msgid "Port for HTTP virtual host requests. Empty or 0 disables it."
+msgstr "HTTP 虛擬主機請求連接埠。留空或設為 0 表示停用。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:208
+msgid "Port for HTTPS virtual host requests. Empty or 0 disables it."
+msgstr "HTTPS 虛擬主機請求連接埠。留空或設為 0 表示停用。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:216
+msgid "Port for TCPMUX HTTP CONNECT requests. Empty or 0 disables it."
+msgstr "TCPMUX HTTP CONNECT 請求連接埠。留空或設為 0 表示停用。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:719
+msgid "Port must be a number between 0 and 65535."
+msgstr "連接埠必須是 0 到 65535 之間的數字。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:723
+msgid "Port must be between 0 and 65535."
+msgstr "連接埠必須介於 0 到 65535 之間。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:742
+msgid "Port must be between 1 and 65535."
+msgstr "連接埠必須介於 1 到 65535 之間。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:745
+msgid "Port range start must not be greater than end."
+msgstr "連接埠範圍起始值不能大於結束值。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
+msgid "Port that frps listens on."
+msgstr "frps 監聽的連接埠。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:552
+msgid ""
+"Ports clients are allowed to bind. Use single port like 3001 or range like "
+"2000-3000."
+msgstr ""
+"允許用戶端繫結的連接埠。可使用單個連接埠（如 3001）或範圍（如 2000-3000）。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:575
+msgid "Private key file for SSH tunnel gateway."
+msgstr "SSH 隧道閘道的私鑰檔案。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:199
 msgid "Proxy bind address"
 msgstr "代理繫結位址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
-msgid ""
-"ProxyBindAddr specifies the address that the proxy binds to. This value may "
-"be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
-msgstr ""
-"ProxyBindAddr 指定代理繫結位址。此值可能與 BindAddr 相同。<br />此值預設為「"
-"0.0.0.0」。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:180
 msgid "QUIC bind port"
 msgstr "QUIC 繫結連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:537
+msgid "QUIC keepalive period"
+msgstr "QUIC 保活週期"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:541
+msgid "QUIC max idle timeout"
+msgstr "QUIC 最大空閒逾時"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:545
+msgid "QUIC max incoming streams"
+msgstr "QUIC 最大傳入流數"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:942
 msgid "RUNNING"
 msgstr "執行中"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:13
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:125
 msgid "Respawn when crashed"
 msgstr "崩潰時重生"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:12
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:212
+msgid "Response header timeout for vhost HTTP server, in seconds."
+msgstr "虛擬主機 HTTP 伺服器回應標頭逾時時間，單位為秒。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:565
+msgid "Retention time for NAT hole punching strategy data."
+msgstr "NAT 打洞策略資料保留時間。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:123
 msgid "Run daemon as group"
 msgstr "以此群組身分執行常駐程式"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:11
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:122
 msgid "Run daemon as user"
 msgstr "以此使用者身分執行常駐程式"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:154
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:158
-msgid "Startup settings"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:983
+msgid "SSH Tunnel"
+msgstr "SSH 隧道"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:582
+msgid "SSH tunnel authorized keys file"
+msgstr "SSH 隧道 authorized_keys 檔案"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:578
+msgid "SSH tunnel auto-generated private key path"
+msgstr "SSH 隧道自動產生私鑰路徑"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:570
+msgid "SSH tunnel bind port"
+msgstr "SSH 隧道繫結連接埠"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:571
+msgid "SSH tunnel gateway bind port. Empty disables this feature."
+msgstr "SSH 隧道閘道繫結連接埠。留空表示停用此功能。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:574
+msgid "SSH tunnel private key file"
+msgstr "SSH 隧道私鑰檔案"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:508
+msgid "Send specific error details to frpc."
+msgstr "向 frpc 傳送具體錯誤詳情。"
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:11
+msgid "Server"
+msgstr "伺服端"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:358
+msgid "Skip checking whether OIDC token issuer matches configured issuer."
+msgstr "跳過檢查 OIDC 權杖頒發者是否匹配設定的頒發者。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:354
+msgid "Skip checking whether the OIDC token is expired."
+msgstr "跳過檢查 OIDC 權杖是否過期。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:985
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:996
+msgid "Startup Settings"
 msgstr "啟動設定"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
-msgid ""
-"SubDomainHost specifies the domain that will be attached to sub-domains "
-"requested by the client when using Vhost proxying. For example, if this "
-"value is set to \"frps.com\" and the client requested the subdomain "
-"\"test\", the resulting URL would be \"test.frps.com\".<br />By default, "
-"this value is \"\"."
-msgstr ""
-"SubDomainHost 指定當使用虛擬主機代理時將附加到用戶端請求網域的子網域。例如，"
-"若將此值設定為「frps.com」，並且用戶端請求了子域「test」，則結果 URL 將為「"
-"test.frps.com」。<br />此值預設為空。"
-
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:223
 msgid "Subdomain host"
 msgstr "子網域主機"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:495
+msgid "TCP keepalive"
+msgstr "TCP 保活"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:496
+msgid "TCP keepalive interval. Negative value disables keepalive."
+msgstr "TCP 保活間隔。負值表示停用保活。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:479
 msgid "TCP mux"
 msgstr "TCP 多路複用器"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
-msgid ""
-"TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
-"client to share a single TCP connection.<br />By default, this value is true."
-msgstr ""
-"TcpMux 切換 TCP 串流多路複用。這允許來自用戶端的多個請求共享單一個 TCP 連線"
-"。<br />預設情況下，此值為 true。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:491
+msgid "TCP mux keepalive interval"
+msgstr "TCP mux 保活間隔"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:47
-msgid ""
-"This list can be used to specify some additional parameters which have not "
-"been included in this LuCI."
-msgstr "此清單用於指定此 LuCI 中未包含的某些其他額外參數。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:215
+msgid "TCPMUX HTTP CONNECT port"
+msgstr "TCPMUX HTTP CONNECT 連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:219
+msgid "TCPMUX passthrough"
+msgstr "TCPMUX 透傳"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:980
+msgid "TLS / QUIC"
+msgstr "TLS / QUIC"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:413
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:525
+msgid "TLS certificate path"
+msgstr "TLS 憑證路徑"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:425
+msgid "TLS certificate path is required when web HTTPS is enabled."
+msgstr "啟用 Web HTTPS 時必須填寫 TLS 憑證路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:431
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:529
+msgid "TLS private key path"
+msgstr "TLS 私鑰路徑"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:443
+msgid "TLS private key path is required when web HTTPS is enabled."
+msgstr "啟用 Web HTTPS 時必須填寫 TLS 私鑰路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:533
+msgid "TLS trusted CA path"
+msgstr "TLS 受信任 CA 路徑"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:241
 msgid "Token"
 msgstr "權杖"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:250
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:270
+msgid "Token and token source are mutually exclusive."
+msgstr "權杖和權杖來源互斥。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:299
+msgid "Token source command"
+msgstr "權杖來源命令"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:322
+msgid "Token source command arguments"
+msgstr "權杖來源命令參數"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:316
+msgid "Token source command is required when token source type is exec."
+msgstr "權杖來源類型為 exec 時必須填寫權杖來源命令。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:332
+msgid "Token source environment"
+msgstr "權杖來源環境變數"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:276
+msgid "Token source file"
+msgstr "權杖來源檔案"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:293
+msgid "Token source file path is required when token source type is file."
+msgstr "權杖來源類型為檔案時必須填寫權杖來源檔案路徑。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:260
+msgid "Token source type"
+msgstr "權杖來源類型"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:242
+msgid "Token used for authentication."
+msgstr "用於驗證的權杖。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:979
+msgid "Transport Settings"
+msgstr "傳輸設定"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:231
+msgid "UDP packet size"
+msgstr "UDP 封包大小"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:232
+msgid "UDP packet size in bytes. Should match frpc."
+msgstr "UDP 資料包大小，單位為位元組。應與 frpc 匹配。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:162
 msgid ""
-"Token specifies the authorization token used to authenticate keys received "
-"from clients. Clients must have a matching token to be authorized to use the "
-"server.<br />By default, this value is \"\"."
+"UDP port used for KCP. Empty disables KCP. Do not reuse the same UDP port as "
+"QUIC."
 msgstr ""
-"Token 指定用於驗證從用戶端接收的金鑰的授權權杖。用戶端必須具有匹配的權杖才能"
-"被授權使用伺服器。<br />此值預設為空。"
+"KCP 使用的 UDP 連接埠。留空表示停用 KCP。請勿與 QUIC 複用同一個 UDP 連接埠。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
-msgid "UDP bind port"
-msgstr "UDP 繫結連接埠"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:181
+msgid ""
+"UDP port used for QUIC. Empty disables QUIC. Do not reuse the same UDP port "
+"as KCP."
+msgstr ""
+"QUIC 使用的 UDP 連接埠。留空表示停用 QUIC。請勿與 KCP 複用同一個 UDP 連接埠。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:589
+msgid "Unique HTTP plugin name."
+msgstr "唯一的 HTTP 外掛名稱。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:736
+msgid "Use a single port like 3001 or a range like 2000-3000."
+msgstr "請使用單一連接埠（如 3001）或連接埠範圍（如 2000-3000）。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:503
+msgid "User connection timeout"
+msgstr "使用者連線逾時"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:626
+msgid "Verify plugin TLS"
+msgstr "驗證外掛 TLS"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:627
+msgid ""
+"Verify the HTTP plugin TLS certificate when the plugin address uses HTTPS."
+msgstr "當外掛位址使用 HTTPS 時驗證 HTTP 外掛的 TLS 憑證。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:203
 msgid "Vhost HTTP port"
 msgstr "虛擬主機 HTTP 連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:211
 msgid "Vhost HTTP timeout"
 msgstr "虛擬主機 HTTP 逾時"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:207
 msgid "Vhost HTTPS port"
 msgstr "虛擬主機 HTTPS 連接埠"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
-msgid ""
-"VhostHttpPort specifies the port that the server listens for HTTP Vhost "
-"requests. If this value is 0, the server will not listen for HTTP requests."
-"<br />By default, this value is 0."
-msgstr ""
-"VhostHttpPort 指定伺服器監聽虛擬主機 HTTP 請求的連接埠。若此值為 0，則伺服器"
-"將不會監聽 HTTP 請求。<br />預設情況，此值為0。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:981
+msgid "Web Server"
+msgstr "Web 伺服器"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
-msgid ""
-"VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
-"server, in seconds.<br />By default, this value is 60."
-msgstr ""
-"VhostHttpTimeout 指定虛擬主機 HTTP 伺服器的回應標頭逾時，以秒為單位。<br />預"
-"設情況下，此值為60。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:381
+msgid "Web server address"
+msgstr "Web 伺服器位址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
-msgid ""
-"VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
-"requests. If this value is 0, the server will not listen for HTTPS requests."
-"<br />By default, this value is 0."
-msgstr ""
-"VhostHttpsPort 指定伺服器監聽虛擬主機 HTTPS 請求的連接埠，若此值為0，則伺服器"
-"將不監聽HTTPS請求。<br />預設情況下，此值為0。"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:450
+msgid "Web server assets directory."
+msgstr "Web 伺服器資源目錄。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:120
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:130
-#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:382
+msgid "Web server bind address."
+msgstr "Web 伺服器繫結位址。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:395
+msgid "Web server password"
+msgstr "Web 伺服器密碼"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:396
+msgid "Web server password."
+msgstr "Web 伺服器密碼。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:385
+msgid "Web server port"
+msgstr "Web 伺服器連接埠"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:386
+msgid "Web server port. Leave empty or set to 0 to disable the web server."
+msgstr "Web 伺服器連接埠。留空或設為 0 表示停用 Web 伺服器。"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:389
+msgid "Web server user"
+msgstr "Web 伺服器使用者"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:390
+msgid "Web server username."
+msgstr "Web 伺服器使用者名稱。"
+
+#: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:4
+msgid "frp"
+msgstr "frp"
+
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:945
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:952
 msgid "frp Server"
 msgstr "frp 伺服器"
 
-#~ msgid ""
-#~ "OS environments pass to frp for config file template, see <a "
-#~ "href=\"https://github.com/fatedier/frp#configuration-file-template\">frp "
-#~ "README</a>"
-#~ msgstr ""
-#~ "傳遞至frp設定檔範本的作業系統環境變數，請參閱 <a href=\"https://"
-#~ "github.com/fatedier/frp#configuration-file-template\">frp README</a>"
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:615
+msgid "frps operations handled by this HTTP plugin."
+msgstr "此 HTTP 外掛處理的 frps 操作。"

--- a/applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json
+++ b/applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json
@@ -1,6 +1,14 @@
 {
-	"admin/services/frps": {
-		"title": "frp Server",
+	"admin/services/frp": {
+		"order": 80,
+		"title": "frp",
+		"action": {
+			"type": "firstchild"
+		}
+	},
+	"admin/services/frp/server": {
+		"order": 10,
+		"title": "Server",
 		"action": {
 			"type": "view",
 			"path": "frps"

--- a/applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json
+++ b/applications/luci-app-frps/root/usr/share/rpcd/acl.d/luci-app-frps.json
@@ -9,10 +9,10 @@
 			"ubus": {
 				"service": [ "list" ]
 			},
-			"uci": ["frps"]
+			"uci": [ "frps" ]
 		},
 		"write": {
-			"uci": ["frps"]
+			"uci": [ "frps" ]
 		}
 	}
 }


### PR DESCRIPTION
## Pull request details

### Description
Update the frpc and frps LuCI applications for the TOML-based configuration generated by the current frp packages.

- expose current frp client and server options with validation
- group both applications under Services -> frp
- show only the installed Server and Client submenu entries
- hide the raw TOML editor while retaining source mapping comments for debugging
- refresh translation templates and PO files
- complete Simplified and Traditional Chinese translations

**Depends on:** https://github.com/openwrt/packages/pull/29593

### Screenshot or video of changes _(if applicable)_
<img width="1920" height="1453" alt="Roc _ Server" src="https://github.com/user-attachments/assets/ca724f90-1b51-4410-b214-eecdcc1730fc" />
<img width="1920" height="1246" alt="Roc _ Client" src="https://github.com/user-attachments/assets/625738bd-addf-42bb-a2a2-9f5e582b3212" />
<img width="1920" height="1817" alt="Server - Roc" src="https://github.com/user-attachments/assets/d2957d6a-fc33-404e-ac54-f69363a5cf64" />
<img width="1920" height="1617" alt="Client - Roc" src="https://github.com/user-attachments/assets/1bb323bb-0d97-4a7f-a1a4-8f644eed6b25" />

---

## Tested on
- **OpenWrt Version:** main/snapshot
- **OpenWrt Target/Subtarget:** qualcommax/aarch64
- **OpenWrt Device:** ipq6000-360v6

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
