### PR TITLE
luci-app-cloudflared: i18n string context

### DIFF
--- a/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js
+++ b/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js
@@ -93,8 +93,8 @@ return view.extend({
 				]),
 				E('label', { 'for': 'log-direction', 'style': 'margin-right: 8px;' }, _('Log Direction:')),
 				E('select', { 'id': 'log-direction', 'style': 'margin-right: 8px;' }, [
-					E('option', { 'value': 'down', 'selected': 'selected' }, _('Down')),
-					E('option', { 'value': 'up' }, _('Up')),
+					E('option', { 'value': 'down', 'selected': 'selected' }, _('Down', 'Log direction')),
+					E('option', { 'value': 'up' }, _('Up', 'Log direction')),
 				]),
 				E('button', {
 					'id': 'download-log',


### PR DESCRIPTION
## Pull request details

### Description
Separate the "Up" and "Down" strings by adding a specific "Log direction" context to decouple them from the "Tunnel status" context.

Previously, the short strings "Up" and "Down" were shared/bundled across different UI elements. In network applications (like Libreswan), these strings often represent **Tunnel Status (Up/Down)**. However, since they are also used here to denote **Log Direction**, they must be decoupled with distinct context metadata. 

This separation ensures that both contexts can be localized accurately and independently without interfering with each other.

---

## Tested on
- **OpenWrt version:** SNAPSHOT
- **LuCI version:** master
- **Web browser:** Chrome

---

## Checklist
- [x] This PR is not from my main or master branch 💩, but a separate branch. ✅
- [x] Each commit has a valid ✒️ `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid 📝 first line subject for packages: `<package name>: title`
- [ ] Incremented 🆙 any `PKG_VERSION` in the Makefile.