### PR TITLE
luci-base: add German translations for "Show" and "Hide"

### DIFF
--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -5548,7 +5548,7 @@ msgstr "Hex-Daten werden beim Speichern und Laden automatisch (de)kodiert"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:17
 msgid "Hide"
-msgstr ""
+msgstr "Ausblenden"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1208
 msgid "Hide <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
@@ -11694,7 +11694,7 @@ msgstr "Kurze Präambel"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:17
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js:142
 msgid "Show"
-msgstr ""
+msgstr "Anzeigen"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:468
 msgid "Show current backup file list"


### PR DESCRIPTION
The status overview page uses "Show" and "Hide" labels for section toggle buttons (span.label.notice). These were missing German translations, causing them to remain in English when the UI language is set to German.

This adds:
- "Show" → "Anzeigen"
- "Hide" → "Ausblenden"