### PR TITLE
luci-mod-network: fix available wifi channels

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -325,7 +325,7 @@ var CBIWifiFrequencyValue = form.Value.extend({
 					return;
 
 				const band = '%dg'.format(freq.band);
-				const available = (freq.restricted && freq.no_ir) ? false: true;
+				const available = !(freq.restricted && freq.flags.includes("no_ir"));
 
 				this.channels[band].push(
 					freq.channel,


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
A channel is marked as not `available` if `rpcd iwinfo freqlist` reports it as `freq.restricted && freq.no_ir`, however neither `iwinfo` nor `rpcd` populate a `no_ir` field; it is instead passed in as a flag. As such, no channel is currently ever restricted from selection. This PR changes it to check for the `no_ir` string in `freq.flags` instead.

Note: nl80211 is the only backend to populate `restricted` meaningfully and it uses `NO_IR` directly.
> (`e->restricted = (e->flags & IWINFO_FREQ_NO_IR) ? 1 : 0;`)

As such, this check can be reduced to just `freq.restricted` but I wanted to keep the spirit of the original.

### Screenshot or video of changes _(if applicable)_
Previously, after editing channel 1 to be `restricted` and `no_ir` for debug purposes, it is still selectable.
<img width="2772" height="715" alt="image" src="https://github.com/user-attachments/assets/419896e8-973f-4ce9-ab60-39c1b2e0833d" />


After, it is hidden.
<img width="2768" height="691" alt="image" src="https://github.com/user-attachments/assets/a2b30585-2b48-41bf-b18b-e56b65cb7c2c" />

### Maintainer 
@systemcrash 
@jow- 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt SNAPSHOT (r34753-c82f2724f5)
**LuCI version:** LuCI Master (26.154.38947~8dd088d)
**Web browser(s):** Chrome 148.0.7778.217 (Official Build) (64-bit)

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.