### PR TITLE
luci-proto-openvpn: i18n fix typo in TLS cert profile label

### DIFF
--- a/protocols/luci-proto-openvpn/htdocs/luci-static/resources/protocol/openvpn.js
+++ b/protocols/luci-proto-openvpn/htdocs/luci-static/resources/protocol/openvpn.js
@@ -1272,7 +1272,7 @@ const openvpnOptions = [
 		tab: 'cryptography',
 		type: form.Value,
 		name: 'tls_cert_profile',
-		label: _('TLS cet profile'),
+		label: _('TLS cert profile'),
 		lvalues: [
 			'insecure',
 			'legacy',


### PR DESCRIPTION
## Pull request details

### Description
Fix a simple typo in the cryptography tab of `luci-proto-openvpn` where 'TLS cert profile' was incorrectly written as 'TLS cet profile'.

---

## Tested on
- **OpenWrt version:** SNAPSHOT
- **LuCI version:** master
- **Web browser:** Chrome

---

## Checklist
- [x] This PR is not from my main or master branch 💩, but a separate branch. ✅
- [x] Each commit has a valid ✒️ `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid 📝 first line subject for packages: `<package name>: title`
- [ ] Incremented 🆙 any `PKG_VERSION` in the Makefile.