### PR TITLE
luci-base: fix setPassword handling

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -15,7 +15,6 @@ const callSetPassword = rpc.declare({
 	object: 'luci',
 	method: 'setPassword',
 	params: [ 'username', 'password', 'oldpassword', 'rpcd' ],
-	expect: { result: 1 }
 });
 
 function checkPassword(value) {
@@ -309,9 +308,12 @@ return view.extend({
 			const user = this.map.lookupOption('username', section_id)[0].formvalue(section_id);
 
 			if (variant.formvalue(section_id) == 'crypted' && value.substring(0, 3) != '$1$')
-				return callSetPassword(user, value, '', true).then(function(success) {
-					if (!success)
+				return callSetPassword(user, value, '', true).then(function(result) {
+					if (!result || !result.result)
 						throw new Error('Failed to create password');
+
+					if (result.hash)
+						uci.set('rpcd', section_id, 'password', result.hash);
 				});
 		};
 		o.remove = function() {};

--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -46,8 +46,7 @@ function callPackageVersionCheck(pkg) {
 	return version;
 }
 
-function set_new_pwd(user, pwd) {
-	const ctx = cursor();
+function set_new_pwd(ctx, user, pwd, change) {
 	let cmd, fd, value;
 
 	cmd = sprintf('/usr/sbin/uhttpd -m %s', shellquote(pwd));
@@ -56,17 +55,20 @@ function set_new_pwd(user, pwd) {
 
 	fd.close();
 
-	ctx.foreach('rpcd', 'login', s => {
-		if (s.username == user) {
-			ctx.set('rpcd', s['.name'], 'password', value);
-			ctx.commit();
-		}
-	});
+	if (change) {
+		ctx.foreach('rpcd', 'login', s => {
+			if (s.username == user) {
+				ctx.set('rpcd', s['.name'], 'password', value);
+				ctx.commit('rpcd');
+			}
+		});
+	}
+
+	return value;
 }
 
-function check_oldpwd(user, pwd) {
+function check_oldpwd(ctx, user, pwd) {
 	let cmd, fd, value;
-	const ctx = cursor();
 	let valid = false;
 
 	cmd = sprintf('/usr/sbin/uhttpd -m %s', shellquote(pwd));
@@ -82,7 +84,7 @@ function check_oldpwd(user, pwd) {
 	return valid;
 }
 
-function check_user(source, entry) {
+function check_user(ctx, source, entry) {
 	let found = false;
 
 	switch (source) {
@@ -98,13 +100,12 @@ function check_user(source, entry) {
 		}
 
 		case 'rpcd': {
-			const ctx = cursor();
 			ctx.foreach('rpcd', 'login', s => {
 				if (s.username == entry)
 					found = true;
-				});
+			});
+			break;
 		}
-		break;
 	}
 	return found;
 }
@@ -542,8 +543,7 @@ const methods = {
 			const user = request.args.username;
 			const pwd = request.args.password;
 			const oldpwd = request.args.oldpassword;
-			const type = request.args.rpcd == true ? 'rpcd' : 'unix';
-			const known_user = check_user(type, user);
+			const type = request.args.rpcd ? 'rpcd' : 'unix';
 			const uci = cursor();
 
 			if (type == 'unix') {
@@ -561,29 +561,20 @@ const methods = {
 					msg: "uhttpd not installed"
 				};
 
-			if (known_user) {
-				if (!oldpwd)
-					return { result: 0 };
+			uci.load('rpcd');
+			const known_user = check_user(uci, type, user);
 
-				/*
-				* check if login is valid
-				*/
-				if (!check_oldpwd(user, oldpwd))
+			if (known_user) {
+				if (!oldpwd || !check_oldpwd(uci, user, oldpwd)) {
 					return { result: 0 };
-			} else {
-				/*
-				 * create user to keep logic of luci-app-acl
-				 */
-				const sid = uci.add('rpcd', 'login');
-				uci.set('rpcd', sid, 'username', user);
-				uci.commit('rpcd');
+				}
 			}
 
 			/*
 			 * encrypt password and assign it to rpcd login
 			 */
-			 set_new_pwd(user, pwd);
-			 return { result: 1 };
+			const value = set_new_pwd(uci, user, pwd, known_user ? true : false);
+			return { result: 1, hash: value };
 		}
 	},
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
@@ -159,9 +159,6 @@ return view.extend({
 			let rpcd = formData.data.rpcd;
 			let oldpw = formData.data.oldpw;
 
-			if (rpc_user && (oldpw == null || oldpw.length == 0))
-				return;
-
 			if (formData.data.pw1 == null || formData.data.pw1.length == 0)
 				return;
 

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js
@@ -23,7 +23,6 @@ var callSetPassword = rpc.declare({
 	object: 'luci',
 	method: 'setPassword',
 	params: [ 'username', 'password', 'oldpassword', 'rpcd' ],
-	expect: { result: 1 }
 });
 
 return view.extend({
@@ -172,11 +171,23 @@ return view.extend({
 				formData.data.pw1,
 				oldpw ? oldpw : '',
 				rpcd ? true : false,
-			).then(function(success) {
-				if (success)
+			).then(function(result) {
+				if (result && result.result) {
+					if (rpcd && result.hash) {
+						let sections = uci.sections('rpcd', 'login');
+
+						for (let s of sections) {
+							if (s.username == rpc_user) {
+								uci.set('rpcd', s['.name'], 'password', result.hash);
+								uci.save('rpcd');
+							}
+						}
+					}
 					ui.addNotification(null, E('p', _('The system password has been successfully changed.')), 'info');
-				else
+				}
+				else {
 					ui.addNotification(null, E('p', _('Failed to change the system password.')), 'danger');
+				}
 
 				formData.data.rpc_user = null;
 				formData.data.user = null;


### PR DESCRIPTION
## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
The earlier commits didn't work for creating new users in rpcd.
Also, creating new users resulted in duplicated rpcd logins, because save and apply also created the uci section. So therefore, `setPassword` returns the generated hash and let `luci-mod-system` and `luci-app-acl` set the new hash.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash @AndyChiang888 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** luci-openwrt-25.12<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** firefox<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.

