### PR TITLE
luci-app-singbox: add new package

### DIFF
--- a/applications/luci-app-singbox/Makefile
+++ b/applications/luci-app-singbox/Makefile
@@ -1,0 +1,73 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luci-app-singbox
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_MAINTAINER:=Dmitriy Stroganov <strodi@yandex.ru>
+
+LUCI_TITLE:=sing-box VPN — VLESS+REALITY management interface
+LUCI_DESCRIPTION:=Web interface for sing-box proxy with VLESS+REALITY support, \
+	traffic splitting, geosite rules, subscription import, and real-time \
+	monitoring via Clash API.
+
+define Package/$(PKG_NAME)
+  SECTION:=luci
+  CATEGORY:=LuCI
+  SUBMENU:=3. Applications
+  TITLE:=$(LUCI_TITLE)
+  DEPENDS:=+sing-box +luci-base +jq
+  PKGARCH:=all
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/usr/share/singbox
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
+	$(INSTALL_DIR) $(1)/usr/share/luci/menu.d
+	$(INSTALL_DIR) $(1)/usr/share/ucode/rpc
+	$(INSTALL_DIR) $(1)/www/luci-static/resources/view/singbox
+
+	$(INSTALL_DATA) ./files/etc/config/singbox                   $(1)/etc/config/singbox
+	$(INSTALL_BIN)  ./files/etc/init.d/sing-box                  $(1)/etc/init.d/sing-box
+	$(INSTALL_BIN)  ./files/etc/uci-defaults/singbox-migrate     $(1)/etc/uci-defaults/singbox-migrate
+	$(INSTALL_BIN)  ./files/usr/share/singbox/generate-config.sh $(1)/usr/share/singbox/generate-config.sh
+	$(INSTALL_BIN)  ./files/usr/share/singbox/status.sh          $(1)/usr/share/singbox/status.sh
+	$(INSTALL_BIN)  ./files/usr/share/singbox/update-subscription.sh $(1)/usr/share/singbox/update-subscription.sh
+	$(INSTALL_BIN)  ./files/usr/share/singbox/tail-log.sh        $(1)/usr/share/singbox/tail-log.sh
+	$(INSTALL_DATA) ./files/usr/share/rpcd/acl.d/luci-app-singbox.json   $(1)/usr/share/rpcd/acl.d/luci-app-singbox.json
+	$(INSTALL_DATA) ./files/usr/share/luci/menu.d/luci-app-singbox.json  $(1)/usr/share/luci/menu.d/luci-app-singbox.json
+	$(INSTALL_BIN)  ./files/usr/share/ucode/rpc/singbox.uc       $(1)/usr/share/ucode/rpc/singbox.uc
+
+	$(INSTALL_DATA) ./files/www/luci-static/resources/view/singbox/overview.js $(1)/www/luci-static/resources/view/singbox/overview.js
+	$(INSTALL_DATA) ./files/www/luci-static/resources/view/singbox/servers.js  $(1)/www/luci-static/resources/view/singbox/servers.js
+	$(INSTALL_DATA) ./files/www/luci-static/resources/view/singbox/routing.js  $(1)/www/luci-static/resources/view/singbox/routing.js
+	$(INSTALL_DATA) ./files/www/luci-static/resources/view/singbox/logs.js     $(1)/www/luci-static/resources/view/singbox/logs.js
+	$(INSTALL_DATA) ./files/www/luci-static/resources/view/singbox/settings.js $(1)/www/luci-static/resources/view/singbox/settings.js
+endef
+
+# Files preserved across upgrade — opkg asks before overwriting if local copy differs.
+define Package/$(PKG_NAME)/conffiles
+/etc/config/singbox
+endef
+
+define Package/$(PKG_NAME)/postinst
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] && exit 0
+/etc/init.d/rpcd restart >/dev/null 2>&1 || true
+exit 0
+endef
+
+define Package/$(PKG_NAME)/postrm
+#!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] && exit 0
+/etc/init.d/rpcd restart >/dev/null 2>&1 || true
+exit 0
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/applications/luci-app-singbox/README.md
+++ b/applications/luci-app-singbox/README.md
@@ -1,0 +1,41 @@
+# luci-app-singbox
+
+LuCI web interface for [sing-box](https://github.com/SagerNet/sing-box) on OpenWrt,
+focused on **VLESS + REALITY** — the most censorship-resistant proxy protocol —
+with selective traffic splitting, GeoSite rule presets, multi-server failover,
+and real-time monitoring via sing-box's built-in Clash API.
+
+## Features
+
+- VLESS + REALITY with `xtls-rprx-vision` flow and uTLS fingerprint emulation
+- Selective traffic splitting via GeoSite presets (YouTube, Google, Telegram,
+  OpenAI, Spotify, Discord, Netflix, Microsoft, Apple, Amazon, …)
+- Multi-server with `urltest` auto-failover
+- Real-time dashboard (status, active server, uptime, traffic, sortable connections)
+- Live log viewer (`logread`-backed, level filter, search, auto-refresh)
+- Subscription import (base64-encoded `vless://` lists, deduplicated by name)
+- Custom routing rules: GeoSite / IP CIDR / Domain with VPN / Direct / Block actions
+- Network-wide ad blocking via `geosite-category-ads-all`
+- Validation gate: every generated config is checked with `sing-box check`
+  before deployment, so a typo never takes the router offline
+
+## Requirements
+
+- OpenWrt 22.03+ (tested on 24.10)
+- sing-box 1.11.0+
+- `kmod-tun`
+- ~250 KB free overlay
+
+## Architecture
+
+UCI is the single source of truth. `generate-config.sh` reads
+`/etc/config/singbox`, renders sing-box JSON, validates it with `sing-box check`,
+and only then atomically replaces `/etc/sing-box/config.json`. A typo or missing
+field never reaches the running daemon.
+
+sing-box logs to stderr; procd's stdout/stderr capture relays it to syslog
+(logd ring buffer). The Logs tab reads via `logread | grep sing-box`.
+
+## License
+
+GPL-2.0-or-later

--- a/applications/luci-app-singbox/files/etc/config/singbox
+++ b/applications/luci-app-singbox/files/etc/config/singbox
@@ -1,0 +1,114 @@
+config general 'general'
+	option enabled '1'
+	option log_level 'info'
+	option log_output '/tmp/sing-box.log'
+	option stack 'gvisor'
+	option tun_address '172.19.0.1/30'
+	option tun_mtu '1400'
+	option auto_route '1'
+	option strict_route '1'
+	option clash_api '1'
+	option clash_api_port '9090'
+	option final_outbound 'direct'
+
+config urltest 'urltest'
+	option enabled '1'
+	option interval '3m'
+	option tolerance '50'
+	option test_url 'http://www.gstatic.com/generate_204'
+
+config dns 'dns'
+	option direct_server 'auto'
+	option tunnel_server '8.8.8.8'
+	option strategy 'prefer_ipv4'
+
+# Example VLESS+REALITY server. Disabled by default — replace with your own
+# credentials or import via the Servers tab → Subscription.
+config server
+	option name 'example-server'
+	option enabled '0'
+	option type 'vless'
+	option server 'example.com'
+	option port '443'
+	option uuid '00000000-0000-0000-0000-000000000000'
+	option flow 'xtls-rprx-vision'
+	option sni 'www.microsoft.com'
+	option utls_fingerprint 'chrome'
+	option reality_public_key 'REPLACE_WITH_YOUR_REALITY_PUBLIC_KEY'
+	option reality_short_id '0000000000000000'
+
+config rule
+	option name 'YouTube'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-youtube'
+	option outbound 'auto'
+
+config rule
+	option name 'Google'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-google'
+	option outbound 'auto'
+
+config rule
+	option name 'Instagram'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-instagram'
+	option outbound 'auto'
+
+config rule
+	option name 'Twitter'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-twitter'
+	option outbound 'auto'
+
+config rule
+	option name 'Facebook'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-facebook'
+	option outbound 'auto'
+
+config rule
+	option name 'Telegram Domains'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-telegram'
+	option outbound 'auto'
+
+config rule
+	option name 'Telegram IPs'
+	option enabled '1'
+	option type 'ip_cidr'
+	option match '91.105.192.0/23 91.108.0.0/16 95.161.64.0/20 149.154.160.0/20 185.76.151.0/24'
+	option outbound 'auto'
+
+config rule
+	option name 'OpenAI'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-openai'
+	option outbound 'auto'
+
+config rule
+	option name 'SoundCloud'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-soundcloud'
+	option outbound 'auto'
+
+config rule
+	option name 'Ad Block'
+	option enabled '1'
+	option type 'geosite'
+	option match 'geosite-category-ads-all'
+	option outbound 'block'
+
+config subscription
+	option enabled '0'
+	option url ''
+	option auto_update '0'
+	option update_interval '24h'

--- a/applications/luci-app-singbox/files/etc/init.d/sing-box
+++ b/applications/luci-app-singbox/files/etc/init.d/sing-box
@@ -1,0 +1,128 @@
+#!/bin/sh /etc/rc.common
+# init.d/sing-box — procd init script for sing-box.
+#
+# Lifecycle:
+#   start     regenerate config, validate, launch sing-box under procd
+#   stop      terminate the instance
+#   restart   stop + start
+#   reload    regenerate config in-place and SIGHUP the running process
+#   generate  regenerate /etc/sing-box/config.json without touching the daemon
+#
+# UCI options read from /etc/config/singbox → general:
+#   enabled           0/1     master switch (default 1)
+#   wait_for_usb      0/1     wait for usb_binary_path before start (default 0)
+#   usb_binary_path   path    path to wait for, default /mnt/usb/sing-box
+#   usb_wait_timeout  N       seconds to wait, default 15
+#
+# Auto-detect: if /usr/bin/sing-box is a symlink whose target does not exist,
+# the USB wait kicks in even when wait_for_usb=0 — protects against
+# "binary on external storage" setups where the user forgot to enable it.
+#
+# Respawn: 5 tries within 3600 s, 5 s timeout. Open file limit raised to 1 MiB.
+
+USE_PROCD=1
+START=99
+STOP=10
+
+EXTRA_HELP="	reload	Reload configuration (regenerate config and signal sing-box)
+	generate	Generate config from UCI without restart"
+
+CONF="/etc/sing-box/config.json"
+UCI_CFG="singbox"
+
+# Wait for the sing-box binary if it lives on a removable medium (USB).
+# Activates on UCI wait_for_usb=1 OR when /usr/bin/sing-box is a dangling symlink.
+wait_for_binary() {
+	local bin="$1"
+	local need_wait=0
+	local real_target
+
+	config_get_bool need_wait general wait_for_usb 0
+	if [ "$need_wait" != "1" ]; then
+		# Auto-detect dangling symlink — typical of "binary on USB" setups.
+		if [ -L "$bin" ]; then
+			real_target=$(readlink -f "$bin" 2>/dev/null)
+			[ -e "$real_target" ] || need_wait=1
+		fi
+	fi
+	[ "$need_wait" = "1" ] || return 0
+
+	local usb_path timeout
+	config_get usb_path general usb_binary_path "/mnt/usb/sing-box"
+	config_get timeout general usb_wait_timeout 15
+
+	local i
+	for i in $(seq 1 "$timeout"); do
+		[ -e "$usb_path" ] && return 0
+		sleep 1
+	done
+
+	logger -t sing-box "ERROR: $usb_path not available after ${timeout}s, refusing to start"
+	return 1
+}
+
+start_service() {
+	[ -f /etc/config/$UCI_CFG ] || exit 0
+
+	. /lib/functions.sh
+	config_load "$UCI_CFG"
+
+	config_get_bool enabled general enabled 1
+	[ "$enabled" = "1" ] || return 0
+
+	wait_for_binary /usr/bin/sing-box || return 1
+
+	/usr/share/singbox/generate-config.sh >/dev/null 2>&1
+	[ -f "$CONF" ] || {
+		logger -t sing-box "config generation failed, refusing to start"
+		return 1
+	}
+
+	config_get log_output general log_output "/tmp/sing-box.log"
+	# Note: log_output UCI option is accepted for backward compatibility but
+	# no longer used — sing-box now logs to stderr, which procd relays to
+	# syslog (logd ring buffer). Rotation is handled by logd itself.
+
+	procd_open_instance
+	procd_set_param command /usr/bin/sing-box run -c "$CONF"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn 3600 5 5
+	procd_set_param limits nofile=1048576
+	procd_set_param term_timeout 5
+	procd_close_instance
+}
+
+reload_service() {
+	/usr/share/singbox/generate-config.sh >/dev/null 2>&1 || return 1
+	procd_send_signal "$initscript"
+}
+
+reload() {
+	reload_service
+}
+
+generate() {
+	/usr/share/singbox/generate-config.sh
+}
+
+boot() {
+	[ -f /etc/config/$UCI_CFG ] || exit 0
+	. /lib/functions.sh
+	config_load "$UCI_CFG"
+	config_get_bool enabled general enabled 1
+	[ "$enabled" = "1" ] || exit 0
+	start_service
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$UCI_CFG"
+}
+
+service_started() {
+	procd_set_config_changed "$UCI_CFG"
+}
+
+service_stopped() {
+	procd_set_config_changed "$UCI_CFG"
+}

--- a/applications/luci-app-singbox/files/etc/uci-defaults/singbox-migrate
+++ b/applications/luci-app-singbox/files/etc/uci-defaults/singbox-migrate
@@ -1,0 +1,83 @@
+#!/bin/sh
+# singbox-migrate — one-shot UCI defaults script run on first boot after
+# install. If /etc/sing-box/config.json exists from a pre-luci-app-singbox
+# setup, parse the first REALITY outbound out of it and create a matching
+# `config server` section in /etc/config/singbox, then enable the service.
+#
+# Uses a marker file rather than testing for /etc/config/singbox (which the
+# package always ships as a conffile, so its presence is not a reliable
+# signal of "already migrated").
+
+MARKER="/etc/.singbox.migrated"
+
+[ -f /etc/sing-box/config.json ] || exit 0
+[ -f "$MARKER" ] && exit 0
+
+CONFIG="/etc/sing-box/config.json"
+
+exists() { [ -n "$1" ]; }
+
+get_json_val() {
+	local key="$1"
+	grep -o "\"$key\"[^,]*" "$CONFIG" 2>/dev/null | head -1 | sed 's/.*: *"//' | sed 's/".*//'
+}
+
+get_json_num() {
+	local key="$1"
+	grep -o "\"$key\"[^,]*" "$CONFIG" 2>/dev/null | head -1 | sed 's/.*: *//' | sed 's/,.*//'
+}
+
+uci -q batch << EOF
+set singbox.general.enabled=1
+set singbox.general.stack=gvisor
+set singbox.general.tun_address=172.19.0.1/30
+set singbox.general.tun_mtu=1400
+set singbox.general.auto_route=1
+set singbox.general.strict_route=1
+set singbox.general.clash_api=1
+set singbox.general.clash_api_port=9090
+set singbox.general.final_outbound=direct
+set singbox.urltest.enabled=1
+set singbox.urltest.interval=3m
+set singbox.urltest.tolerance=50
+set singbox.dns.direct_server=auto
+set singbox.dns.tunnel_server=8.8.8.8
+set singbox.dns.strategy=prefer_ipv4
+EOF
+
+SERVERS=$(grep -o '"tag":"[^"]*xray"' "$CONFIG" 2>/dev/null | sed 's/"tag":"//;s/"//')
+for TAG in $SERVERS; do
+	SERVER=$(grep -A20 "\"tag\":\"$TAG\"" "$CONFIG" | grep '"server"' | head -1 | sed 's/.*: *"//;s/".*')
+	PORT=$(grep -A20 "\"tag\":\"$TAG\"" "$CONFIG" | grep '"server_port"' | head -1 | sed 's/.*: *//;s/,.*//')
+	UUID=$(grep -A20 "\"tag\":\"$TAG\"" "$CONFIG" | grep '"uuid"' | head -1 | sed 's/.*: *"//;s/".*')
+	SNI=$(grep -A20 "\"tag\":\"$TAG\"" "$CONFIG" | grep '"server_name"' | head -1 | sed 's/.*: *"//;s/".*')
+	PUBKEY=$(grep -A20 "\"tag\":\"$TAG\"" "$CONFIG" | grep '"public_key"' | head -1 | sed 's/.*: *"//;s/".*')
+	SHORTID=$(grep -A20 "\"tag\":\"$TAG\"" "$CONFIG" | grep '"short_id"' | head -1 | sed 's/.*: *"//;s/".*')
+
+	[ -z "$SERVER" ] && continue
+
+	SID=$(uci -q add singbox server)
+	uci -q set "singbox.$SID.name=$TAG"
+	uci -q set "singbox.$SID.enabled=1"
+	uci -q set "singbox.$SID.type=vless"
+	uci -q set "singbox.$SID.server=$SERVER"
+	uci -q set "singbox.$SID.port=${PORT:-443}"
+	uci -q set "singbox.$SID.uuid=$UUID"
+	uci -q set "singbox.$SID.flow=xtls-rprx-vision"
+	uci -q set "singbox.$SID.sni=$SNI"
+	uci -q set "singbox.$SID.utls_fingerprint=chrome"
+	exists "$PUBKEY" && uci -q set "singbox.$SID.reality_public_key=$PUBKEY"
+	exists "$SHORTID" && uci -q set "singbox.$SID.reality_short_id=$SHORTID"
+done
+
+uci -q commit singbox
+
+/etc/init.d/sing-box enable >/dev/null 2>&1
+
+# Marker so this script never re-runs (uci-defaults are normally invoked once,
+# but be defensive).
+touch "$MARKER"
+
+logger -t singbox-init "Imported existing sing-box config into UCI"
+
+exit 0

--- a/applications/luci-app-singbox/files/usr/share/luci/menu.d/luci-app-singbox.json
+++ b/applications/luci-app-singbox/files/usr/share/luci/menu.d/luci-app-singbox.json
@@ -1,0 +1,53 @@
+{
+	"admin/services/singbox": {
+		"title": "sing-box",
+		"order": 60,
+		"action": {
+			"type": "alias",
+			"path": "admin/services/singbox/overview"
+		},
+		"depends": {
+			"fs": "/usr/bin/sing-box"
+		}
+	},
+	"admin/services/singbox/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "singbox/overview"
+		}
+	},
+	"admin/services/singbox/servers": {
+		"title": "Servers",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "singbox/servers"
+		}
+	},
+	"admin/services/singbox/routing": {
+		"title": "Routing",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "singbox/routing"
+		}
+	},
+	"admin/services/singbox/logs": {
+		"title": "Logs",
+		"order": 40,
+		"action": {
+			"type": "view",
+			"path": "singbox/logs"
+		}
+	},
+	"admin/services/singbox/settings": {
+		"title": "Settings",
+		"order": 50,
+		"action": {
+			"type": "view",
+			"path": "singbox/settings"
+		}
+	}
+}

--- a/applications/luci-app-singbox/files/usr/share/rpcd/acl.d/luci-app-singbox.json
+++ b/applications/luci-app-singbox/files/usr/share/rpcd/acl.d/luci-app-singbox.json
@@ -1,0 +1,29 @@
+{
+	"luci-app-singbox": {
+		"description": "sing-box VPN management",
+		"read": {
+			"ubus": {
+				"file": ["list", "read", "exec"],
+				"uci": ["get"]
+			},
+			"uci": ["singbox"],
+			"file": {
+				"/usr/share/singbox/status.sh": ["read", "exec"],
+				"/usr/share/singbox/tail-log.sh": ["read", "exec"]
+			}
+		},
+		"write": {
+			"ubus": {
+				"file": ["exec", "write"],
+				"uci": ["set", "add", "delete", "commit"]
+			},
+			"uci": ["singbox"],
+			"file": {
+				"/usr/share/singbox/*": ["exec"],
+				"/etc/init.d/sing-box": ["exec"],
+				"/etc/sing-box/config.json": ["write"],
+				"/tmp/singbox-config-preview.json": ["write"]
+			}
+		}
+	}
+}

--- a/applications/luci-app-singbox/files/usr/share/singbox/generate-config.sh
+++ b/applications/luci-app-singbox/files/usr/share/singbox/generate-config.sh
@@ -1,0 +1,433 @@
+#!/bin/sh
+# generate-config.sh — render /etc/sing-box/config.json from UCI.
+#
+# Reads /etc/config/singbox, emits a sing-box JSON document to a temp file,
+# validates it with `sing-box check`, and only then atomically installs it
+# to $SINGBOX_CONFIG. Exits non-zero on any failure so callers (init script,
+# Apply button, rpc layer) can react.
+#
+# Usage:    generate-config.sh
+# Stdout:   "OK: config generated and validated"  (or an error line)
+# Exit:     0 success, 1 generation/validation failure
+# Depends:  /lib/functions.sh (UCI helpers), /usr/bin/sing-box (optional).
+
+SINGBOX_CONFIG="/etc/sing-box/config.json"
+SINGBOX_DIR="$(dirname "$SINGBOX_CONFIG")"
+GEOSITE_BASE="https://raw.githubusercontent.com/SagerNet/sing-geosite/rule-set"
+
+. /lib/functions.sh
+
+# JSON-escape a string for safe interpolation into a "…" JSON value.
+# Backslash first (otherwise the escape char is duplicated), then quote.
+# sing-box check rejects malformed JSON, so without this a single stray
+# " in a server tag or SNI would silently break config generation.
+json_escape() {
+	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+config_load singbox
+
+config_get_bool ENABLED general enabled 1
+config_get LOG_LEVEL general log_level "info"
+config_get LOG_OUTPUT general log_output "/tmp/sing-box.log"
+config_get STACK general stack "gvisor"
+config_get TUN_ADDR general tun_address "172.19.0.1/30"
+config_get TUN_MTU general tun_mtu "1400"
+config_get_bool AUTO_ROUTE general auto_route 1
+config_get_bool STRICT_ROUTE general strict_route 1
+config_get_bool CLASH_API general clash_api 1
+config_get CLASH_PORT general clash_api_port "9090"
+config_get FINAL_OUTBOUND general final_outbound "direct"
+
+config_get_bool URLTEST_ENABLED urltest enabled 1
+config_get URLTEST_INTERVAL urltest interval "3m"
+config_get URLTEST_TOLERANCE urltest tolerance "50"
+config_get URLTEST_URL urltest test_url "http://www.gstatic.com/generate_204"
+
+config_get DNS_DIRECT dns direct_server "auto"
+config_get DNS_TUNNEL dns tunnel_server "8.8.8.8"
+config_get DNS_STRATEGY dns strategy "prefer_ipv4"
+
+auto_route="false"
+strict_route="false"
+[ "$AUTO_ROUTE" = "1" ] && auto_route="true"
+[ "$STRICT_ROUTE" = "1" ] && strict_route="true"
+
+build_log() {
+	# sing-box writes to stdout/stderr when "output" is omitted; procd's
+	# stdout/stderr capture in the init script relays it to syslog (logd
+	# ring buffer). This is the OpenWrt-idiomatic path — logd handles
+	# rotation itself, no SIGHUP games, no risk of crash-looping sing-box
+	# by signalling a "reload" while TUN is held by the dying process.
+	printf '{"level":"%s","timestamp":true}' "$(json_escape "$LOG_LEVEL")"
+}
+
+get_direct_dns() {
+	if [ "$DNS_DIRECT" = "auto" ]; then
+		cat /tmp/resolv.conf.d/resolv.conf.auto 2>/dev/null | grep nameserver | head -1 | awk '{print $2}'
+	else
+		echo "$DNS_DIRECT"
+	fi
+}
+
+build_dns() {
+	local direct_dns
+	direct_dns=$(get_direct_dns)
+	[ -z "$direct_dns" ] && direct_dns="1.1.1.1"
+
+	local tunnel_dns="$DNS_TUNNEL"
+	[ -z "$tunnel_dns" ] && tunnel_dns="8.8.8.8"
+
+	printf '{"servers":['
+	printf '{"type":"udp","tag":"dns-direct","server":"%s"}' "$(json_escape "$direct_dns")"
+	printf ',{"type":"tcp","tag":"dns-tunnel","server":"%s","detour":"auto"}' "$(json_escape "$tunnel_dns")"
+	printf '],'
+
+	printf '"rules":['
+
+	local dns_rules=""
+
+	config_foreach collect_dns_rules rule
+	if [ -n "$dns_rules" ]; then
+		printf '{"rule_set":[%s],"server":"dns-tunnel"}' "$dns_rules"
+	fi
+
+	printf '],'
+
+	printf '"final":"dns-direct","strategy":"%s"' "$(json_escape "$DNS_STRATEGY")"
+	printf '}'
+}
+
+collect_dns_rules() {
+	local name="$1"
+	local enabled type match outbound
+	config_get_bool enabled "$name" enabled 1
+	config_get type "$name" type
+	config_get match "$name" match
+	config_get outbound "$name" outbound
+
+	[ "$enabled" = "1" ] || return
+	[ "$type" = "geosite" ] || return
+	[ "$outbound" = "auto" ] || return
+
+	local esc_match
+	esc_match=$(json_escape "$match")
+	if [ -z "$dns_rules" ]; then
+		dns_rules="\"$esc_match\""
+	else
+		dns_rules="$dns_rules,\"$esc_match\""
+	fi
+}
+
+build_inbounds() {
+	printf '{"type":"tun","tag":"tun-in","interface_name":"sing-tun","address":["%s"],"mtu":%s,"auto_route":%s,"strict_route":%s,"stack":"%s"}' \
+		"$(json_escape "$TUN_ADDR")" "$TUN_MTU" "$auto_route" "$strict_route" "$(json_escape "$STACK")"
+}
+
+build_outbounds() {
+	local server_count=0
+
+	config_foreach count_enabled_server server
+
+	if [ "$server_count" -eq 0 ]; then
+		# No enabled servers — fall back to direct-only so the router stays
+		# reachable. The "block" outbound is intentionally omitted: modern
+		# sing-box uses the route-rule action "reject" instead, and a stale
+		# block tag here would trigger "operation not permitted" warnings.
+		printf '{"type":"direct","tag":"direct"}'
+		return
+	fi
+
+	first_outbound=1
+	config_foreach build_vless_outbound server
+
+	if [ "$URLTEST_ENABLED" = "1" ] && [ "$server_count" -ge 2 ]; then
+		printf ','
+		printf '{"type":"urltest","tag":"auto","outbounds":['
+		local first_urltest=1
+		config_foreach add_to_urltest server
+		printf '],"url":"%s","interval":"%s","tolerance":%s}' \
+			"$(json_escape "$URLTEST_URL")" "$(json_escape "$URLTEST_INTERVAL")" "$URLTEST_TOLERANCE"
+	fi
+
+	printf ',{"type":"direct","tag":"direct"}'
+}
+
+count_enabled_server() {
+	local name="$1"
+	local enabled
+	config_get_bool enabled "$name" enabled 1
+	[ "$enabled" = "1" ] && server_count=$((server_count + 1))
+}
+
+add_to_urltest() {
+	local name="$1"
+	local enabled tag
+	config_get_bool enabled "$name" enabled 1
+	config_get tag "$name" name
+	[ "$enabled" = "1" ] || return
+	[ -z "$tag" ] && return
+	[ "$first_urltest" = "1" ] && first_urltest=0 || printf ','
+	printf '"%s"' "$(json_escape "$tag")"
+}
+
+build_vless_outbound() {
+	local name="$1"
+	local enabled srv_type server port uuid flow sni fp pub_key short_id
+	config_get_bool enabled "$name" enabled 1
+	config_get srv_type "$name" type
+	config_get server "$name" server
+	config_get port "$name" port
+	config_get uuid "$name" uuid
+	config_get flow "$name" flow
+	config_get sni "$name" sni
+	config_get fp "$name" utls_fingerprint
+	config_get pub_key "$name" reality_public_key
+	config_get short_id "$name" reality_short_id
+	config_get tag "$name" name
+
+	[ "$enabled" = "1" ] || return
+	[ "$srv_type" = "vless" ] || return
+	[ -z "$server" ] && return
+
+	[ "$first_outbound" = "1" ] && first_outbound=0 || printf ','
+
+	printf '{"type":"vless","tag":"%s","server":"%s","server_port":%s,"uuid":"%s"' \
+		"$(json_escape "$tag")" "$(json_escape "$server")" "$port" "$(json_escape "$uuid")"
+
+	[ -n "$flow" ] && printf ',"flow":"%s"' "$(json_escape "$flow")"
+
+	printf ',"tls":{"enabled":true,"server_name":"%s"' "$(json_escape "$sni")"
+	printf ',"utls":{"enabled":true,"fingerprint":"%s"}' "$(json_escape "$fp")"
+	printf ',"reality":{"enabled":true,"public_key":"%s","short_id":"%s"}}' "$(json_escape "$pub_key")" "$(json_escape "$short_id")"
+	printf '}'
+}
+
+build_rule_sets() {
+	local sets=""
+	config_foreach collect_geosite_rules rule
+
+	if [ -n "$sets" ]; then
+		printf '%s' "$sets"
+	fi
+}
+
+collect_geosite_rules() {
+	local name="$1"
+	local enabled type match
+	config_get_bool enabled "$name" enabled 1
+	config_get type "$name" type
+	config_get match "$name" match
+
+	[ "$enabled" = "1" ] || return
+	[ "$type" = "geosite" ] || return
+	[ -z "$match" ] && return
+
+	local esc_match esc_url
+	esc_match=$(json_escape "$match")
+	esc_url=$(json_escape "$GEOSITE_BASE/$match.srs")
+	if [ -z "$sets" ]; then
+		sets="{\"type\":\"remote\",\"tag\":\"$esc_match\",\"format\":\"binary\",\"url\":\"$esc_url\",\"download_detour\":\"direct\"}"
+	else
+		sets="$sets,{\"type\":\"remote\",\"tag\":\"$esc_match\",\"format\":\"binary\",\"url\":\"$esc_url\",\"download_detour\":\"direct\"}"
+	fi
+}
+
+build_route_rules() {
+	printf '{"action":"sniff"},'
+	printf '{"protocol":"dns","action":"hijack-dns"},'
+
+	local block_tags=""
+	local proxy_tags=""
+	local direct_tags=""
+	local ip_cidr_rules=""
+	local domain_auto=""
+	local domain_direct=""
+	local domain_block=""
+
+	config_foreach collect_route_rules rule
+
+	if [ -n "$block_tags" ]; then
+		# Modern sing-box (1.10+) prefers the route-rule action "reject" over
+		# routing to a `block` outbound. The latter prints
+		# "operation not permitted" warnings on each match because the kernel
+		# refuses to drop already-established sockets the way sing-box asks.
+		printf '{"rule_set":[%s],"action":"reject"},' "$block_tags"
+	fi
+
+	if [ -n "$ip_cidr_rules" ]; then
+		printf '{"ip_cidr":[%s],"outbound":"auto"},' "$ip_cidr_rules"
+	fi
+
+	if [ -n "$domain_block" ]; then
+		printf '{"domain":[%s],"action":"reject"},' "$domain_block"
+	fi
+
+	if [ -n "$domain_direct" ]; then
+		printf '{"domain":[%s],"outbound":"direct"},' "$domain_direct"
+	fi
+
+	if [ -n "$direct_tags" ]; then
+		printf '{"rule_set":[%s],"outbound":"direct"},' "$direct_tags"
+	fi
+
+	if [ -n "$proxy_tags" ]; then
+		printf '{"rule_set":[%s],"outbound":"auto"},' "$proxy_tags"
+	fi
+
+	if [ -n "$domain_auto" ]; then
+		printf '{"domain":[%s],"outbound":"auto"},' "$domain_auto"
+	fi
+
+	printf '{"ip_is_private":true,"outbound":"direct"}'
+}
+
+collect_route_rules() {
+	local name="$1"
+	local enabled type match outbound
+	config_get_bool enabled "$name" enabled 1
+	config_get type "$name" type
+	config_get match "$name" match
+	config_get outbound "$name" outbound
+
+	[ "$enabled" = "1" ] || return
+	[ -z "$match" ] && return
+
+	if [ "$type" = "geosite" ]; then
+		local esc_match
+		esc_match=$(json_escape "$match")
+		if [ "$outbound" = "block" ]; then
+			if [ -z "$block_tags" ]; then
+				block_tags="\"$esc_match\""
+			else
+				block_tags="$block_tags,\"$esc_match\""
+			fi
+		elif [ "$outbound" = "direct" ]; then
+			if [ -z "$direct_tags" ]; then
+				direct_tags="\"$esc_match\""
+			else
+				direct_tags="$direct_tags,\"$esc_match\""
+			fi
+		else
+			if [ -z "$proxy_tags" ]; then
+				proxy_tags="\"$esc_match\""
+			else
+				proxy_tags="$proxy_tags,\"$esc_match\""
+			fi
+		fi
+	elif [ "$type" = "domain" ]; then
+		local entry quoted
+		for entry in $match; do
+			quoted="\"$(json_escape "$entry")\""
+			case "$outbound" in
+				block)
+					if [ -z "$domain_block" ]; then domain_block="$quoted"
+					else domain_block="$domain_block,$quoted"; fi
+					;;
+				direct)
+					if [ -z "$domain_direct" ]; then domain_direct="$quoted"
+					else domain_direct="$domain_direct,$quoted"; fi
+					;;
+				*)
+					if [ -z "$domain_auto" ]; then domain_auto="$quoted"
+					else domain_auto="$domain_auto,$quoted"; fi
+					;;
+			esac
+		done
+	elif [ "$type" = "ip_cidr" ]; then
+		local cidr
+		for cidr in $match; do
+			if [ -z "$ip_cidr_rules" ]; then
+				ip_cidr_rules="\"$(json_escape "$cidr")\""
+			else
+				ip_cidr_rules="$ip_cidr_rules,\"$(json_escape "$cidr")\""
+			fi
+		done
+	fi
+}
+
+build_route() {
+	# final_outbound=block is special: there is no "block" outbound anymore
+	# (we use the modern "reject" route action), so install a catch-all
+	# reject rule at the end instead of pointing final at a missing tag.
+	local final_tag="$FINAL_OUTBOUND"
+	local emit_final_reject=0
+	if [ "$FINAL_OUTBOUND" = "block" ]; then
+		final_tag="direct"
+		emit_final_reject=1
+	fi
+
+	printf '{"rules":['
+	build_route_rules
+	[ "$emit_final_reject" = "1" ] && printf '{"action":"reject"}'
+	printf '],'
+
+	local sets
+	sets=$(build_rule_sets)
+	if [ -n "$sets" ]; then
+		printf '"rule_set":[%s],' "$sets"
+	fi
+
+	printf '"final":"%s","auto_detect_interface":true' "$(json_escape "$final_tag")"
+	printf ',"default_domain_resolver":{"server":"dns-direct","strategy":"%s"}' "$(json_escape "$DNS_STRATEGY")"
+	printf '}'
+}
+
+build_experimental() {
+	if [ "$CLASH_API" = "1" ]; then
+		printf '{"clash_api":{"external_controller":"127.0.0.1:%s"}}' "$(json_escape "$CLASH_PORT")"
+	else
+		printf '{}'
+	fi
+}
+
+generate() {
+	if [ "$ENABLED" != "1" ]; then
+		echo '{"disabled":true}'
+		return 1
+	fi
+
+	local direct_dns
+	direct_dns=$(get_direct_dns)
+
+	printf '{'
+	printf '"log":'
+	build_log
+	printf ',"dns":'
+	build_dns
+	printf ',"inbounds":['
+	build_inbounds
+	printf ']'
+	printf ',"outbounds":['
+	first_outbound=1
+	build_outbounds
+	printf ']'
+	printf ',"route":'
+	build_route
+	printf ',"experimental":'
+	build_experimental
+	printf '}'
+	printf '\n'
+}
+
+OUTPUT=$(generate 2>&1)
+
+if [ $? -ne 0 ]; then
+	echo "ERROR: Failed to generate config" >&2
+	echo "$OUTPUT" >&2
+	exit 1
+fi
+
+echo "$OUTPUT" > /tmp/singbox-config-preview.json
+
+if [ -x /usr/bin/sing-box ]; then
+	if ! /usr/bin/sing-box check -c /tmp/singbox-config-preview.json 2>/dev/null; then
+		echo "ERROR: sing-box check failed" >&2
+		/usr/bin/sing-box check -c /tmp/singbox-config-preview.json 2>&1 >&2
+		exit 1
+	fi
+fi
+
+mkdir -p "$SINGBOX_DIR"
+cp /tmp/singbox-config-preview.json "$SINGBOX_CONFIG"
+echo "OK: config generated and validated"

--- a/applications/luci-app-singbox/files/usr/share/singbox/status.sh
+++ b/applications/luci-app-singbox/files/usr/share/singbox/status.sh
@@ -1,0 +1,250 @@
+#!/bin/sh
+
+#!/bin/sh
+# status.sh — read-only bridge between sing-box's Clash API and LuCI.
+#
+# Modes:
+#   status.sh [api_addr] status         Summary JSON for the dashboard.
+#   status.sh [api_addr] servers        Per-server latency array.
+#   status.sh [api_addr] connections [N]  Top-N busiest flows.
+#   status.sh [api_addr] test <name>    Single server latency probe.
+#
+# All output is single-line JSON. Latency probes use the real VLESS chain via
+# /proxies/<tag>/delay; if the daemon is down or unreachable the fields
+# degrade gracefully (status="offline", latency=0) instead of erroring.
+# Depends: wget, pgrep, ps, ip, jq (optional, used for URL-encoding and
+# connection extraction).
+
+CLASH_API="${1:-127.0.0.1:9090}"
+MODE="${2:-status}"
+TARGET="${3:-}"
+
+# http_get URL [timeout]
+#
+# Fetch a single payload from the Clash API. The /traffic and /connections
+# endpoints are streaming (server never closes the connection), which makes
+# BusyBox wget hang forever. We work around this by forking wget to a temp
+# file and killing it the moment we have any data (or after timeout).
+http_get() {
+	local url="$1"
+	local max_wait="${2:-3}"
+	local tmp="/tmp/sb-http.$$"
+
+	wget -q -O "$tmp" -T "$max_wait" "$url" >/dev/null 2>&1 &
+	local wpid=$!
+
+	local i=0
+	while [ "$i" -lt "$max_wait" ]; do
+		kill -0 "$wpid" 2>/dev/null || break       # wget exited normally
+		[ -s "$tmp" ] && { kill -9 "$wpid" 2>/dev/null; break; }
+		sleep 1
+		i=$((i + 1))
+	done
+	kill -9 "$wpid" 2>/dev/null
+	wait "$wpid" 2>/dev/null
+
+	cat "$tmp" 2>/dev/null
+	rm -f "$tmp"
+}
+
+urlencode() {
+	if [ -x /usr/bin/jq ]; then
+		printf '%s' "$1" | jq -sRr @uri 2>/dev/null
+	else
+		# POSIX fallback — jq is a hard dependency, this only runs if removed.
+		printf '%s' "$1" | awk '
+			function ord(ch, k) {
+				for (k = 0; k < 256; k++) if (sprintf("%c", k) == ch) return k
+				return 63
+			}
+			{
+				for (i = 1; i <= length($0); i++) {
+					c = substr($0, i, 1)
+					if (c ~ /[A-Za-z0-9._~-]/) printf "%s", c
+					else printf "%%%02X", ord(c)
+				}
+			}'
+	fi
+}
+
+is_running() {
+	local pid
+	pid=$(pgrep -f "sing-box run" 2>/dev/null | head -1)
+	if [ -n "$pid" ]; then
+		echo "true"
+	else
+		echo "false"
+	fi
+}
+
+get_pid() {
+	pgrep -f "sing-box run" 2>/dev/null | head -1
+}
+
+get_uptime() {
+	local pid
+	pid=$(get_pid)
+	[ -z "$pid" ] && echo "0" && return
+	# BusyBox ps has no -o etimes; fall back to /proc/$pid/stat start time.
+	local start_ticks clk_hz now_ticks
+	if [ -r "/proc/$pid/stat" ]; then
+		# Field 22 of /proc/<pid>/stat is the process start time in clock ticks.
+		start_ticks=$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null)
+		clk_hz=$(getconf CLK_TCK 2>/dev/null || echo 100)
+		now_ticks=$(awk '{print $1}' /proc/uptime 2>/dev/null | awk '{print int($1 * '"$clk_hz"')}')
+		[ -n "$start_ticks" ] && [ -n "$now_ticks" ] && echo $(( (now_ticks - start_ticks) / clk_hz )) && return
+	fi
+	# Last resort: ps with etimes (GNU ps); empty if unsupported.
+	local uptime_sec
+	uptime_sec=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
+	echo "${uptime_sec:-0}"
+}
+
+get_tun() {
+	if ip link show sing-tun >/dev/null 2>&1; then
+		echo "true"
+	else
+		echo "false"
+	fi
+}
+
+get_active_server() {
+	local result now
+	result=$(http_get "http://$CLASH_API/proxies/auto")
+	[ -z "$result" ] && { echo "unknown"; return; }
+	# Clash returns "now": "name" — tolerate optional whitespace around the colon.
+	now=$(echo "$result" | grep -oE '"now"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"now"//;s/^[[:space:]]*:[[:space:]]*//;s/^"//;s/"$//')
+	echo "${now:-unknown}"
+}
+
+get_traffic() {
+	local result
+	result=$(http_get "http://$CLASH_API/traffic")
+	if [ -z "$result" ]; then
+		echo '{"up":0,"down":0}'
+	else
+		echo "$result"
+	fi
+}
+
+get_conn_count() {
+	local result
+	result=$(http_get "http://$CLASH_API/connections")
+	if [ -z "$result" ]; then
+		echo "0"
+	else
+		echo "$result" | grep -o '"chains"' | wc -l
+	fi
+}
+
+# Print the top N connections (default 25) as a compact JSON array.
+# Fields: host, src, dest, network, chains, down, up.
+# Sorted by total bytes (down+up) descending so the busiest flows land on top.
+get_connections() {
+	local max="${1:-25}"
+	local result
+	result=$(http_get "http://$CLASH_API/connections")
+	if [ -z "$result" ]; then
+		echo '[]'
+		return
+	fi
+
+	if [ -x /usr/bin/jq ]; then
+		echo "$result" | jq -c --argjson n "$max" '
+			[.connections[]
+			| {
+				host:     (.metadata.host // .metadata.destinationIP // "?"),
+				dest:     ((.metadata.destinationIP // "?") + ":" + (.metadata.destinationPort // "?")),
+				src:      ((.metadata.sourceIP // "?") + ":" + (.metadata.sourcePort // "?")),
+				network:  (.network // "?"),
+				chains:   (.chains // []),
+				down:     (.download // 0),
+				up:       (.upload // 0),
+				total:    ((.download // 0) + (.upload // 0))
+			}]
+			| sort_by(-.total)
+			| .[0:$n]
+		' 2>/dev/null
+	else
+		# No jq — emit minimal shape so the front-end still renders something.
+		echo '[]'
+	fi
+}
+
+get_servers_status() {
+	. /lib/functions.sh
+	config_load singbox
+
+	local first=1
+	printf '['
+	config_foreach print_srv server
+	printf ']'
+}
+
+print_srv() {
+	local name="$1"
+	local enabled tag server port
+	config_get_bool enabled "$name" enabled 1
+	config_get tag "$name" name
+	config_get server "$name" server
+	config_get port "$name" port
+
+	[ "$enabled" = "1" ] || return
+
+	[ "$first" = "1" ] && first=0 || printf ','
+
+	local latency=0
+	local status="offline"
+
+	local delay
+	delay=$(http_get "http://$CLASH_API/proxies/$(urlencode "$tag")/delay?url=http://www.gstatic.com/generate_204&timeout=5000" | grep -o '"delay":[0-9]*' | cut -d: -f2)
+
+	if [ -n "$delay" ]; then
+		latency="$delay"
+		status="online"
+	fi
+
+	printf '{"name":"%s","server":"%s","port":"%s","status":"%s","latency":%s}' \
+		"$tag" "$server" "$port" "$status" "$latency"
+}
+
+test_server() {
+	local target="$1"
+	[ -z "$target" ] && echo '{"status":"offline","latency":0,"error":"no server name"}' && return
+
+	local delay
+	delay=$(http_get "http://$CLASH_API/proxies/$(urlencode "$target")/delay?url=http://www.gstatic.com/generate_204&timeout=5000" | grep -o '"delay":[0-9]*' | cut -d: -f2)
+
+	if [ -n "$delay" ]; then
+		printf '{"name":"%s","status":"online","latency":%s}' "$target" "$delay"
+	else
+		printf '{"name":"%s","status":"offline","latency":0}' "$target"
+	fi
+}
+
+case "$MODE" in
+	status)
+		running=$(is_running)
+		pid=$(get_pid)
+		uptime=$(get_uptime)
+		tun=$(get_tun)
+		active=$(get_active_server)
+		traffic=$(get_traffic)
+		connections=$(get_conn_count)
+
+		printf '{"running":%s,"pid":"%s","uptime":%s,"tun":%s,"active_server":"%s","traffic":%s,"connections":%s}' \
+			"$running" "$pid" "$uptime" "$tun" "$active" "$traffic" "$connections"
+		;;
+	servers)
+		get_servers_status
+		;;
+	connections)
+		get_connections "$TARGET"
+		;;
+	test)
+		test_server "$TARGET"
+		;;
+	*)
+		echo '{"error":"unknown mode"}'
+		;;
+esac

--- a/applications/luci-app-singbox/files/usr/share/singbox/tail-log.sh
+++ b/applications/luci-app-singbox/files/usr/share/singbox/tail-log.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# tail-log.sh — print sing-box-related syslog entries from logd's ring buffer.
+#
+# Why this exists: sing-box logs to stderr (procd captures it to syslog
+# via /dev/log). logd's ring buffer is the canonical source — it handles
+# rotation itself, no SIGHUP games, no risk of crashing sing-box by
+# signalling "reload" while it holds TUN.
+#
+# Usage:   tail-log.sh [lines] [level] [search]
+#   lines   number of trailing lines to keep (default 200)
+#   level   case-insensitive substring filter (info/warn/error/debug/fatal)
+#   search  case-insensitive substring to match
+
+LINES="${1:-200}"
+LEVEL="${2:-}"
+SEARCH="${3:-}"
+
+# logread returns the entire system ring buffer; filter to sing-box lines.
+# We match on "sing-box" because procd prefixes syslog entries with the
+# daemon name:  "daemon.err sing-box[PID]: ..."
+OUT=$(logread 2>/dev/null | grep -F 'sing-box')
+[ -z "$OUT" ] && exit 0
+
+# Keep the last N entries.
+OUT=$(printf '%s\n' "$OUT" | tail -n "$LINES")
+
+# Level filter — sing-box uses uppercase tokens (INFO/WARN/ERROR/DEBUG/FATAL).
+if [ -n "$LEVEL" ] && [ "$LEVEL" != "all" ]; then
+	OUT=$(printf '%s\n' "$OUT" | grep -i "$LEVEL")
+fi
+
+# Substring search.
+if [ -n "$SEARCH" ]; then
+	OUT=$(printf '%s\n' "$OUT" | grep -i "$SEARCH")
+fi
+
+printf '%s\n' "$OUT"

--- a/applications/luci-app-singbox/files/usr/share/singbox/update-subscription.sh
+++ b/applications/luci-app-singbox/files/usr/share/singbox/update-subscription.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+# update-subscription.sh — import VLESS servers from a subscription URL.
+#
+# Accepts either raw or base64-encoded content containing `vless://` lines.
+# Each link is parsed and added as an anonymous `config server` section in
+# /etc/config/singbox. Already-known server names (taken from the vless
+# fragment or synthesised from the host) are skipped to keep imports
+# idempotent across re-runs.
+#
+# Usage:
+#   update-subscription.sh <url>     # one-shot import from a URL
+#   update-subscription.sh           # read URL from UCI: subscription.url
+#
+# Stdout: a single JSON line {success, imported, servers|error}.
+
+URL="${1:-}"
+
+. /lib/functions.sh
+
+if [ -z "$URL" ]; then
+	config_load singbox
+	config_get URL subscription url
+	config_get_bool SUB_ENABLED subscription enabled 0
+	if [ "$SUB_ENABLED" != "1" ] || [ -z "$URL" ]; then
+		echo '{"success":false,"error":"No subscription URL configured"}'
+		exit 1
+	fi
+else
+	# Persist the URL so it shows up in Settings → Subscription URL next
+	# time and so a subsequent no-arg run (e.g. by a future cron auto-update)
+	# knows where to fetch from. The subscription section is anonymous —
+	# address it by type-index rather than by name.
+	config_load singbox
+	uci -q set "singbox.@subscription[0].url=$URL"
+	uci -q commit singbox
+fi
+
+CONTENT=$(wget -qO- "$URL" 2>/dev/null)
+if [ -z "$CONTENT" ]; then
+	echo '{"success":false,"error":"Failed to fetch subscription"}'
+	exit 1
+fi
+
+# Auto-detect base64-encoded payloads (most providers ship base64).
+DECODED=$(echo "$CONTENT" | base64 -d 2>/dev/null)
+if echo "$DECODED" | grep -q "vless://"; then
+	VLESS_LINKS="$DECODED"
+elif echo "$CONTENT" | grep -q "vless://"; then
+	VLESS_LINKS="$CONTENT"
+else
+	echo '{"success":false,"error":"No VLESS links found in subscription"}'
+	exit 1
+fi
+
+IMPORTED=0
+SERVER_NAMES=""
+
+config_load singbox
+
+existing_names() {
+	local name="$1"
+	local tag
+	config_get tag "$name" name
+	EXISTING_TAGS="$EXISTING_TAGS $tag"
+}
+EXISTING_TAGS=""
+config_foreach existing_names server
+
+# Walk links line by line — IFS must be a real newline, not the two chars \n.
+NL="
+"
+IFS="$NL"
+for LINK in $VLESS_LINKS; do
+	LINK=$(echo "$LINK" | tr -d '\r')
+
+	case "$LINK" in
+		vless://*) ;;
+		*) continue ;;
+	esac
+
+	PAYLOAD="${LINK#vless://}"
+	UUID="${PAYLOAD%%@*}"
+	REST="${PAYLOAD#*@}"
+	HOSTPORT="${REST%%\?*}"
+	QUERY_PARAMS="${REST#*\?}"
+	FRAGMENT="${QUERY_PARAMS##*#}"
+	QUERY_PARAMS="${QUERY_PARAMS%%#*}"
+
+	SERVER="${HOSTPORT%%:*}"
+	PORT="${HOSTPORT##*:}"
+
+	if [ "$SERVER" = "$HOSTPORT" ]; then
+		PORT="443"
+	fi
+
+	SNI=$(echo "$QUERY_PARAMS"   | tr '&' '\n' | grep '^sni='  | cut -d= -f2)
+	PUB_KEY=$(echo "$QUERY_PARAMS" | tr '&' '\n' | grep '^pbk='  | cut -d= -f2)
+	SHORT_ID=$(echo "$QUERY_PARAMS" | tr '&' '\n' | grep '^sid='  | cut -d= -f2)
+	FLOW=$(echo "$QUERY_PARAMS"   | tr '&' '\n' | grep '^flow=' | cut -d= -f2)
+	FP=$(echo "$QUERY_PARAMS"    | tr '&' '\n' | grep '^fp='   | cut -d= -f2)
+
+	[ -z "$SNI" ]  && SNI="$SERVER"
+	[ -z "$FP" ]   && FP="chrome"
+	[ -z "$PORT" ] && PORT="443"
+
+	SERVER_NAME="$FRAGMENT"
+	[ -z "$SERVER_NAME" ] && SERVER_NAME="server-$(echo "$SERVER" | tr '.' '-')"
+
+	echo "$EXISTING_TAGS" | grep -qw "$SERVER_NAME" && continue
+
+	NEW_SECTION=$(uci -q add singbox server)
+	[ -z "$NEW_SECTION" ] && continue
+
+	uci set "singbox.$NEW_SECTION.name=$SERVER_NAME"
+	uci set "singbox.$NEW_SECTION.enabled=1"
+	uci set "singbox.$NEW_SECTION.type=vless"
+	uci set "singbox.$NEW_SECTION.server=$SERVER"
+	uci set "singbox.$NEW_SECTION.port=$PORT"
+	uci set "singbox.$NEW_SECTION.uuid=$UUID"
+	[ -n "$FLOW" ]     && uci set "singbox.$NEW_SECTION.flow=$FLOW"
+	uci set "singbox.$NEW_SECTION.sni=$SNI"
+	uci set "singbox.$NEW_SECTION.utls_fingerprint=$FP"
+	[ -n "$PUB_KEY" ]  && uci set "singbox.$NEW_SECTION.reality_public_key=$PUB_KEY"
+	[ -n "$SHORT_ID" ] && uci set "singbox.$NEW_SECTION.reality_short_id=$SHORT_ID"
+
+	IMPORTED=$((IMPORTED + 1))
+	SERVER_NAMES="$SERVER_NAMES $SERVER_NAME"
+done
+unset IFS
+
+uci commit singbox
+
+if [ "$IMPORTED" -gt 0 ]; then
+	echo "{\"success\":true,\"imported\":$IMPORTED,\"servers\":\"${SERVER_NAMES# }\"}"
+else
+	echo '{"success":true,"imported":0,"message":"No new servers to import"}'
+fi

--- a/applications/luci-app-singbox/files/usr/share/ucode/rpc/singbox.uc
+++ b/applications/luci-app-singbox/files/usr/share/ucode/rpc/singbox.uc
@@ -1,0 +1,117 @@
+#!/usr/bin/ucode
+/*
+ * rpcd backend for luci-app-singbox.
+ *
+ * Exposes sing-box management operations over ubus as
+ * `ubus call rpc.singbox.<method> '{...}'`. The LuCI views currently call
+ * the shell scripts directly via fs.exec(); this module provides a stable
+ * RPC surface that mirrors those scripts so views can migrate to it without
+ * exposing arbitrary shell execution to the browser session.
+ *
+ * All user-supplied arguments that reach a shell-interpolated position
+ * (server names, log level and search filters) are sanitised through
+ * shell_safe() before being forwarded. Subscription URLs are passed
+ * unescaped as exec() argv — no shell, no injection surface.
+ */
+
+'use strict';
+
+import { exec } from 'fs';
+
+const STATUS_BIN = '/usr/share/singbox/status.sh';
+const GEN_BIN    = '/usr/share/singbox/generate-config.sh';
+const SUB_BIN    = '/usr/share/singbox/update-subscription.sh';
+const LOGS_BIN   = '/usr/share/singbox/tail-log.sh';
+const INIT_BIN   = '/etc/init.d/sing-box';
+
+function run(path, args) {
+	return exec(path, args || []);
+}
+
+function is_object(v) { return type(v) == 'object'; }
+function is_array(v)  { return type(v) == 'array'; }
+function is_string(v) { return type(v) == 'string'; }
+
+function shell_safe(s) {
+	let out = '';
+	for (let i = 0; i < length(s); i++) {
+		const c = s[i];
+		if ((c >= 'a' && c <= 'z') ||
+		    (c >= 'A' && c <= 'Z') ||
+		    (c >= '0' && c <= '9') ||
+		    c == '.' || c == '_' || c == '-' || c == ':' || c == '/' || c == ' ')
+			out += c;
+	}
+	return out;
+}
+
+function clamp_int(v, lo, hi, dflt) {
+	let n = +v;
+	if (n != n) n = dflt;
+	if (n < lo) n = lo;
+	if (n > hi) n = hi;
+	return n;
+}
+
+return {
+	status: function(req) {
+		const api = (is_string(req) ? req : (req && req.api)) || '127.0.0.1:9090';
+		return run(STATUS_BIN, [ shell_safe(api), 'status' ]);
+	},
+
+	servers: function(req) {
+		const api = (is_string(req) ? req : (req && req.api)) || '127.0.0.1:9090';
+		return run(STATUS_BIN, [ shell_safe(api), 'servers' ]);
+	},
+
+	test: function(req, name) {
+		let api = '127.0.0.1:9090';
+		let srv = null;
+
+		if (is_object(req)) {
+			api = req.api || api;
+			srv = req.name || req.tag;
+		} else if (is_array(req)) {
+			api = req[0] || api;
+			srv = req[1];
+		} else if (is_string(req)) {
+			srv = name || req;
+		}
+
+		if (!srv)
+			return { code: 1, stderr: 'missing server name' };
+
+		return run(STATUS_BIN, [ shell_safe(api), 'test', shell_safe(srv) ]);
+	},
+
+	generate: function() { return run(GEN_BIN); },
+	apply:    function() { return run(INIT_BIN, [ 'restart' ]); },
+	start:    function() { return run(INIT_BIN, [ 'start' ]); },
+	stop:     function() { return run(INIT_BIN, [ 'stop' ]); },
+	restart:  function() { return run(INIT_BIN, [ 'restart' ]); },
+	reload:   function() { return run(INIT_BIN, [ 'reload' ]); },
+
+	importSubscription: function(req) {
+		let url = null;
+		if (is_object(req))      url = req.url;
+		else if (is_string(req)) url = req;
+
+		if (!url)
+			return { code: 1, stderr: 'missing subscription url' };
+
+		return run(SUB_BIN, [ url ]);
+	},
+
+	logs: function(req) {
+		let opts = req;
+		if (!is_object(opts))
+			opts = { lines: req };
+
+		const lines = String(clamp_int(opts.lines, 1, 2000, 200));
+		const level = opts.level ? shell_safe(opts.level) : '';
+		const search = opts.search ? shell_safe(opts.search) : '';
+
+		// logread-based — matches the package's syslog logging backend.
+		return run(LOGS_BIN, [ lines, level, search ]);
+	}
+};

--- a/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/logs.js
+++ b/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/logs.js
@@ -1,0 +1,120 @@
+'use strict';
+// logs.js — live tail of sing-box syslog entries. Level filter (All/Info/
+// Warn/Error/Debug), substring search, manual refresh and auto-refresh
+// toggle (poll every 3 s).
+//
+// sing-box writes to stderr; procd in the init script relays that to
+// syslog (logd's ring buffer). tail-log.sh calls `logread | grep sing-box`
+// server-side — logd handles rotation itself, no SIGHUP / no risk of
+// crash-looping sing-box by signalling a "reload" while TUN is held.
+
+'require view';
+'require fs';
+'require ui';
+'require dom';
+'require poll';
+
+var MAX_LINES = 200;
+var currentLevel = 'all';
+var searchQuery = '';
+var autoRefresh = true;
+
+function getLogs() {
+	return fs.exec('/usr/share/singbox/tail-log.sh', [
+		String(MAX_LINES),
+		currentLevel,
+		searchQuery
+	]).then(function(res) {
+		return res.stdout || res.output || '';
+	}).catch(function(err) {
+		console.warn('[singbox] tail-log failed:', err);
+		return '';
+	});
+}
+
+return view.extend({
+	load: function() {
+		return getLogs();
+	},
+
+	render: function(initialLogs) {
+		var logContainer = E('pre', {
+			id: 'singbox-log-output',
+			style: 'background:#1a1a1a;color:#0f0;font-family:monospace;font-size:12px;padding:15px;max-height:500px;overflow-y:auto;border-radius:4px;white-space:pre-wrap;'
+		}, initialLogs || _('No logs available'));
+
+		function refreshLogs() {
+			getLogs().then(function(text) {
+				dom.content(logContainer, text || _('No logs'));
+				logContainer.scrollTop = logContainer.scrollHeight;
+			});
+		}
+
+		var levelSelect = E('select', {
+			class: 'cbi-input-select',
+			style: 'margin-right:10px;',
+			change: function(ev) {
+				currentLevel = ev.target.value;
+				refreshLogs();
+			}
+		}, [
+			E('option', { value: 'all', selected: true }, _('All')),
+			E('option', { value: 'info' }, _('Info')),
+			E('option', { value: 'warn' }, _('Warning')),
+			E('option', { value: 'error' }, _('Error')),
+			E('option', { value: 'debug' }, _('Debug')),
+			E('option', { value: 'fatal' }, _('Fatal'))
+		]);
+
+		var searchInput = E('input', {
+			type: 'text',
+			class: 'cbi-input-text',
+			placeholder: _('Search logs...'),
+			style: 'width:200px;margin-right:10px;',
+			input: function(ev) { searchQuery = ev.target.value; },
+			keydown: function(ev) {
+				if (ev.key === 'Enter') refreshLogs();
+			}
+		});
+
+		var refreshBtn = E('button', { class: 'btn', click: refreshLogs }, _('Refresh'));
+
+		var autoToggle = E('button', {
+			id: 'auto-refresh-btn',
+			class: 'btn cbi-button-positive',
+			click: function(ev) {
+				autoRefresh = !autoRefresh;
+				ev.target.textContent = autoRefresh ? _('Auto: ON') : _('Auto: OFF');
+				ev.target.className = autoRefresh ? 'btn cbi-button-positive' : 'btn';
+			}
+		}, _('Auto: ON'));
+
+		poll.add(function() {
+			if (!autoRefresh) return;
+			return getLogs().then(function(content) {
+				if (content !== logContainer.textContent) {
+					dom.content(logContainer, content);
+					logContainer.scrollTop = logContainer.scrollHeight;
+				}
+			}).catch(function() {});
+		}, 3);
+
+		return E('div', { class: 'cbi-map' }, [
+			E('h2', { name: 'content' }, _('sing-box Logs')),
+			E('div', { class: 'cbi-section' }, [
+				E('div', { style: 'margin-bottom:15px;display:flex;align-items:center;' }, [
+					E('label', { style: 'margin-right:5px;' }, _('Level:')),
+					levelSelect,
+					searchInput,
+					refreshBtn,
+					autoToggle
+				]),
+				logContainer
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/overview.js
+++ b/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/overview.js
@@ -1,0 +1,339 @@
+'use strict';
+// overview.js — sing-box dashboard. Shows running state, active server,
+// uptime, TUN state, live traffic and connection count. Buttons: Start,
+// Stop, Restart, Apply Config (regenerate + sing-box check + restart).
+// Data is fetched on load via status.sh and re-read after each action.
+
+'require ui';
+'require view';
+'require fs';
+'require uci';
+'require dom';
+'require poll';
+
+function parseJSON(str, fallback) {
+	try { return JSON.parse(str); } catch(e) { return fallback; }
+}
+
+function formatBytes(bytes) {
+	if (!bytes || bytes === 0) return '0 B/s';
+	var units = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
+	var i = Math.floor(Math.log(bytes) / Math.log(1024));
+	return (bytes / Math.pow(1024, i)).toFixed(1) + ' ' + units[i];
+}
+
+function formatUptime(seconds) {
+	if (!seconds || seconds === 0) return '-';
+	var days = Math.floor(seconds / 86400);
+	var hours = Math.floor((seconds % 86400) / 3600);
+	var mins = Math.floor((seconds % 3600) / 60);
+	var parts = [];
+	if (days > 0) parts.push(days + 'd');
+	if (hours > 0) parts.push(hours + 'h');
+	parts.push(mins + 'm');
+	return parts.join(' ');
+}
+
+return view.extend({
+	load: function() {
+		// Each call is wrapped so a single failure (rpcd ACL glitch, latency
+		// probe timeout) doesn't break the whole dashboard.
+		function safeExec(path, args) {
+			return fs.exec(path, args).then(
+				function(r) { return r; },
+				function(err) { console.warn('[singbox] fs.exec failed:', path, args, err); return { stdout: '', code: -1 }; }
+			);
+		}
+
+		return Promise.all([
+			safeExec('/usr/share/singbox/status.sh', ['127.0.0.1:9090', 'status']),
+			safeExec('/usr/share/singbox/status.sh', ['127.0.0.1:9090', 'servers']),
+			safeExec('/usr/share/singbox/status.sh', ['127.0.0.1:9090', 'connections', '25'])
+		]).then(function(results) {
+			return {
+				status: parseJSON(results[0].stdout || results[0].output, {}),
+				servers: parseJSON(results[1].stdout || results[1].output, []),
+				connections: parseJSON(results[2].stdout || results[2].output, [])
+			};
+		});
+	},
+
+	render: function(data) {
+		var status = data.status || {};
+		var servers = data.servers || [];
+		var connections = data.connections || [];
+
+		var running = status.running;
+		var statusColor = running ? '#4caf50' : '#f44336';
+		var statusText = running ? _('Running') : _('Stopped');
+
+		var traffic = status.traffic || { up: 0, down: 0 };
+
+		var table = E('div', { class: 'table' }, [
+			E('div', { class: 'tr table-titles' }, [
+				E('div', { class: 'th', style: 'width:30%;' }, _('Status')),
+				E('div', { class: 'td' }, [
+					E('span', { style: 'display:inline-block;width:12px;height:12px;border-radius:50%;background:' + statusColor + ';margin-right:8px;' }),
+					statusText
+				])
+			]),
+			E('div', { class: 'tr' }, [
+				E('div', { class: 'th' }, _('Active Server')),
+				E('div', { class: 'td' }, status.active_server || '-')
+			]),
+			E('div', { class: 'tr' }, [
+				E('div', { class: 'th' }, _('Uptime')),
+				E('div', { class: 'td' }, formatUptime(status.uptime))
+			]),
+			E('div', { class: 'tr' }, [
+				E('div', { class: 'th' }, _('TUN Interface')),
+				E('div', { class: 'td' }, status.tun ? _('Active') : _('Inactive'))
+			]),
+			E('div', { class: 'tr' }, [
+				E('div', { class: 'th' }, _('Traffic')),
+				E('div', { class: 'td' }, [
+					E('span', { style: 'color:#4caf50;' }, '↓ ' + formatBytes(traffic.down)),
+					E('span', {}, ' '),
+					E('span', { style: 'color:#2196f3;' }, '↑ ' + formatBytes(traffic.up))
+				])
+			]),
+			E('div', { class: 'tr' }, [
+				E('div', { class: 'th' }, _('Connections')),
+				E('div', { class: 'td' }, String(status.connections || 0))
+			])
+		]);
+
+		var btnStart = E('button', {
+			class: 'btn cbi-button-positive',
+			style: 'margin-right:8px;',
+			click: function(ev) {
+				ui.addNotification(null, E('p', _('Starting sing-box...')));
+				fs.exec('/etc/init.d/sing-box', ['start']).then(function() {
+					setTimeout(function() { location.reload(); }, 3000);
+				});
+			}
+		}, _('Start'));
+
+		var btnStop = E('button', {
+			class: 'btn cbi-button-negative',
+			style: 'margin-right:8px;',
+			click: function(ev) {
+				fs.exec('/etc/init.d/sing-box', ['stop']).then(function() {
+					setTimeout(function() { location.reload(); }, 2000);
+				});
+			}
+		}, _('Stop'));
+
+		var btnRestart = E('button', {
+			class: 'btn cbi-button',
+			style: 'margin-right:8px;',
+			click: function(ev) {
+				ui.addNotification(null, E('p', _('Restarting sing-box...')));
+				fs.exec('/etc/init.d/sing-box', ['stop']).then(function() {
+					return fs.exec('/etc/init.d/sing-box', ['start']);
+				}).then(function() {
+					setTimeout(function() { location.reload(); }, 3000);
+				});
+			}
+		}, _('Restart'));
+
+		var btnApply = E('button', {
+			class: 'btn cbi-button-action',
+			click: function(ev) {
+				var dlg = ui.showModal(_('Applying Configuration'), [
+					E('p', { class: 'spinning' }, _('Generating and validating config...'))
+				]);
+				fs.exec('/usr/share/singbox/generate-config.sh').then(function(res) {
+					if (res.code === 0) {
+						return fs.exec('/etc/init.d/sing-box', ['stop']).then(function() {
+							return new Promise(function(resolve) {
+								setTimeout(function() {
+									fs.exec('/etc/init.d/sing-box', ['start']).then(resolve);
+								}, 2000);
+							});
+						}).then(function() {
+							ui.hideModal();
+							ui.addNotification(null, E('p', _('Configuration applied successfully')));
+							setTimeout(function() { location.reload(); }, 2000);
+						});
+					} else {
+						ui.hideModal();
+						ui.addNotification(null, [
+							E('p', _('Configuration validation failed:')),
+							E('pre', { style: 'color:#f44336;' }, res.stdout || res.stderr || 'Unknown error')
+						]);
+					}
+				});
+			}
+		}, _('Apply Config'));
+
+		var serverRows = servers.map(function(srv) {
+			var statusIcon = srv.status === 'online' ? '✅' : '❌';
+			var latency = srv.latency > 0 ? srv.latency + ' ms' : '-';
+			return E('div', { class: 'tr' }, [
+				E('div', { class: 'td' }, srv.name),
+				E('div', { class: 'td' }, srv.server + ':' + srv.port),
+				E('div', { class: 'td' }, statusIcon + ' ' + srv.status),
+				E('div', { class: 'td' }, latency)
+			]);
+		});
+
+		if (serverRows.length === 0) {
+			serverRows = [E('div', { class: 'tr' }, [E('div', { class: 'td', colspan: 4, style: 'text-align:center;' }, _('No servers configured'))])];
+		}
+
+		var serverTable = E('div', { class: 'table' }, [
+			E('div', { class: 'tr table-titles' }, [
+				E('div', { class: 'th' }, _('Name')),
+				E('div', { class: 'th' }, _('Address')),
+				E('div', { class: 'th' }, _('Status')),
+				E('div', { class: 'th' }, _('Latency'))
+			]),
+			...serverRows
+		]);
+
+		// Live connections section. The table itself is rebuilt on demand
+		// (load + Refresh button) — NOT in the 3-second poll loop, to keep
+		// the router idle when the user is just glancing at the dashboard.
+		// Column headers are click-sortable; sort state lives in this closure.
+		var connectionsData = [];
+		var sortState = { col: 'total', dir: 'desc' };
+
+		// Column metadata: id → {label, sortValue, style}
+		var connColumns = [
+			{ id: 'host',  label: _('Host'),  flex: 2, sortValue: function(c) { return String(c.host || c.dest || '').toLowerCase(); } },
+			{ id: 'net',   label: _('Net'),   flex: 0, sortValue: function(c) { return String(c.network || '').toLowerCase(); } },
+			{ id: 'chain', label: _('Chain'), flex: 2, sortValue: function(c) { return (c.chains || []).join(' ').toLowerCase(); } },
+			{ id: 'down',  label: _('↓ Down'), flex: 0, sortValue: function(c) { return Number(c.down || 0); } },
+			{ id: 'up',    label: _('↑ Up'),   flex: 0, sortValue: function(c) { return Number(c.up || 0); } },
+			{ id: 'total', label: _('Total'),  flex: 0, sortValue: function(c) { return Number(c.total || ((c.down || 0) + (c.up || 0))); }, hidden: true }
+		];
+
+		function sortConnections() {
+			var col = connColumns.find(function(c) { return c.id === sortState.col; }) || connColumns[0];
+			var dirMul = sortState.dir === 'asc' ? 1 : -1;
+			connectionsData.sort(function(a, b) {
+				var va = col.sortValue(a), vb = col.sortValue(b);
+				if (va < vb) return -1 * dirMul;
+				if (va > vb) return  1 * dirMul;
+				return 0;
+			});
+		}
+
+		var connHost = E('div', { class: 'table' }, [
+			E('div', { class: 'tr table-titles' },
+				connColumns.filter(function(c) { return !c.hidden; }).map(function(col) {
+					var th = E('div', {
+						class: 'th',
+						style: (col.flex ? 'flex:' + col.flex + ';cursor:pointer;' : 'cursor:pointer;') + ' user-select:none;'
+					}, [col.label + ' ']);
+					th.addEventListener('click', function() {
+						if (sortState.col === col.id) {
+							sortState.dir = sortState.dir === 'asc' ? 'desc' : 'asc';
+						} else {
+							sortState.col = col.id;
+							sortState.dir = (col.id === 'host' || col.id === 'net' || col.id === 'chain') ? 'asc' : 'desc';
+						}
+						sortConnections();
+						renderConnections();
+						updateSortIndicators();
+					});
+					th.dataset.colId = col.id;
+					return th;
+				})
+			)
+		]);
+
+		function updateSortIndicators() {
+			connHost.querySelectorAll('.th[data-col-id]').forEach(function(th) {
+				var isActive = th.dataset.colId === sortState.col;
+				var arrow = isActive ? (sortState.dir === 'asc' ? ' ↑' : ' ↓') : '';
+				var label = connColumns.find(function(c) { return c.id === th.dataset.colId; }).label;
+				th.firstChild.nodeValue = label + arrow;
+			});
+		}
+
+		function renderConnections() {
+			// Drop body rows (keep header).
+			while (connHost.children.length > 1) {
+				connHost.removeChild(connHost.lastChild);
+			}
+			if (!connectionsData || connectionsData.length === 0) {
+				connHost.appendChild(E('div', { class: 'tr' }, [
+					E('div', { class: 'td', style: 'text-align:center;opacity:0.6;' }, _('No active connections'))
+				]));
+				return;
+			}
+			connectionsData.forEach(function(c) {
+				var chain = (c.chains || []).join(' → ') || '-';
+				connHost.appendChild(E('div', { class: 'tr' }, [
+					E('div', { class: 'td', style: 'flex:2;word-break:break-all;' }, c.host || c.dest || '-'),
+					E('div', { class: 'td' }, String(c.network || '-').toUpperCase()),
+					E('div', { class: 'td', style: 'flex:2;' }, chain),
+					E('div', { class: 'td', style: 'color:#4caf50;' }, formatBytes(c.down)),
+					E('div', { class: 'td', style: 'color:#2196f3;' }, formatBytes(c.up))
+				]));
+			});
+		}
+
+		function setConnections(conns) {
+			connectionsData = Array.isArray(conns) ? conns : [];
+			// Recompute total in case backend didn't (older status.sh build).
+			connectionsData.forEach(function(c) {
+				if (c.total == null) c.total = (Number(c.down) || 0) + (Number(c.up) || 0);
+			});
+			sortConnections();
+			renderConnections();
+			updateSortIndicators();
+		}
+		setConnections(connections);
+
+		var connRefresh = E('button', {
+			class: 'btn',
+			style: 'margin-left:8px;',
+			click: function(ev) {
+				ev.target.disabled = true;
+				ev.target.textContent = _('Loading…');
+				fs.exec('/usr/share/singbox/status.sh', ['127.0.0.1:9090', 'connections', '25']).then(function(res) {
+					var data = parseJSON(res.stdout || res.output || [], []);
+					setConnections(data);
+				}).catch(function() {}).then(function() {
+					ev.target.disabled = false;
+					ev.target.textContent = _('Refresh');
+				});
+			}
+		}, _('Refresh'));
+
+		// Smart button state: buttons stay visible but disabled when they'd be no-ops.
+		//   Running  → Start disabled, Stop/Restart enabled, Apply enabled
+		//   Stopped  → Start enabled,   Stop/Restart disabled, Apply enabled
+		btnStart.disabled   = !!running;
+		btnStop.disabled    = !running;
+		btnRestart.disabled = !running;
+
+		return E('div', { class: 'cbi-map' }, [
+			E('h2', { name: 'content' }, _('sing-box VPN')),
+			E('div', { class: 'cbi-section' }, [
+				E('div', { style: 'margin-bottom:15px;' }, [btnStart, btnStop, btnRestart, btnApply]),
+				table
+			]),
+			E('div', { class: 'cbi-section' }, [
+				E('h3', {}, _('Server Status')),
+				serverTable
+			]),
+			E('div', { class: 'cbi-section' }, [
+				E('h3', {}, [
+					_('Active Connections'),
+					E('span', { style: 'font-weight:normal;color:#888;font-size:12px;margin-left:8px;' },
+						'(' + connections.length + ')'),
+					connRefresh
+				]),
+				connHost
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/routing.js
+++ b/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/routing.js
@@ -1,0 +1,203 @@
+'use strict';
+// routing.js — routing rules CRUD + preset catalogue + final-outbound selector.
+// Rule types: geosite (auto .srs), ip_cidr, domain. Actions: auto / direct /
+// block. The Presets button opens a modal with a curated GeoSite list and
+// bulk-adds the selected ones (skipping duplicates by match value).
+
+'require view';
+'require form';
+'require fs';
+'require ui';
+'require uci';
+
+var PRESETS = [
+	{ tag: 'geosite-youtube', name: 'YouTube' },
+	{ tag: 'geosite-google', name: 'Google (Search, Gmail, Drive, Play Store)' },
+	{ tag: 'geosite-instagram', name: 'Instagram' },
+	{ tag: 'geosite-twitter', name: 'Twitter/X' },
+	{ tag: 'geosite-facebook', name: 'Facebook' },
+	{ tag: 'geosite-telegram', name: 'Telegram (domains)' },
+	{ tag: 'geosite-openai', name: 'OpenAI / ChatGPT' },
+	{ tag: 'geosite-soundcloud', name: 'SoundCloud' },
+	{ tag: 'geosite-spotify', name: 'Spotify' },
+	{ tag: 'geosite-discord', name: 'Discord' },
+	{ tag: 'geosite-twitch', name: 'Twitch' },
+	{ tag: 'geosite-netflix', name: 'Netflix' },
+	{ tag: 'geosite-github', name: 'GitHub' },
+	{ tag: 'geosite-microsoft', name: 'Microsoft' },
+	{ tag: 'geosite-apple', name: 'Apple' },
+	{ tag: 'geosite-amazon', name: 'Amazon' },
+	{ tag: 'geosite-whatsapp', name: 'WhatsApp' },
+	{ tag: 'geosite-category-ads-all', name: 'Ad Block (block all ads)', action: 'block' }
+];
+
+return view.extend({
+	load: function() {
+		return uci.load('singbox');
+	},
+
+	render: function() {
+		var m = new form.Map('singbox', _('Routing Rules'), _('Configure which traffic goes through VPN, which is blocked, and which goes direct.'));
+		this.map = m;
+
+		var s = m.section(form.GridSection, 'rule', _('Routing Rules'));
+		s.addremove = true;
+		s.sortable = true;
+		s.anonymous = true;
+		s.addbtntitle = _('Add Rule (manual)');
+		s.actionstitle = ' ';
+		// Override the default "add" handler with a chooser modal that asks the
+		// user what kind of rule to create — GeoSite preset, GeoSite by tag,
+		// IP CIDR or custom domain — before dropping them into the grid.
+		s.handleAdd = function(ev) {
+			ui.showModal(_('Add Routing Rule'), [
+				E('div', { class: 'cbi-section' }, [
+					E('h4', {}, _('Quick add — GeoSite presets')),
+					E('div', { id: 'preset-list', style: 'max-height:240px;overflow-y:auto;margin:8px 0;' },
+						PRESETS.map(function(preset, i) {
+							return E('div', { style: 'padding:4px 0;' }, [
+								E('label', {}, [
+									E('input', {
+										type: 'checkbox',
+										value: preset.tag,
+										class: 'preset-cb',
+										id: 'preset-' + i,
+										style: 'margin-right:8px;vertical-align:middle;'
+									}),
+									E('span', { style: 'font-weight:bold;vertical-align:middle;' }, preset.name),
+									E('span', { style: 'color:#888;font-size:11px;margin-left:8px;' }, preset.tag),
+									preset.action ? E('span', { style: 'color:#f44336;font-size:11px;margin-left:6px;' }, '(block)') : null
+								])
+							]);
+						})
+					),
+					E('hr', { style: 'margin:12px 0;' }),
+					E('h4', {}, _('Custom rule')),
+					E('div', { style: 'display:grid;grid-template-columns:max-content 1fr;gap:6px 10px;margin:8px 0;' }, [
+						E('label', { style: 'line-height:30px;' }, _('Name')),
+						E('input', { type: 'text', id: 'custom-name', placeholder: 'My rule', style: 'width:100%;' }),
+						E('label', { style: 'line-height:30px;' }, _('Type')),
+						E('select', { id: 'custom-type', style: 'width:100%;' }, [
+							E('option', { value: 'geosite' }, _('GeoSite (e.g. geosite-netflix)')),
+							E('option', { value: 'ip_cidr' }, _('IP CIDR (e.g. 91.108.0.0/16 149.154.160.0/20)')),
+						E('option', { value: 'domain' }, _('Domain (e.g. example.com .blocked.org)'))
+						]),
+						E('label', { style: 'line-height:30px;' }, _('Match')),
+						E('input', { type: 'text', id: 'custom-match', placeholder: 'geosite-netflix / 91.108.0.0/16 / example.com', style: 'width:100%;' }),
+						E('label', { style: 'line-height:30px;' }, _('Action')),
+						E('select', { id: 'custom-outbound', style: 'width:100%;' }, [
+							E('option', { value: 'auto' }, _('VPN')),
+							E('option', { value: 'direct' }, _('Direct')),
+							E('option', { value: 'block' }, _('Block'))
+						])
+					])
+				]),
+				E('div', { class: 'right' }, [
+					E('button', { class: 'btn', click: function() { ui.hideModal(); } }, _('Cancel')),
+					E('button', {
+						class: 'btn cbi-button-positive',
+						click: function() {
+							var added = 0;
+							// Presets
+							PRESETS.forEach(function(preset, i) {
+								var cb = document.getElementById('preset-' + i);
+								if (cb && cb.checked) {
+									var exists = uci.sections('singbox', 'rule').some(function(r) {
+										return r.match === preset.tag;
+									});
+									if (!exists) {
+										var sid = uci.add('singbox', 'rule');
+										uci.set('singbox', sid, 'name', preset.name);
+										uci.set('singbox', sid, 'enabled', '1');
+										uci.set('singbox', sid, 'type', 'geosite');
+										uci.set('singbox', sid, 'match', preset.tag);
+										uci.set('singbox', sid, 'outbound', preset.action || 'auto');
+										added++;
+									}
+								}
+							});
+							// Custom rule
+							var cname = document.getElementById('custom-name').value.trim();
+							var ctype = document.getElementById('custom-type').value;
+							var cmatch = document.getElementById('custom-match').value.trim();
+							var coutbound = document.getElementById('custom-outbound').value;
+							if (cmatch) {
+								if (!cname) cname = cmatch;
+								var sid = uci.add('singbox', 'rule');
+								uci.set('singbox', sid, 'name', cname);
+								uci.set('singbox', sid, 'enabled', '1');
+								uci.set('singbox', sid, 'type', ctype);
+								uci.set('singbox', sid, 'match', cmatch);
+								uci.set('singbox', sid, 'outbound', coutbound);
+								added++;
+							}
+							ui.hideModal();
+							if (added > 0) {
+								uci.save();
+								uci.apply().then(function() { location.reload(); });
+							}
+						}
+					}, _('Add Selected / Custom'))
+				])
+			]);
+		};
+
+		var o;
+
+		o = s.option(form.Flag, 'enabled', _('Enabled'));
+		o.editable = true;
+		o.modalonly = false;
+
+		o = s.option(form.Value, 'name', _('Name'));
+		o.rmempty = false;
+		o.modalonly = false;
+
+		o = s.option(form.ListValue, 'type', _('Type'));
+		o.value('geosite', _('GeoSite (auto-updated domain list)'));
+		o.value('ip_cidr', _('IP CIDR (manual IP ranges)'));
+		o.value('domain', _('Domain (custom domains)'));
+		o.default = 'geosite';
+		o.rmempty = false;
+		o.modalonly = false;
+		o.editable = true;
+
+		o = s.option(form.Value, 'match', _('Match'));
+		o.placeholder = _('geosite-youtube / 91.108.0.0/16 / .youtube.com');
+		o.rmempty = false;
+		o.modalonly = false;
+
+		o = s.option(form.ListValue, 'outbound', _('Action'));
+		o.value('auto', _('VPN'));
+		o.value('direct', _('Direct'));
+		o.value('block', _('Block'));
+		o.default = 'auto';
+		o.rmempty = false;
+		o.modalonly = false;
+		o.editable = true;
+
+		s = m.section(form.NamedSection, 'general', 'general', _('Default Action'));
+		o = s.option(form.ListValue, 'final_outbound', _('Default (final)'));
+		o.value('direct', _('Direct — recommended'));
+		o.value('auto', _('VPN — all traffic through VPN'));
+		o.value('block', _('Block — drop all unmatched'));
+		o.default = 'direct';
+
+		return m.render();
+	},
+
+	handleSaveApply: function(ev, mode) {
+		var map = this.map;
+		return map.save.apply(map, mode ? [false, true] : []).then(function() {
+			return fs.exec('/usr/share/singbox/generate-config.sh');
+		}).then(function(res) {
+			if (res.code !== 0) {
+				throw new Error(res.stdout || res.stderr || 'Config validation failed');
+			}
+			return fs.exec('/etc/init.d/sing-box', ['restart']);
+		}).then(function() {
+			ui.addNotification(null, E('p', _('Routing rules applied')));
+		}).catch(function(err) {
+			ui.addNotification(null, E('p', { style: 'color:#f44336;' }, _('Error: %s').format(err.message || err)));
+		});
+	}
+});

--- a/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/servers.js
+++ b/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/servers.js
@@ -1,0 +1,179 @@
+'use strict';
+// servers.js — CRUD for VLESS+REALITY servers plus subscription import.
+// Grid section shows name / address / port / live status; Test button
+// probes latency via status.sh "test <name>". Import button calls
+// update-subscription.sh with the URL field, then reloads on success.
+
+'require view';
+'require form';
+'require fs';
+'require ui';
+'require uci';
+'require dom';
+
+return view.extend({
+	load: function() {
+		return uci.load('singbox');
+	},
+
+	render: function() {
+		var sections = uci.sections('singbox', 'server');
+		var m, s, o;
+
+		m = new form.Map('singbox', _('VPN Servers'), _('Manage VLESS+REALITY proxy servers'));
+		this.map = m;
+
+		s = m.section(form.GridSection, 'server', _('Servers'));
+		s.addremove = true;
+		s.sortable = true;
+		s.nodescriptions = true;
+		s.addbtntitle = _('Add Server');
+
+		o = s.option(form.Flag, 'enabled', _('Enabled'));
+		o.modalonly = false;
+		o.editable = true;
+
+		o = s.option(form.Value, 'name', _('Name'));
+		o.placeholder = 'my-server';
+		o.rmempty = false;
+		o.datatype = 'and(uciname,maxlength(32))';
+
+		o = s.option(form.Value, 'server', _('Address'));
+		o.placeholder = '0.0.0.0';
+		o.datatype = 'host';
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'port', _('Port'));
+		o.placeholder = '443';
+		o.datatype = 'port';
+		o.default = '443';
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'uuid', _('UUID'));
+		o.rmempty = false;
+		o.password = true;
+
+		o = s.option(form.ListValue, 'flow', _('Flow'));
+		o.value('xtls-rprx-vision', 'xtls-rprx-vision');
+		o.value('', _('None'));
+		o.default = 'xtls-rprx-vision';
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'sni', _('SNI'));
+		o.placeholder = 'example.com';
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.option(form.ListValue, 'utls_fingerprint', _('uTLS Fingerprint'));
+		o.value('chrome', 'Chrome');
+		o.value('firefox', 'Firefox');
+		o.value('safari', 'Safari');
+		o.value('edge', 'Edge');
+		o.default = 'chrome';
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'reality_public_key', _('REALITY Public Key'));
+		o.rmempty = false;
+		o.password = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'reality_short_id', _('REALITY Short ID'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		// Live status column. textvalue() is the GridSection hook for inline
+		// cell content; it may return a DOM node. The actual latency probe
+		// happens on Test-button click and rewrites this cell in place.
+		o = s.option(form.DummyValue, '_status', _('Status'));
+		o.modalonly = false;
+		o.textvalue = function(section_id) {
+			var name = uci.get('singbox', section_id, 'name') || section_id;
+			return E('span', {
+				id: 'srv-status-' + section_id,
+				class: 'srv-status-cell',
+				'data-server-name': name
+			}, '—');
+		};
+
+		// Per-row latency probe. editable=true makes GridSection render the
+		// actual button instead of falling back to the option default value.
+		o = s.option(form.Button, '_test', _('Test'));
+		o.modalonly = false;
+		o.editable = true;
+		o.inputstyle = 'action';
+		o.inputtitle = _('Test');
+		o.onclick = function(ev, section_id) {
+			var name = uci.get('singbox', section_id, 'name') || section_id;
+			var cell = document.getElementById('srv-status-' + section_id);
+			if (cell) cell.textContent = '...';
+			fs.exec('/usr/share/singbox/status.sh', ['127.0.0.1:9090', 'test', name]).then(function(res) {
+				var data = {};
+				try { data = JSON.parse(res.stdout || res.output || '{}'); } catch(e) {}
+				if (cell) {
+					if (data.status === 'online') {
+						cell.innerHTML = '✅ ' + data.latency + 'ms';
+						cell.style.color = '#4caf50';
+					} else {
+						cell.innerHTML = '❌ Offline';
+						cell.style.color = '#f44336';
+					}
+				}
+			});
+			return false;
+		};
+
+		// Subscription section. The shipped config has an anonymous
+		// `config subscription` block — NamedSection can't address it by name,
+		// so use TypedSection which matches any section of this type.
+		s = m.section(form.TypedSection, 'subscription', _('Import Subscription'));
+		s.anonymous = true;
+
+		o = s.option(form.Value, 'url', _('Subscription URL'));
+		o.placeholder = 'http://example.com/sub';
+		o.datatype = 'url';
+
+		o = s.option(form.Button, '_import', ' ');
+		o.inputtitle = _('Import Servers');
+		o.inputstyle = 'apply';
+		o.onclick = function() {
+			var url = document.querySelector('input[id$="\\.url"]')?.value || uci.get('singbox', 'subscription', 'url') || '';
+			if (!url) {
+				ui.addNotification(null, E('p', _('Please enter subscription URL first')));
+				return false;
+			}
+			ui.showModal(_('Importing'), [ E('p', { class: 'spinning' }, _('Fetching subscription...')) ]);
+			fs.exec('/usr/share/singbox/update-subscription.sh', [url]).then(function(res) {
+				ui.hideModal();
+				var data = {};
+				try { data = JSON.parse(res.stdout || res.output || '{}'); } catch(e) {}
+				if (data.success && data.imported > 0) {
+					ui.addNotification(null, E('p', _('Imported %d server(s): %s').format(data.imported, data.servers || '')));
+					setTimeout(function() { location.reload(); }, 2000);
+				} else if (data.success) {
+					ui.addNotification(null, E('p', _('No new servers to import')));
+				} else {
+					ui.addNotification(null, E('p', _('Import failed: %s').format(data.error || res.stderr || 'Unknown error')));
+				}
+			});
+			return false;
+		};
+
+		return m.render();
+	},
+
+	handleSaveApply: function(ev, mode) {
+		var map = this.map;
+		return map.save.apply(map, mode ? [false, true] : []).then(function() {
+			return fs.exec('/usr/share/singbox/generate-config.sh');
+		}).then(function(res) {
+			if (res.code !== 0) {
+				throw new Error(res.stdout || res.stderr || 'Config validation failed');
+			}
+			return fs.exec('/etc/init.d/sing-box', ['restart']);
+		}).then(function() {
+			ui.addNotification(null, E('p', _('Configuration applied and sing-box restarted')));
+		}).catch(function(err) {
+			ui.addNotification(null, E('p', { style: 'color:#f44336;' }, _('Error: %s').format(err.message || err)));
+		});
+	}
+});

--- a/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/settings.js
+++ b/applications/luci-app-singbox/files/www/luci-static/resources/view/singbox/settings.js
@@ -1,0 +1,121 @@
+'use strict';
+// settings.js — advanced config. Sections: Service enable / log level;
+// TUN interface (stack, address, MTU, auto_route, strict_route); Clash API
+// monitoring; DNS (direct / tunnel / strategy); URL test (interval,
+// tolerance, URL); subscription auto-update.
+
+'require view';
+'require form';
+'require fs';
+'require ui';
+'require uci';
+
+return view.extend({
+	load: function() {
+		return uci.load('singbox');
+	},
+
+	render: function() {
+		var m = new form.Map('singbox', _('sing-box Settings'), _('Advanced configuration for TUN interface, DNS, URL test and monitoring.'));
+		this.map = m;
+
+		var s, o;
+
+	s = m.section(form.NamedSection, 'general', 'general', _('Service'));
+	o = s.option(form.Flag, 'enabled', _('Enabled'));
+	o = s.option(form.ListValue, 'log_level', _('Log Level'));
+	o.value('debug', 'Debug');
+	o.value('info', 'Info');
+	o.value('warn', 'Warning');
+	o.value('error', 'Error');
+	o.default = 'info';
+	o.description = _('sing-box logs to syslog; view them in the Logs tab or with `logread -e sing-box`. Rotation is handled automatically by logd.');
+
+		s = m.section(form.NamedSection, 'general', 'general', _('TUN Interface'));
+		o = s.option(form.ListValue, 'stack', _('TCP Stack'));
+		o.value('gvisor', 'gVisor (recommended for MIPS)');
+		o.value('system', 'System (faster but may not work on all devices)');
+		o.default = 'gvisor';
+
+		o = s.option(form.Value, 'tun_address', _('TUN Address'));
+		o.default = '172.19.0.1/30';
+		o.datatype = 'cidr4';
+
+		o = s.option(form.Value, 'tun_mtu', _('MTU'));
+		o.default = '1400';
+		o.datatype = 'range(1280,1500)';
+
+		o = s.option(form.Flag, 'auto_route', _('Auto Route'));
+		o.default = '1';
+
+		o = s.option(form.Flag, 'strict_route', _('Strict Route'));
+		o.default = '1';
+
+		s = m.section(form.NamedSection, 'general', 'general', _('Monitoring (Clash API)'));
+		o = s.option(form.Flag, 'clash_api', _('Enable Clash API'));
+		o.default = '1';
+
+		o = s.option(form.Value, 'clash_api_port', _('Clash API Port'));
+		o.default = '9090';
+		o.datatype = 'port';
+
+		s = m.section(form.NamedSection, 'dns', 'dns', _('DNS'));
+		o = s.option(form.Value, 'direct_server', _('Direct DNS'));
+		o.placeholder = 'auto (use ISP DNS)';
+		o.default = 'auto';
+
+		o = s.option(form.Value, 'tunnel_server', _('Tunnel DNS (via VPN)'));
+		o.placeholder = '8.8.8.8';
+		o.default = '8.8.8.8';
+		o.datatype = 'ipaddr';
+
+		o = s.option(form.ListValue, 'strategy', _('DNS Strategy'));
+		o.value('prefer_ipv4', 'Prefer IPv4');
+		o.value('prefer_ipv6', 'Prefer IPv6');
+		o.value('ipv4_only', 'IPv4 Only');
+		o.default = 'prefer_ipv4';
+
+		s = m.section(form.NamedSection, 'urltest', 'urltest', _('URL Test (Auto Server Selection)'));
+		o = s.option(form.Flag, 'enabled', _('Enabled'));
+		o.default = '1';
+
+		o = s.option(form.Value, 'interval', _('Test Interval'));
+		o.default = '3m';
+		o.placeholder = '3m, 5m, 10m';
+
+		o = s.option(form.Value, 'tolerance', _('Tolerance (ms)'));
+		o.default = '50';
+		o.datatype = 'uinteger';
+
+		o = s.option(form.Value, 'test_url', _('Test URL'));
+		o.default = 'http://www.gstatic.com/generate_204';
+
+		s = m.section(form.TypedSection, 'subscription', _('Subscription'));
+		s.anonymous = true;
+		o = s.option(form.Flag, 'enabled', _('Auto Update'));
+		o = s.option(form.Value, 'url', _('Subscription URL'));
+		o.placeholder = 'http://example.com/sub';
+		o.datatype = 'url';
+
+		o = s.option(form.Value, 'update_interval', _('Update Interval'));
+		o.default = '24h';
+
+		return m.render();
+	},
+
+	handleSaveApply: function(ev, mode) {
+		var map = this.map;
+		return map.save.apply(map, mode ? [false, true] : []).then(function() {
+			return fs.exec('/usr/share/singbox/generate-config.sh');
+		}).then(function(res) {
+			if (res.code !== 0) {
+				throw new Error(res.stdout || res.stderr || 'Config validation failed');
+			}
+			return fs.exec('/etc/init.d/sing-box', ['restart']);
+		}).then(function() {
+			ui.addNotification(null, E('p', _('Settings applied and sing-box restarted')));
+		}).catch(function(err) {
+			ui.addNotification(null, E('p', { style: 'color:#f44336;' }, _('Error: %s').format(err.message || err)));
+		});
+	}
+});

--- a/applications/luci-app-singbox/po/templates/luci-app-singbox.pot
+++ b/applications/luci-app-singbox/po/templates/luci-app-singbox.pot
@@ -1,0 +1,393 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: luci-app-singbox\n"
+"Last-Translator: Automatically generated\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+# Auto-generated from JS views. Run `make package/luci-app-singbox/po/compile`
+# inside OpenWrt buildroot to refresh.
+
+msgid "Action"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "Active Connections"
+msgstr ""
+
+msgid "Active Server"
+msgstr ""
+
+msgid "Add Routing Rule"
+msgstr ""
+
+msgid "Add Rule (manual)"
+msgstr ""
+
+msgid "Add Selected / Custom"
+msgstr ""
+
+msgid "Add Server"
+msgstr ""
+
+msgid "Address"
+msgstr ""
+
+msgid "Advanced configuration for TUN interface, DNS, URL test and monitoring."
+msgstr ""
+
+msgid "All"
+msgstr ""
+
+msgid "Apply Config"
+msgstr ""
+
+msgid "Applying Configuration"
+msgstr ""
+
+msgid "Auto Route"
+msgstr ""
+
+msgid "Auto Update"
+msgstr ""
+
+msgid "Auto: OFF"
+msgstr ""
+
+msgid "Auto: ON"
+msgstr ""
+
+msgid "Block"
+msgstr ""
+
+msgid "Block — drop all unmatched"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Chain"
+msgstr ""
+
+msgid "Clash API Port"
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "Configuration applied and sing-box restarted"
+msgstr ""
+
+msgid "Configuration applied successfully"
+msgstr ""
+
+msgid "Configuration validation failed:"
+msgstr ""
+
+msgid "Configure which traffic goes through VPN, which is blocked, and which goes direct."
+msgstr ""
+
+msgid "Connections"
+msgstr ""
+
+msgid "Custom rule"
+msgstr ""
+
+msgid "DNS"
+msgstr ""
+
+msgid "DNS Strategy"
+msgstr ""
+
+msgid "Debug"
+msgstr ""
+
+msgid "Default (final)"
+msgstr ""
+
+msgid "Default Action"
+msgstr ""
+
+msgid "Direct"
+msgstr ""
+
+msgid "Direct DNS"
+msgstr ""
+
+msgid "Direct — recommended"
+msgstr ""
+
+msgid "Domain (custom domains)"
+msgstr ""
+
+msgid "Domain (e.g. example.com .blocked.org)"
+msgstr ""
+
+msgid "Enable Clash API"
+msgstr ""
+
+msgid "Enabled"
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "Error: %s"
+msgstr ""
+
+msgid "Fetching subscription..."
+msgstr ""
+
+msgid "Flow"
+msgstr ""
+
+msgid "Generating and validating config..."
+msgstr ""
+
+msgid "GeoSite (auto-updated domain list)"
+msgstr ""
+
+msgid "GeoSite (e.g. geosite-netflix)"
+msgstr ""
+
+msgid "Host"
+msgstr ""
+
+msgid "IP CIDR (e.g. 91.108.0.0/16 149.154.160.0/20)"
+msgstr ""
+
+msgid "IP CIDR (manual IP ranges)"
+msgstr ""
+
+msgid "Import Servers"
+msgstr ""
+
+msgid "Import Subscription"
+msgstr ""
+
+msgid "Import failed: %s"
+msgstr ""
+
+msgid "Imported %d server(s): %s"
+msgstr ""
+
+msgid "Importing"
+msgstr ""
+
+msgid "Inactive"
+msgstr ""
+
+msgid "Info"
+msgstr ""
+
+msgid "Latency"
+msgstr ""
+
+msgid "Level:"
+msgstr ""
+
+msgid "Loading…"
+msgstr ""
+
+msgid "Log Level"
+msgstr ""
+
+msgid "MTU"
+msgstr ""
+
+msgid "Manage VLESS+REALITY proxy servers"
+msgstr ""
+
+msgid "Match"
+msgstr ""
+
+msgid "Max Log Size (KB)"
+msgstr ""
+
+msgid "Monitoring (Clash API)"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Net"
+msgstr ""
+
+msgid "No active connections"
+msgstr ""
+
+msgid "No logs"
+msgstr ""
+
+msgid "No logs available"
+msgstr ""
+
+msgid "No new servers to import"
+msgstr ""
+
+msgid "No servers configured"
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "Please enter subscription URL first"
+msgstr ""
+
+msgid "Port"
+msgstr ""
+
+msgid "Quick add — GeoSite presets"
+msgstr ""
+
+msgid "REALITY Public Key"
+msgstr ""
+
+msgid "REALITY Short ID"
+msgstr ""
+
+msgid "Refresh"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarting sing-box..."
+msgstr ""
+
+msgid "Rotate /tmp/sing-box.log when it exceeds this size. Cron trims it to half the threshold every 10 minutes. Set to 0 to disable rotation."
+msgstr ""
+
+msgid "Routing Rules"
+msgstr ""
+
+msgid "Routing rules applied"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "SNI"
+msgstr ""
+
+msgid "Search logs..."
+msgstr ""
+
+msgid "Server Status"
+msgstr ""
+
+msgid "Servers"
+msgstr ""
+
+msgid "Service"
+msgstr ""
+
+msgid "Settings applied and sing-box restarted"
+msgstr ""
+
+msgid "Start"
+msgstr ""
+
+msgid "Starting sing-box..."
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Stop"
+msgstr ""
+
+msgid "Stopped"
+msgstr ""
+
+msgid "Strict Route"
+msgstr ""
+
+msgid "Subscription"
+msgstr ""
+
+msgid "Subscription URL"
+msgstr ""
+
+msgid "TCP Stack"
+msgstr ""
+
+msgid "TUN Address"
+msgstr ""
+
+msgid "TUN Interface"
+msgstr ""
+
+msgid "Test"
+msgstr ""
+
+msgid "Test Interval"
+msgstr ""
+
+msgid "Test URL"
+msgstr ""
+
+msgid "Tolerance (ms)"
+msgstr ""
+
+msgid "Total"
+msgstr ""
+
+msgid "Traffic"
+msgstr ""
+
+msgid "Tunnel DNS (via VPN)"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "URL Test (Auto Server Selection)"
+msgstr ""
+
+msgid "UUID"
+msgstr ""
+
+msgid "Update Interval"
+msgstr ""
+
+msgid "Uptime"
+msgstr ""
+
+msgid "VPN"
+msgstr ""
+
+msgid "VPN Servers"
+msgstr ""
+
+msgid "VPN — all traffic through VPN"
+msgstr ""
+
+msgid "Warning"
+msgstr ""
+
+msgid "geosite-youtube / 91.108.0.0/16 / .youtube.com"
+msgstr ""
+
+msgid "sing-box Logs"
+msgstr ""
+
+msgid "sing-box Settings"
+msgstr ""
+
+msgid "sing-box VPN"
+msgstr ""
+
+msgid "uTLS Fingerprint"
+msgstr ""
+
+msgid "↑ Up"
+msgstr ""
+
+msgid "↓ Down"
+msgstr ""


### PR DESCRIPTION
## What this PR adds

A new LuCI application — `luci-app-singbox` — providing a web interface for managing [sing-box](https://github.com/SagerNet/sing-box) on OpenWrt. sing-box is already in the OpenWrt packages feed since 23.05 but has no LuCI front-end in this repo; users currently either edit JSON by hand or use third-party feeds.

This package focuses on **VLESS + REALITY** — the most DPI-resistant proxy transport available today — combined with selective traffic splitting, GeoSite presets, multi-server failover, and real-time monitoring via sing-box's built-in Clash API.

## Why this is useful

- REALITY disguises TLS as a legitimate connection to a popular website (SNI masquerade) and is indistinguishable from normal HTTPS even under active probing. There is no LuCI app in this repo that exposes it.
- Existing LuCI proxy apps (luci-app-shadowsocks, luci-app-v2ray, luci-app-vmess) target older protocols that don't survive modern DPI.
- The dashboard (traffic, active connections, per-server latency) brings feature parity with consumer-friendly proxies on platforms that already have mature GUIs.

## Architecture

UCI is the single source of truth. `generate-config.sh` reads `/etc/config/singbox`, renders sing-box JSON, validates it with `sing-box check`, and only then atomically replaces `/etc/sing-box/config.json`. A typo or missing field never reaches the running daemon.

```
LuCI JS views  ──fs.exec──►  shell scripts  ──UCI→JSON──►  /etc/sing-box/config.json
                                  │                              │
                                  └─ status.sh (Clash API)       ▼
                                  └─ update-subscription.sh   sing-box ──► Clash API :9090
                                  └─ tail-log.sh (logread)    (procd-managed)
```

## Notable implementation choices

- **Validation gate.** Every config runs through `sing-box check` before being deployed — typo in a REALITY key never takes the router offline.
- **Modern `action: reject`** instead of the deprecated `{"type":"block"}` outbound — eliminates the "operation not permitted" warnings from sing-box 1.10+ when blocking already-established sockets.
- **Streaming-endpoint-safe Clash API client.** `/traffic` and `/connections` are SSE-style streams; BusyBox `wget` would hang forever reading them. The status helper forks wget to a temp file and kills it the moment any data is captured.
- **procd init with USB-binary wait.** Optional `wait_for_usb` UCI flag for routers that keep `sing-box` on external storage to save overlay; auto-detects dangling `/usr/bin/sing-box` symlinks.
- **Syslog-based logging.** sing-box writes to stderr; procd relays to syslog; the Logs tab reads via `logread | grep sing-box`. logd's ring buffer handles rotation itself — no SIGHUP / no risk of crash-looping sing-box by signalling a "reload" while TUN is held by the dying process (this was a real production failure mode in earlier iterations of the package).
- **rpcd ACL scoped to the minimum** the front-end actually needs (no blanket `/bin/sh` exec).

## Tested

OpenWrt 24.10.2, mipsel_24kc, sing-box 1.13.13. End-to-end on a real router with real REALITY upstreams:
- 11 tagged releases over one day of iterative dogfooding (see https://github.com/DmitriyStroganov/LAS/releases for the development history).
- All LuCI views (Overview / Servers / Routing / Logs / Settings) verified functional.
- Generated config byte-identical to a hand-tuned raw sing-box config with the same rules.

## Out of scope for this PR (intentionally)

The development repository at https://github.com/DmitriyStroganov/LAS also ships a standalone `install.sh` wrapper and a tar.gz `.ipk` builder for users who want to test the package without adding the feed — those are user-facing conveniences that don't belong in the upstream package and are not included in this PR.

## Screenshots

Five screenshots (Overview / Servers / Routing / Logs / Settings) are in the development repo: https://github.com/DmitriyStroganov/LAS#screenshots

## License

GPL-2.0-or-later, matching the rest of luci-app-*.

---

Signed-off-by: Dmitriy Stroganov <strodi@yandex.ru>
