### PR TITLE
luci-app-snmpd: set default encryption and authentification

### DIFF
--- a/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
+++ b/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
@@ -464,8 +464,8 @@ return L.view.extend({
 		go.value('SHA-224', _('SHA-224'));
 		go.value('SHA', _('SHA'));
 		go.value('MD5', _('MD5'));
-		go.rmempty = true;
 		go.default = 'SHA-256';
+		go.rmempty = false;
 
 		// SNMPv3 auth pass
 		go = g.option(form.Value, 'auth_pass',
@@ -485,8 +485,8 @@ return L.view.extend({
 		go.value('AES-192', _('AES-192'));
 		go.value('AES', _('AES'));
 		go.value('DES', _('DES'));
-		go.rmempty = true;
 		go.default = 'AES';
+		go.rmempty = false;
 
 		// SNMPv3 privacy/encryption pass
 		go = g.option(form.Value, 'privacy_pass',


### PR DESCRIPTION
## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
If no authentification or encryption is specified, the default value is dropped in LuCI.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash @micpf

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12 <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** openwrt-25.12 luci<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Firefox<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
