### PR TITLE
luci-app-nut: i18n fix typo in UPS Monitor section title

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
@@ -127,7 +127,7 @@ return view.extend({
 		o = s.option(form.ListValue, 'flag', _('Notification flags'));
 		ESIFlags(o)
 
-		s = m.section(form.TypedSection, 'monitor', _('UPS Monitor User Settings)'));
+		s = m.section(form.TypedSection, 'monitor', _('UPS Monitor User Settings'));
 		MonitorUserOptions(s);
 
 		o = s.option(form.ListValue, 'type', _('User type (Primary/Auxiliary)'));


### PR DESCRIPTION
## Pull request details

### Description
Fix a simple typo in the `luci-app-nut` monitor section title where an accidental trailing parenthesis was included inside the i18n string ('UPS Monitor User Settings)').


## Tested on
- **OpenWrt version:** SNAPSHOT
- **LuCI version:** master
- **Web browser:** Chrome

---

## Checklist
- [x] This PR is not from my main or master branch 💩, but a separate branch. ✅
- [x] Each commit has a valid ✒️ `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid 📝 first line subject for packages: `<package name>: title`
- [ ] Incremented 🆙 any `PKG_VERSION` in the Makefile.