### PR TITLE
luci-base: fix German translation of "Unmanaged"

### DIFF
--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -13952,7 +13952,7 @@ msgstr "Unbekannter Fehlercode"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
 #: modules/luci-compat/luasrc/model/network.lua:965
 msgid "Unmanaged"
-msgstr "Ignoriert"
+msgstr "Nicht verwaltet"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:174
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:196


### PR DESCRIPTION
The German translation of "Unmanaged" (network protocol type) was "Ignoriert" (Ignored), which is misleading. An unmanaged interface is not ignored — it exists but is simply not configured by the system.

This changes the translation to "Nicht verwaltet" (Not managed) which accurately reflects the meaning of the protocol type in the network interface context.