### PR TITLE
luci-mod-status: resolve named counters in nftables view

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
@@ -143,19 +143,34 @@ const action_translations = {
 };
 
 return view.extend({
+
+	resolveCounter(data, spec, counter) {
+		if (typeof(counter) == 'object')
+			return counter;
+
+		for (let d of data)
+			if (typeof(d.counter) == 'object' &&
+				d.counter.family == spec.family &&
+				d.counter.table == spec.table &&
+				d.counter.name == counter)
+				return d.counter;
+
+		return null;
+	},
+
 	load() {
 		return Promise.all([
-			L.resolveDefault(fs.exec_direct('/usr/sbin/nft', [ '--terse', '--json', 'list', 'ruleset' ], 'json'), {}),
+			L.resolveDefault(fs.exec_direct('/usr/sbin/nft', ['--terse', '--json', 'list', 'ruleset'], 'json'), {}),
 			fs.stat('/usr/sbin/iptables-legacy-save').then(function() {
-                return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-legacy-save'), '');
-            }).catch(function() {
-                return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-save'), '');
-            }),
-            fs.stat('/usr/sbin/ip6tables-legacy-save').then(function() {
-                return L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-legacy-save'), '');
-            }).catch(function() {
-                return L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-save'), '');
-            })
+				return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-legacy-save'), '');
+			}).catch(function() {
+				return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-save'), '');
+			}),
+			fs.stat('/usr/sbin/ip6tables-legacy-save').then(function() {
+				return L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-legacy-save'), '');
+			}).catch(function() {
+				return L.resolveDefault(fs.exec_direct('/usr/sbin/ip6tables-save'), '');
+			})
 		]);
 	},
 
@@ -582,8 +597,11 @@ return view.extend({
 					empty = false;
 
 					if (typeof(se) == 'object' && se.counter) {
-						row.childNodes[0].appendChild(
-							this.renderCounter(se.counter));
+						const ctr = this.resolveCounter(data, spec, se.counter);
+
+						if (ctr)
+							row.childNodes[0].appendChild(
+								this.renderCounter(ctr));
 					}
 
 					// append each mapped action to the actions column
@@ -595,9 +613,12 @@ return view.extend({
 				const res = this.renderExpr(se, spec.table);
 
 				if (typeof(se) == 'object' && se.counter) {
-					row.childNodes[0].insertBefore(
-						this.renderCounter(se.counter),
-						row.childNodes[0].firstChild);
+					const ctr = this.resolveCounter(data, spec, se.counter);
+
+					if (ctr)
+						row.childNodes[0].insertBefore(
+							this.renderCounter(ctr),
+							row.childNodes[0].firstChild);
 				}
 				else if (this.isActionExpression(se)) {
 					dom.append(row.childNodes[1], [ res ]);


### PR DESCRIPTION
### Description

The nftables status view rendered the byte/packet badge by reading .bytes/.packets directly off a rule's counter statement. That only holds for anonymous (inline) counters, whose JSON statement is an object. Named counter objects (counter name "<n>") are serialized as a bare name string instead, so .bytes was undefined and the badge showed "undefinedB". Named counters are used in banIP for example.

Resolve named counter references against the standalone counter objects of the same family and table before rendering, and skip the badge when a reference cannot be resolved instead of emitting garbage.

While at it, replace some whitespaces with tabs as well.

### Screenshot changes
Old nftables view:
<img width="851" height="514" alt="nftables_old" src="https://github.com/user-attachments/assets/f2bd86da-e7aa-4e0d-8709-352cff0d13a0" />

New nftables view:
<img width="851" height="514" alt="nftables_new" src="https://github.com/user-attachments/assets/e96815fa-00b2-4c32-93af-cd98c391d8d8" />

## Tested on
Bananapi BPI-R3, mediatek/filogic, OpenWrt SNAPSHOT (r34876-a1a3659c29)

---

Signed-off-by: Dirk Brenken <dev@brenken.org>