### PR TITLE
luci-{base,mod-system}: add support for RGB LEDs

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -203,7 +203,7 @@ const methods = {
 			for (let led in lsdir('/sys/class/leds')) {
 				let s;
 
-				result[led] = { triggers: [] };
+				result[led] = { triggers: [], multi_channel: false, channels: {} };
 
 				s = trim(readfile(`/sys/class/leds/${led}/trigger`));
 				for (let trigger in split(s, ' ')) {
@@ -211,6 +211,16 @@ const methods = {
 
 					if (trigger != result[led].triggers[-1])
 						result[led].active_trigger = result[led].triggers[-1];
+				}
+				s = access(`/sys/class/leds/${led}/multi_index`);
+				if (s) {
+					let channels = split(trim(readfile(`/sys/class/leds/${led}/multi_index`)), ' ');
+					let intensities = split(trim(readfile(`/sys/class/leds/${led}/multi_intensity`)), ' ');
+
+					for (let i = 0; i < length(channels); i++) {
+						result[led].channels[channels[i]] = int(intensities[i]);
+					}
+					result[led].multi_channel = true;
 				}
 
 				s = readfile(`/sys/class/leds/${led}/brightness`);

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js
@@ -97,6 +97,26 @@ return view.extend({
 			for (let plugin of plugins) {
 				plugin.form.addFormOptions(s);
 			}
+			const led_names = Object.keys(leds);
+			for (let i = 0; i < led_names.length; i++) {
+				let led = leds[led_names[i]];
+				o = s.option(form.Value, `${led_names[i]}_brightness`, _('Brightness'));
+				o.depends('sysfs', led_names[i]);
+				o.ucioption = 'brightness';
+				o.datatype = `range(0,${led.max_brightness})`;
+				o.placeholder = led.max_brightness;
+				o.modalonly = true;
+				if (led.multi_channel) {
+					for (let channel in led.channels) {
+						o = s.option(form.Value, `${led_names[i]}_color_${channel}`, channel);
+						o.ucioption = `color_${channel}`;
+						o.depends('sysfs', led_names[i]);
+						o.datatype = `range(0,${led.max_brightness})`;
+						o.placeholder = led.channels[channel];
+						o.modalonly = true;
+					}
+				}
+			}
 
 			const opts = s.getOption();
 


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.git
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->

Add support for changing LED brightness and colors in LuCI.

The attributes (color names, maximum and current brightness, etc.) are pulled directly from sysfs (in case of using e.g. CMY instead of RGB) which might hamper translation efforts. It may be worth it to simply hard-code the color names to be RGB for this purpose.

Note: I have written very little JS code overall so there are definitely stupid mistakes in the code. 

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->

<img width="900" height="506" alt="image" src="https://github.com/user-attachments/assets/069c4980-a7ad-4afe-acf1-96b5bb9776d0" />


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@feckert 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt 24.10 (r29199+104-d5ac5cdfb2)
**LuCI version:** LuCI openwrt-24.10 branch (24.297.79519~bcd13b9)
**Web browser(s):** Firefox 151.0.2-1

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
