### PR TITLE
luci-app-hh4xmodem: add app to control MDM9207 modems

### DIFF
--- a/applications/luci-app-hh4xmodem/Makefile
+++ b/applications/luci-app-hh4xmodem/Makefile
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2026 HH4xModem
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=MDM9207 Modem Manager for HH40V/HH41V
+LUCI_DESCRIPTION:=Provides LuCI interface to monitor and control the MDM9207 modem in HH40V and HH41V routers. Features include signal quality monitoring, network mode selection, data usage tracking, and device information display.
+LUCI_DEPENDS:=+luci-base +ucode-mod-socket
+LUCI_PKGARCH:=all
+
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Devon Openheim <devopenm@proton.me>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/calllog.js
+++ b/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/calllog.js
@@ -1,0 +1,180 @@
+/*
+ * calllog.js - Call log viewer for HH4xModem
+ * Copyright (C) 2026 HH4xModem
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+'use strict';
+'require rpc';
+'require view';
+'require ui';
+
+// Load custom stylesheet once
+if (!document.querySelector('link[href*="hh4xmodem.css"]')) {
+	document.querySelector('head').appendChild(E('link', {
+		'rel': 'stylesheet',
+		'type': 'text/css',
+		'href': L.resource('view/hh4xmodem/hh4xmodem.css') + '?_=' + Date.now()
+	}));
+}
+
+const callCallLogData = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'get_calllog_data'
+});
+
+const callClearCallLog = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'clear_call_log',
+	reject: true
+});
+
+// ---- Helpers ----
+
+function formatDate(dateStr) {
+	if (!dateStr) return '--';
+	// Format: "2026-06-06 05:44:17" -> relative or short
+	return dateStr;
+}
+
+function formatDuration(seconds) {
+	if (seconds == null || seconds == 0) return '--';
+	if (seconds < 60) return seconds + 's';
+	const m = Math.floor(seconds / 60);
+	const s = seconds % 60;
+	if (m < 60) return m + 'm ' + s + 's';
+	const h = Math.floor(m / 60);
+	const mn = m % 60;
+	return h + 'h ' + mn + 'm ' + s + 's';
+}
+
+function callTypeLabel(type) {
+	// CallLogType: 0=incoming, 1=outgoing, 2=missed, 3=?
+	switch (type) {
+		case 0: return { text: _('Incoming'), cls: 'call-incoming' };
+		case 1: return { text: _('Outgoing'), cls: 'call-outgoing' };
+		case 2: return { text: _('Missed'), cls: 'call-missed' };
+		default: return { text: _('Unknown'), cls: '' };
+	}
+}
+
+function createCard(title, content) {
+	return E('div', { 'class': 'cbi-section hh4x-card' }, [
+		E('div', { 'class': 'hh4x-card-header' }, [
+			E('h3', { 'class': 'hh4x-card-title' }, [title])
+		]),
+		E('div', { 'class': 'hh4x-card-body' }, content)
+	]);
+}
+
+function createInfoRow(label, value) {
+	return E('div', { 'class': 'hh4x-info-row' }, [
+		E('span', { 'class': 'hh4x-info-label' }, [label]),
+		E('span', { 'class': 'hh4x-info-value' }, [value != null ? String(value) : '--'])
+	]);
+}
+
+return view.extend({
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null,
+
+	load: function () {
+		return callCallLogData({ list_type: 0, page: 1 });
+	},
+
+	render: function (data) {
+		let countInfo = data.GetCallLogCountInfo || {};
+		let listData = data.GetCallLogList || {};
+		let callLog = listData.CallLogList || [];
+
+		let body = E('div', { 'class': 'hh4x-page' }, [
+			E('div', { 'class': 'hh4x-page-header' }, [
+				E('h2', { 'class': 'hh4x-page-title' }, [_('Call Log')]),
+				E('p', { 'class': 'hh4x-page-desc' }, [
+					_('View incoming, outgoing, and missed call history from the modem.')
+				]),
+				E('button', {
+					'class': 'cbi-button cbi-button-negative',
+					'style': 'margin-top:8px;',
+					'click': function (e) {
+						e.preventDefault();
+						if (!confirm(_('Clear all call log entries? This cannot be undone.'))) return;
+						var btn = e.target;
+						btn.disabled = true;
+						btn.textContent = _('Clearing...');
+						callClearCallLog().then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Cleared');
+								setTimeout(function () { window.location.reload(); }, 2000);
+							} else {
+								ui.addNotification(null, E('p', [_('Clear failed: ') + (r?.error || _('Unknown error'))]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Clear All');
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Clear All');
+						});
+					}
+				}, [_('Clear All')])
+			])
+		]);
+
+		// ---- Summary Card ----
+		let totalCalls = countInfo.TotalUsedCount || 0;
+		let summaryCard = createCard(_('Call Summary'), [
+			E('div', { 'class': 'hh4x-summary-grid' }, [
+				E('div', { 'class': 'hh4x-summary-item' }, [
+					E('span', { 'class': 'hh4x-summary-count' }, [String(countInfo.IncomingCallUsed || 0)]),
+					E('span', { 'class': 'hh4x-summary-label' }, [_('Incoming')])
+				]),
+				E('div', { 'class': 'hh4x-summary-item' }, [
+					E('span', { 'class': 'hh4x-summary-count' }, [String(countInfo.OutgoingCallUsed || 0)]),
+					E('span', { 'class': 'hh4x-summary-label' }, [_('Outgoing')])
+				]),
+				E('div', { 'class': 'hh4x-summary-item' }, [
+					E('span', { 'class': 'hh4x-summary-count' }, [String(countInfo.MissedCallUsed || 0)]),
+					E('span', { 'class': 'hh4x-summary-label' }, [_('Missed')])
+				]),
+				E('div', { 'class': 'hh4x-summary-item' }, [
+					E('span', { 'class': 'hh4x-summary-count' }, [String(totalCalls)]),
+					E('span', { 'class': 'hh4x-summary-label' }, [_('Total')])
+				])
+			])
+		]);
+		body.appendChild(summaryCard);
+
+		// ---- Call Log Table Card ----
+		if (callLog.length === 0) {
+			body.appendChild(createCard(_('Call History'), [
+				E('p', { 'style': 'text-align:center;color:var(--text-color-medium);padding:2em 0;' }, [_('No call records found.')])
+			]));
+		} else {
+			let rows = [];
+			for (let call of callLog) {
+				let typeInfo = callTypeLabel(call.CallLogType);
+				let typeBadge = E('span', { 'class': 'hh4x-call-type-badge ' + typeInfo.cls }, [typeInfo.text]);
+				let dur = formatDuration(call.Duration);
+
+				rows.push(E('div', { 'class': 'hh4x-call-row' }, [
+					E('div', { 'class': 'hh4x-call-left' }, [
+						typeBadge,
+						E('span', { 'class': 'hh4x-call-number' }, [call.TelNumber || '--'])
+					]),
+					E('div', { 'class': 'hh4x-call-right' }, [
+						E('span', { 'class': 'hh4x-call-date' }, [formatDate(call.Date)]),
+						E('span', { 'class': 'hh4x-call-duration' }, [dur])
+					])
+				]));
+			}
+
+			body.appendChild(createCard(_('Call History (' + callLog.length + ')'), [
+				E('div', { 'class': 'hh4x-call-list' }, rows)
+			]));
+		}
+
+		return body;
+	}
+});

--- a/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/dashboard.js
+++ b/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/dashboard.js
@@ -1,0 +1,1455 @@
+/*
+ * dashboard.js - Merged dashboard (Status/Network/Usage/About) for HH4xModem
+ * Copyright (C) 2026 HH4xModem
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+'use strict';
+'require rpc';
+'require view';
+'require ui';
+'require poll';
+'require uci';
+
+if (!document.querySelector('link[href*="hh4xmodem.css"]')) {
+	document.querySelector('head').appendChild(E('link', {
+		'rel': 'stylesheet',
+		'type': 'text/css',
+		'href': L.resource('view/hh4xmodem/hh4xmodem.css') + '?_=' + Date.now()
+	}));
+}
+
+const callAllFull = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'get_all_full'
+});
+
+const callAll = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'get_all'
+});
+
+const callSetMode = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'set_network_mode',
+	params: { mode: null },
+	reject: true
+});
+
+const callConnect = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'send_connect',
+	reject: true
+});
+
+const callReboot = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'reboot_modem',
+	reject: true
+});
+
+const callUnlockSim = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'unlock_sim',
+	params: { code: '', lock_state: 0 },
+	reject: true
+});
+
+const callDisconnect = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'disconnect_modem',
+	reject: true
+});
+
+const callUnlockPin = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'unlock_pin',
+	params: { pin: '' },
+	reject: true
+});
+
+const callUnlockPuk = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'unlock_puk',
+	params: { puk: '', new_pin: '' },
+	reject: true
+});
+
+const callChangePin = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'change_pin',
+	params: { old_pin: '', new_pin: '' },
+	reject: true
+});
+
+const callChangePinState = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'change_pin_state',
+	params: { pin: '', enable: true },
+	reject: true
+});
+
+const callClearUsage = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'clear_usage',
+	reject: true
+});
+
+const callSetUsageSettings = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'set_usage_settings',
+	params: { settings: {} },
+	reject: true
+});
+
+const callResetModem = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'reset_modem',
+	reject: true
+});
+
+const callSetConnectionSettings = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'set_connection_settings',
+	params: { settings: {} },
+	reject: true
+});
+
+const callEditProfile = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'edit_profile',
+	params: { profile: {} },
+	reject: true
+});
+
+const callDeleteProfile = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'delete_profile',
+	params: { profile_id: 0 },
+	reject: true
+});
+
+const callSetDefaultProfile = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'set_default_profile',
+	params: { profile_id: 0 },
+	reject: true
+});
+
+function formatBytes(bytes) {
+	if (bytes == null || bytes == 0) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const k = 1024;
+	const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), units.length - 1);
+	return (bytes / Math.pow(k, i)).toFixed(i > 0 ? 1 : 0) + ' ' + units[i];
+}
+
+function formatSpeed(bps) {
+	if (bps == null || bps == 0) return '--';
+	const bpsNum = parseInt(bps);
+	if (bpsNum >= 125000) return (bpsNum / 125000).toFixed(1) + ' Mbps';
+	if (bpsNum >= 125) return (bpsNum / 125).toFixed(0) + ' Kbps';
+	return bpsNum + ' Bps';
+}
+
+function formatDuration(seconds) {
+	if (seconds == null) return '--';
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	const s = Math.floor(seconds % 60);
+	if (h > 0) return h + 'h ' + m + 'm ' + s + 's';
+	if (m > 0) return m + 'm ' + s + 's';
+	return s + 's';
+}
+
+function signalQualityClass(value, type) {
+	if (value == null) return 'signal-unknown';
+	if (type === 'rsrp') {
+		if (value > -95) return 'signal-good';
+		if (value > -110) return 'signal-fair';
+		return 'signal-poor';
+	}
+	if (type === 'rsrq') {
+		if (value >= -10) return 'signal-good';
+		if (value >= -15) return 'signal-fair';
+		return 'signal-poor';
+	}
+	if (type === 'sinr') {
+		if (value >= 20) return 'signal-good';
+		if (value >= 13) return 'signal-fair';
+		return 'signal-poor';
+	}
+	if (type === 'ecio') {
+		if (value >= -8) return 'signal-good';
+		if (value >= -13) return 'signal-fair';
+		return 'signal-poor';
+	}
+	if (type === 'rssi') {
+		if (value >= -75) return 'signal-good';
+		if (value >= -85) return 'signal-fair';
+		return 'signal-poor';
+	}
+	return 'signal-unknown';
+}
+
+function networkTypeLabel(netType) {
+	const types = {
+		0: 'Unknown', 1: 'GSM', 2: 'GPRS', 3: 'EDGE',
+		4: 'WCDMA', 5: 'HSDPA', 6: 'HSUPA', 7: 'HSPA',
+		8: 'LTE', 9: 'NR/5G'
+	};
+	return types[netType] || 'Unknown (' + netType + ')';
+}
+
+function simStateLabel(state) {
+	switch (state) {
+		case 0: return _('No SIM');
+		case 1: return _('Detected');
+		case 2: return _('PIN required');
+		case 3: return _('PUK required');
+		case 4: return _('SIM locked (NCK required)');
+		case 5: return _('PUK blocked');
+		case 6: return _('Invalid');
+		case 7: return _('Ready');
+		case 11: return _('Initializing');
+		default: return _('Unknown') + ' (' + (state != null ? state : '--') + ')';
+	}
+}
+
+function createCard(title, content, icon) {
+	icon = icon || '';
+	return E('div', { 'class': 'cbi-section hh4x-card' }, [
+		E('div', { 'class': 'hh4x-card-header' }, (function() {
+			var c = [];
+			if (icon) c.push(E('span', { 'class': 'hh4x-card-icon' }, [icon]));
+			c.push(E('h3', { 'class': 'hh4x-card-title' }, [title]));
+			return c;
+		})()),
+		E('div', { 'class': 'hh4x-card-body' }, content)
+	]);
+}
+
+function createInfoRow(label, value, className) {
+	return E('div', { 'class': 'hh4x-info-row' + (className ? ' ' + className : '') }, [
+		E('span', { 'class': 'hh4x-info-label' }, [label]),
+		E('span', { 'class': 'hh4x-info-value' }, [value != null ? String(value) : '--'])
+	]);
+}
+
+function getSignalMetrics(signal) {
+	var netType = parseInt(signal.NetworkType) || 0;
+	if (netType === 8 || netType === 9) {
+		return [
+			{ label: 'RSRP', field: 'RSRP', unit: 'dBm', type: 'rsrp' },
+			{ label: 'RSSI', field: 'RSSI', unit: 'dBm', type: 'rssi' },
+			{ label: 'RSRQ', field: 'RSRQ', unit: 'dB', type: 'rsrq' },
+			{ label: 'SINR', field: 'SINR', unit: 'dB', type: 'sinr' }
+		];
+	}
+	if (netType >= 4 && netType <= 7) {
+		return [
+			{ label: 'RSCP', field: 'RSCP', unit: 'dBm', type: 'rsrp' },
+			{ label: 'RSSI', field: 'RSSI', unit: 'dBm', type: 'rssi' },
+			{ label: 'RSRQ', field: 'RSRQ', unit: 'dB', type: 'rsrq' },
+			{ label: 'Ec/Io', field: 'EcIo', unit: 'dB', type: 'ecio' }
+		];
+	}
+	return [
+		{ label: 'RSSI', field: 'RSSI', unit: 'dBm', type: 'rssi' },
+		{ label: 'RSCP', field: 'RSCP', unit: 'dBm', type: 'rsrp' },
+		{ label: 'RSRQ', field: 'RSRQ', unit: 'dB', type: 'rsrq' },
+		{ label: 'Ec/Io', field: 'EcIo', unit: 'dB', type: 'ecio' }
+	];
+}
+
+function createSignalIndicator(label, value, unit, type) {
+	if (value == null)
+		return createInfoRow(label, '--');
+
+	let cls = signalQualityClass(parseInt(value) || 0, type);
+	let pct = 0;
+	let numVal = parseInt(value) || 0;
+
+	if (type === 'rsrp') pct = Math.min(100, Math.max(0, (numVal + 140) * 100 / 60));
+	else if (type === 'rssi') pct = Math.min(100, Math.max(0, (numVal + 120) * 100 / 60));
+	else if (type === 'rsrq') pct = Math.min(100, Math.max(0, (numVal + 20) * 100 / 25));
+	else if (type === 'sinr') pct = Math.min(100, Math.max(0, numVal * 100 / 30));
+	else if (type === 'ecio') pct = Math.min(100, Math.max(0, (numVal + 25) * 100 / 25));
+
+	let labelMap = { rsrp: 'RSRP', rssi: 'RSSI', rsrq: 'RSRQ', sinr: 'SINR', ecio: 'Ec/Io' };
+
+	return E('div', { 'class': 'hh4x-signal-row' }, [
+		E('span', { 'class': 'hh4x-signal-label' }, [labelMap[type] || label]),
+		E('div', { 'class': 'hh4x-signal-bar-bg' }, [
+			E('div', {
+				'class': 'hh4x-signal-bar ' + cls,
+				'style': 'width: ' + pct.toFixed(0) + '%'
+			})
+		]),
+		E('span', { 'class': 'hh4x-signal-value ' + cls }, [
+			value + (unit ? ' ' + unit : '')
+		])
+	]);
+}
+
+function createBar(value, max, label, colorClass) {
+	let pct = max > 0 ? Math.min(100, (value / max) * 100) : 0;
+	return E('div', { 'class': 'hh4x-usage-bar-group' }, [
+		E('div', { 'class': 'hh4x-usage-bar-row' }, [
+			E('span', { 'class': 'hh4x-usage-bar-label' }, [label]),
+			E('span', { 'class': 'hh4x-usage-bar-pct' }, [pct.toFixed(1) + '%'])
+		]),
+		E('div', { 'class': 'hh4x-usage-bar-bg' }, [
+			E('div', {
+				'class': 'hh4x-usage-bar ' + (colorClass || ''),
+				'style': 'width: ' + pct.toFixed(0) + '%'
+			})
+		])
+	]);
+}
+
+function updateSignalValue(el, value, unit, type) {
+	if (!el) return;
+	var num = parseInt(value) || 0;
+	var cls = signalQualityClass(num, type);
+	el.textContent = value != null ? value + unit : '--';
+	el.className = 'hh4x-signal-value ' + cls;
+}
+
+function updateSignalBar(el, value, type) {
+	if (!el) return;
+	var num = parseInt(value) || 0;
+	var pct = 0;
+	if (type === 'rsrp') pct = Math.min(100, Math.max(0, (num + 140) * 100 / 60));
+	else if (type === 'rssi') pct = Math.min(100, Math.max(0, (num + 120) * 100 / 60));
+	else if (type === 'rsrq') pct = Math.min(100, Math.max(0, (num + 20) * 100 / 25));
+	else if (type === 'sinr') pct = Math.min(100, Math.max(0, num * 100 / 30));
+	else if (type === 'ecio') pct = Math.min(100, Math.max(0, (num + 25) * 100 / 25));
+	el.style.width = pct.toFixed(0) + '%';
+	el.className = 'hh4x-signal-bar ' + signalQualityClass(num, type);
+}
+
+function updateInfoValue(row, value) {
+	if (!row) return;
+	var valEl = row.querySelector('.hh4x-info-value');
+	if (valEl) valEl.textContent = value != null ? String(value) : '--';
+}
+
+function startPolling(interval) {
+	poll.add(function() {
+		return callAll().then(function(d) {
+			var signal = d.GetNetworkInfo || {};
+			var conn = d.GetConnectionState || {};
+			var grid = document.querySelector('.hh4x-signal-grid');
+			if (!grid) return;
+			var rows = Array.from(grid.children);
+			var metrics = getSignalMetrics(signal);
+			for (var i = 0; i < Math.min(rows.length, metrics.length); i++) {
+				var m = metrics[i];
+				var val = signal[m.field];
+				var isValid = val != null && parseFloat(val) !== 0;
+				var row = rows[i];
+				if (isValid && row.classList.contains('hh4x-signal-row')) {
+					updateSignalValue(row.querySelector('.hh4x-signal-value'), val, ' ' + m.unit, m.type);
+					updateSignalBar(row.querySelector('.hh4x-signal-bar'), val, m.type);
+				} else if (isValid) {
+					var newRow = createSignalIndicator(m.label, val, m.unit, m.type);
+					row.parentNode.replaceChild(newRow, row);
+				} else if (row.classList.contains('hh4x-signal-row')) {
+					var vEl = row.querySelector('.hh4x-signal-value');
+					if (vEl) { vEl.textContent = '--'; vEl.className = 'hh4x-signal-value signal-unknown'; }
+					var bEl = row.querySelector('.hh4x-signal-bar');
+					if (bEl) { bEl.style.width = '0%'; bEl.className = 'hh4x-signal-bar signal-unknown'; }
+				}
+			}
+			var body = grid.closest('.hh4x-card-body') || grid.parentNode;
+			if (body) {
+				var infoRows = body.querySelectorAll('hr.hh4x-divider ~ .hh4x-info-row');
+				var sv = [
+					signal.SignalStrength != null ? signal.SignalStrength + '/5' : '--',
+					signal.Band ? 'Band ' + signal.Band : '--',
+					signal.CellId || '--',
+					signal.eNBID || '--',
+					signal.PLMN || '--',
+					signal.mcc && signal.mnc ? signal.mcc + '/' + signal.mnc : '--',
+					signal.CGI || '--'
+				];
+				infoRows.forEach(function(row, i) {
+					if (i < sv.length) updateInfoValue(row, sv[i]);
+				});
+			}
+			var cards = document.querySelectorAll('.hh4x-card');
+			for (var ci = 0; ci < cards.length; ci++) {
+				var t = cards[ci].querySelector('.hh4x-card-title');
+				if (t && t.textContent === 'Connection') {
+					var r = cards[ci].querySelectorAll('.hh4x-info-row');
+					if (r.length >= 6) {
+						updateInfoValue(r[3], formatSpeed(conn.Speed_Dl));
+						updateInfoValue(r[4], formatSpeed(conn.Speed_Ul));
+					}
+					break;
+				}
+			}
+		}).catch(function() {
+			/* Modem temporarily unreachable — swallow silently.
+			   LuCI's poll.step already catches rejections, but we
+			   handle explicitly for clarity and future notifications. */
+		});
+	}, interval);
+}
+
+// Wait until the modem's actual connection state matches the target
+// (true = connected/ConnectionStatus==2, false = disconnected) before
+// reloading the page. The Connect/Disconnect RPC returns as soon as the
+// modem *accepts* the request, but establishing/tearing down the data
+// connection takes several seconds longer; reloading too early shows the
+// stale state.
+function waitForConnection(targetConnected, done) {
+	var deadline = Date.now() + 40000;
+	function check() {
+		callAll().then(function (d) {
+			var cs = (d.GetConnectionState || {}).ConnectionStatus;
+			var connected = cs == 2;
+			if (connected === targetConnected) { done(); return; }
+			if (Date.now() > deadline) { done(); return; }
+			setTimeout(check, 2000);
+		}).catch(function () {
+			if (Date.now() > deadline) { done(); return; }
+			setTimeout(check, 2000);
+		});
+	}
+	check();
+}
+
+const networkModes = [
+	{ value: 0, label: '2G Only (GSM)' },
+	{ value: 1, label: '3G Only (WCDMA)' },
+	{ value: 2, label: '2G/3G Auto' },
+	{ value: 3, label: '4G/LTE Only' },
+	{ value: 4, label: '2G/3G Auto (fallback from 4G)' },
+	{ value: 5, label: '3G/4G Auto' },
+	{ value: 6, label: '2G/3G/4G Auto (recommended)' }
+];
+
+function authTypeLabel(authType) {
+	const types = { 0: 'None', 1: 'PAP', 2: 'CHAP', 3: 'PAP & CHAP' };
+	return types[authType] || 'Unknown (' + authType + ')';
+}
+
+function pdpTypeLabel(pdpType) {
+	const types = { 0: 'IPv4', 2: 'IPv6', 3: 'IPv4v6' };
+	return types[pdpType] || 'Unknown (' + pdpType + ')';
+}
+
+function showProfileModal(mode, profileData, profileList) {
+	var overlay = document.getElementById('hh4x-apn-modal');
+	if (!overlay) {
+		overlay = E('div', { 'class': 'hh4x-modal-overlay', 'id': 'hh4x-apn-modal' });
+		var modal = E('div', { 'class': 'hh4x-modal' }, [
+			E('div', { 'class': 'hh4x-modal-header' }, [
+				E('span', { 'class': 'hh4x-modal-title', 'id': 'apn-modal-title' }),
+				E('button', {
+					'class': 'hh4x-modal-close cbi-button',
+					'click': function () { overlay.style.display = 'none'; }
+				}, [_('Cancel')])
+			]),
+			E('div', { 'class': 'hh4x-modal-body', 'id': 'apn-modal-body' })
+		]);
+		overlay.appendChild(modal);
+		overlay.addEventListener('click', function (e) {
+			if (e.target === overlay) overlay.style.display = 'none';
+		});
+		document.body.appendChild(overlay);
+	}
+
+	var isEdit = (mode === 'edit');
+	var p = isEdit ? profileData : { ProfileName: '', APN: '', UserName: '', Password: '', AuthType: 0, DailNumber: '*' };
+
+	overlay.querySelector('#apn-modal-title').textContent = isEdit ? _('Edit Profile') : _('Add Profile');
+
+	var body = overlay.querySelector('#apn-modal-body');
+	body.innerHTML = '';
+
+	body.appendChild(E('div', { 'class': 'hh4x-form-group' }, [
+		E('label', { 'class': 'hh4x-form-label' }, [_('Profile Name:')]),
+		E('input', { 'type': 'text', 'class': 'cbi-input-text', 'id': 'apn-form-name',
+			'value': p.ProfileName, 'placeholder': _('Profile name'), 'style': 'width:100%;' })
+	]));
+	body.appendChild(E('div', { 'class': 'hh4x-form-group' }, [
+		E('label', { 'class': 'hh4x-form-label' }, [_('APN:')]),
+		E('input', { 'type': 'text', 'class': 'cbi-input-text', 'id': 'apn-form-apn',
+			'value': p.APN, 'placeholder': _('e.g. internet'), 'style': 'width:100%;' })
+	]));
+	body.appendChild(E('div', { 'class': 'hh4x-form-group' }, [
+		E('label', { 'class': 'hh4x-form-label' }, [_('Username:')]),
+		E('input', { 'type': 'text', 'class': 'cbi-input-text', 'id': 'apn-form-user',
+			'value': p.UserName, 'placeholder': _('Optional'), 'style': 'width:100%;' })
+	]));
+	body.appendChild(E('div', { 'class': 'hh4x-form-group' }, [
+		E('label', { 'class': 'hh4x-form-label' }, [_('Password:')]),
+		E('input', { 'type': 'password', 'class': 'cbi-input-text', 'id': 'apn-form-pass',
+			'value': p.Password, 'placeholder': _('Optional'), 'style': 'width:100%;' })
+	]));
+	body.appendChild(E('div', { 'class': 'hh4x-form-group' }, [
+		E('label', { 'class': 'hh4x-form-label' }, [_('Auth Type:')]),
+		E('select', { 'class': 'cbi-input-select', 'id': 'apn-form-auth' }, [
+			E('option', { value: 0, selected: p.AuthType == 0 ? true : undefined }, ['None']),
+			E('option', { value: 1, selected: p.AuthType == 1 ? true : undefined }, ['PAP']),
+			E('option', { value: 2, selected: p.AuthType == 2 ? true : undefined }, ['CHAP']),
+			E('option', { value: 3, selected: p.AuthType == 3 ? true : undefined }, ['PAP & CHAP'])
+		])
+	]));
+	body.appendChild(E('div', { 'class': 'hh4x-form-group' }, [
+		E('label', { 'class': 'hh4x-form-label' }, [_('Dial Number:')]),
+		E('input', { 'type': 'text', 'class': 'cbi-input-text', 'id': 'apn-form-dial',
+			'value': p.DailNumber, 'placeholder': _('e.g. *99#'), 'style': 'width:100%;' })
+	]));
+	body.appendChild(E('div', { 'style': 'font-size:0.8em;color:var(--text-color-medium);margin-top:8px;' },
+		[_('The new settings take effect after reconnecting the modem (Disconnect then Connect).')]));
+
+	body.appendChild(E('div', { 'class': 'hh4x-modal-actions' }, [
+		E('button', {
+			'class': 'cbi-button cbi-button-neutral',
+			'click': function () { overlay.style.display = 'none'; }
+		}, [_('Cancel')]),
+		E('button', {
+			'class': 'cbi-button cbi-button-apply',
+			'id': 'apn-save-btn',
+			'click': function () {
+				var formData = {
+					ProfileName: document.getElementById('apn-form-name').value.trim(),
+					APN: document.getElementById('apn-form-apn').value.trim(),
+					UserName: document.getElementById('apn-form-user').value.trim(),
+					Password: document.getElementById('apn-form-pass').value,
+					AuthType: parseInt(document.getElementById('apn-form-auth').value),
+					DailNumber: document.getElementById('apn-form-dial').value.trim()
+				};
+				if (!formData.ProfileName) { ui.addNotification(null, E('p', [_('Profile name is required.')]), 'info'); return; }
+				if (!formData.APN) { ui.addNotification(null, E('p', [_('APN is required.')]), 'info'); return; }
+				if (isEdit) formData.ProfileID = profileData.ProfileID;
+				var btn = document.getElementById('apn-save-btn');
+				btn.disabled = true;
+				btn.textContent = _('Saving...');
+				callEditProfile({ profile: formData }).then(function (r) {
+					if (r && r.error == null) {
+						btn.textContent = _('✓ Saved');
+						setTimeout(function () { window.location.reload(); }, 1500);
+					} else {
+						ui.addNotification(null, E('p', [_('Save failed: ') + (r?.error || _('Unknown error'))]), 'error');
+						btn.disabled = false;
+						btn.textContent = _('Save');
+					}
+				}).catch(function (err) {
+					ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+					btn.disabled = false;
+					btn.textContent = _('Save');
+				});
+			}
+		}, [_('Save')])
+	]));
+
+	overlay.style.display = '';
+}
+
+function parseContext(modemData) {
+	var signal  = modemData.GetNetworkInfo || {};
+	var status  = modemData.GetSystemStatus || {};
+	var conn    = modemData.GetConnectionState || {};
+	var usage   = modemData.GetUsageRecord || {};
+	var network = modemData.GetNetworkSettings || {};
+	var reg     = modemData.GetNetworkRegisterState || {};
+	var profiles = modemData.GetProfileList || {};
+	var curProfile = modemData.getCurrentProfile || {};
+	var sysinfo  = modemData.GetSystemInfo || {};
+	var sim      = modemData.GetSimStatus || {};
+	var simPinLocked = (sim.SIMState == 2);
+	var simReady = (sim.SIMState == 7);
+	var simPinSet = (sim.PinState == 1 || sim.PinState == 2);
+	var smsSet  = modemData.GetSMSSettings || {};
+	var smsSto  = modemData.GetSMSStorageState || {};
+	var lan     = modemData.GetLanSettings || {};
+	var upnp    = modemData.GetUpnpSettings || {};
+	var lang    = modemData.GetCurrentLanguage || {};
+	var connSet = modemData.GetConnectionSettings || {};
+
+	return {
+		signal: signal, status: status, conn: conn, usage: usage,
+		network: network, reg: reg, profiles: profiles, curProfile: curProfile,
+		sysinfo: sysinfo, sim: sim, simPinLocked: simPinLocked,
+		simReady: simReady, simPinSet: simPinSet, smsSet: smsSet,
+		smsSto: smsSto, lan: lan, upnp: upnp, lang: lang, connSet: connSet
+	};
+}
+
+function renderStatusTab(ctx) {
+	var signal = ctx.signal, status = ctx.status, conn = ctx.conn;
+
+	var connState = conn.ConnectionStatus != null ? conn.ConnectionStatus : status.ConnectionStatus;
+	var isConnected = connState == 2;
+
+	return E('div', {
+		'data-tab': 'status',
+		'data-tab-title': _('Status'),
+		'data-tab-active': 'true'
+	}, [
+		E('div', { 'class': 'hh4x-row hh4x-row-2col' }, [
+			createCard('Connection', [
+				E('div', { 'class': 'hh4x-status-indicator ' + (isConnected ? 'status-connected' : 'status-disconnected') }, [
+					E('span', { 'class': 'hh4x-status-dot' }, [isConnected ? '●' : '○']),
+					E('span', { 'class': 'hh4x-status-text' }, [
+						isConnected ? _('Connected') : _('Disconnected')
+					]),
+					isConnected
+						? E('button', {
+							'class': 'cbi-button cbi-button-negative hh4x-connect-btn',
+							'style': 'margin-left:8px;padding:2px 8px;font-size:12px;vertical-align:middle;',
+							'click': function (e) {
+								e.stopPropagation();
+								var btn = e.target;
+								btn.disabled = true;
+								btn.textContent = _('Disconnecting...');
+								callDisconnect().then(function (r) {
+									if (r && r.error == null) {
+										btn.textContent = _('Disconnecting...');
+										waitForConnection(false, function () { window.location.reload(); });
+									} else {
+										ui.addNotification(null, E('p', [_('Disconnect failed: ') + (r?.error || _('Unknown error'))]), 'error');
+										btn.disabled = false;
+										btn.textContent = _('Disconnect');
+									}
+								}).catch(function (err) {
+									ui.addNotification(null, E('p', [_('Disconnect error: ') + String(err)]), 'error');
+									btn.disabled = false;
+									btn.textContent = _('Disconnect');
+								});
+							}
+						}, [_('Disconnect')])
+						: E('button', {
+							'class': 'cbi-button cbi-button-apply hh4x-connect-btn',
+							'style': 'margin-left:8px;padding:2px 8px;font-size:12px;vertical-align:middle;',
+							'click': function (e) {
+								e.stopPropagation();
+								var btn = e.target;
+								btn.disabled = true;
+								btn.textContent = _('Connecting...');
+								callConnect().then(function (r) {
+									if (r && r.error == null) {
+										btn.textContent = _('Connecting...');
+										waitForConnection(true, function () { window.location.reload(); });
+									} else {
+										ui.addNotification(null, E('p', [_('Connect failed: ') + (r?.error || _('Unknown error'))]), 'error');
+										btn.disabled = false;
+										btn.textContent = _('Connect');
+									}
+								}).catch(function (err) {
+									ui.addNotification(null, E('p', [_('Connect error: ') + String(err)]), 'error');
+									btn.disabled = false;
+									btn.textContent = _('Connect');
+								});
+							}
+						}, [_('Connect')])
+				]),
+				createInfoRow('Network', networkTypeLabel(status.NetworkType || signal.NetworkType)),
+				createInfoRow('Network Name', status.NetworkName || signal.NetworkName || '--'),
+				createInfoRow('IP Address', conn.IPv4Adrress || '--'),
+				createInfoRow('Download Speed', formatSpeed(conn.Speed_Dl)),
+				createInfoRow('Upload Speed', formatSpeed(conn.Speed_Ul)),
+				createInfoRow('Connection Time', formatDuration(conn.ConnectionTime)),
+				createInfoRow('Roaming', conn.Domestic_Roaming == 1 ? _('Yes') : _('No'))
+			]),
+			createCard('Signal Quality', [
+				E('div', { 'class': 'hh4x-signal-grid' }, (function() {
+					var sigMetrics = getSignalMetrics(signal);
+					return sigMetrics.map(function(m) {
+						var val = signal[m.field];
+						if (val == null || val === 'reserved' || val === '' || parseFloat(val) === 0)
+							return createInfoRow(m.label, '--');
+						return createSignalIndicator(m.label, val, m.unit, m.type);
+					});
+				})()),
+				E('hr', { 'class': 'hh4x-divider' }),
+				createInfoRow('Signal Level', signal.SignalStrength != null ? signal.SignalStrength + '/5' : '--'),
+				createInfoRow('Band', signal.Band ? 'Band ' + signal.Band : '--'),
+				createInfoRow('Cell ID', signal.CellId || '--'),
+				createInfoRow('eNB ID', signal.eNBID || '--'),
+				createInfoRow('PLMN', signal.PLMN || '--'),
+				createInfoRow('MCC/MNC', signal.mcc && signal.mnc ? signal.mcc + '/' + signal.mnc : '--'),
+				createInfoRow('CGI', signal.CGI || '--')
+			])
+		])
+	]);
+}
+
+function renderNetworkTab(ctx) {
+	var network = ctx.network, signal = ctx.signal, reg = ctx.reg,
+		curProfile = ctx.curProfile, connSet = ctx.connSet, profiles = ctx.profiles;
+
+	var currentMode = network.NetworkMode;
+	var currentLabel = 'Unknown';
+	for (var m of networkModes) {
+		if (m.value === currentMode) {
+			currentLabel = m.label;
+			break;
+		}
+	}
+
+	return E('div', {
+		'data-tab': 'network',
+		'data-tab-title': _('Network')
+	}, [
+		E('div', { 'class': 'hh4x-row hh4x-row-2col' }, [
+			createCard('Current Network Mode', [
+				E('div', { 'class': 'hh4x-current-mode' }, [
+					E('span', { 'class': 'hh4x-mode-badge' }, [String(currentMode)]),
+					E('span', { 'class': 'hh4x-mode-label' }, [currentLabel])
+				]),
+				E('hr', { 'class': 'hh4x-divider' }),
+				createInfoRow('Band Selection', network.NetselectionMode === 1 ? _('Automatic') : _('Manual')),
+				createInfoRow('Network Band', network.NetworkBand == null || network.NetworkBand == 255 ? _('All') : network.NetworkBand),
+				createInfoRow('Roaming', network.DomesticRoam == 1 || network.NetworkRoaming == 1 ? _('Enabled') : _('Disabled'))
+			]),
+			createCard('Change Network Mode', [
+				E('div', { 'class': 'hh4x-warning' }, [
+					E('span', { 'class': 'hh4x-warning-icon' }, ['⚠']),
+					E('span', {}, [_('Changing the network mode will temporarily disconnect the data connection.')])
+				]),
+				E('br'),
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('Select network mode:')]),
+					E('select', { 'id': 'netmode-select', 'class': 'cbi-input-select' },
+						networkModes.map(function (m) {
+							var attrs = { value: m.value };
+							if (m.value === currentMode)
+								attrs.selected = true;
+							return E('option', attrs, [m.label]);
+						})
+					)
+				]),
+				E('br'),
+				E('button', {
+					'id': 'apply-mode-btn',
+					'class': 'cbi-button cbi-button-apply',
+					'click': function (ev) {
+						ev.preventDefault();
+						var select = document.getElementById('netmode-select');
+						var mode = parseInt(select.value);
+						var btn = document.getElementById('apply-mode-btn');
+						btn.disabled = true;
+						btn.textContent = _('Applying...');
+						callSetMode({ mode: mode }).then(function (result) {
+							if (result && typeof result === 'object' && result.error == null) {
+								btn.textContent = _('✓ Applied');
+								setTimeout(function () {
+									btn.disabled = false;
+									btn.textContent = _('Apply');
+									window.location.reload();
+								}, 3000);
+							} else {
+								btn.textContent = result?.error || _('Failed');
+								setTimeout(function () {
+									btn.disabled = false;
+									btn.textContent = _('Apply');
+								}, 3000);
+							}
+						}).catch(function (err) {
+							btn.textContent = _('Error: ') + String(err);
+							setTimeout(function () {
+								btn.disabled = false;
+								btn.textContent = _('Apply');
+							}, 5000);
+						});
+					}
+				}, [_('Apply')])
+			])
+		]),
+		E('div', { 'class': 'hh4x-row hh4x-row-2col' }, [
+			createCard('Registration', [
+				createInfoRow('Registration State', reg.regist_state >= 1 || reg.RegisterState >= 1 ? _('Registered') : _('Not Registered')),
+				createInfoRow('Network Operator', reg.NetworkFullName || signal.NetworkName || signal.PLMN_name || reg.PLMN || '--'),
+				E('hr', { 'class': 'hh4x-divider' }),
+				createInfoRow('Current APN', curProfile.APN ? String(curProfile.APN) : _('Auto (Network Provided)')),
+				createInfoRow('Connection Mode', connSet.ConnectMode == 1 ? _('Automatic') : _('Manual')),
+				createInfoRow('PDP Type', connSet.PdpType != null ? pdpTypeLabel(connSet.PdpType) : '--')
+			]),
+			createCard('Connection Mode', [
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('Connection mode:')]),
+					E('select', { 'id': 'conn-mode-select', 'class': 'cbi-input-select' }, [
+						E('option', { value: 1, selected: connSet.ConnectMode == 1 ? true : undefined }, [_('Automatic')]),
+						E('option', { value: 0, selected: (connSet.ConnectMode == 0 || connSet.ConnectMode == null) ? true : undefined }, [_('Manual')])
+					])
+				]),
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('PDP Type:')]),
+					E('select', { 'id': 'pdp-type-select', 'class': 'cbi-input-select' }, [
+						E('option', { value: 0, selected: (connSet.PdpType == 0 || connSet.PdpType == null) ? true : undefined }, ['IPv4']),
+						E('option', { value: 2, selected: connSet.PdpType == 2 ? true : undefined }, ['IPv6']),
+						E('option', { value: 3, selected: connSet.PdpType == 3 ? true : undefined }, ['IPv4v6'])
+					])
+				]),
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'style': 'display:flex;align-items:center;gap:8px;' }, [
+						E('input', { 'type': 'checkbox', 'id': 'roaming-connect', 'checked': (connSet.RoamingConnect == 1) ? true : undefined }),
+						_('Roaming Connect')
+					])
+				]),
+				E('hr', { 'class': 'hh4x-divider' }),
+				E('button', {
+					'class': 'cbi-button cbi-button-apply',
+					'id': 'apply-conn-mode-btn',
+					'click': function (e) {
+						e.preventDefault();
+						var connectMode = parseInt(document.getElementById('conn-mode-select').value);
+						var pdpType = parseInt(document.getElementById('pdp-type-select').value);
+						var roaming = document.getElementById('roaming-connect').checked ? 1 : 0;
+						var btn = e.target;
+						btn.disabled = true;
+						btn.textContent = _('Saving...');
+						callSetConnectionSettings({ settings: {
+							ConnectMode: connectMode,
+							PdpType: pdpType,
+							RoamingConnect: roaming,
+							IdleTime: connSet.IdleTime || 600
+						}}).then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Saved');
+								setTimeout(function () { window.location.reload(); }, 2000);
+							} else {
+								ui.addNotification(null, E('p', [_('Save failed: ') + (r?.error || _('Unknown error'))]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Apply');
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Apply');
+						});
+					}
+				}, [_('Apply')])
+			])
+		]),
+		E('div', { 'class': 'hh4x-row' }, [
+			createCard('APN Profiles', function () {
+				var items = [];
+				items.push(createInfoRow(_('Current Profile'), curProfile.ProfileName || '--'));
+				items.push(createInfoRow(_('Active APN'), curProfile.APN ? String(curProfile.APN) : _('Auto (Network Provided)')));
+				items.push(E('hr', { 'class': 'hh4x-divider' }));
+				var list = profiles.ProfileList || [];
+				if (list.length === 0) {
+					items.push(E('div', { 'style': 'padding:0.5em 0;color:var(--text-color-medium);' }, [_('No profiles available.')]));
+				} else {
+					list.forEach(function (p) {
+						var actions = [];
+						if (!p.IsPredefine) {
+							actions.push(E('button', {
+								'class': 'cbi-button cbi-button-action',
+								'style': 'font-size:0.8em;padding:2px 8px;',
+								'click': function (e) { e.preventDefault(); showProfileModal('edit', p, profiles.ProfileList); }
+							}, [_('Edit')]));
+							actions.push(E('button', {
+								'class': 'cbi-button cbi-button-negative',
+								'style': 'font-size:0.8em;padding:2px 8px;',
+								'click': function (e) {
+									e.preventDefault();
+									if (!confirm(_('Delete profile %s?').format(p.ProfileName))) return;
+									var btn = e.target;
+									btn.disabled = true;
+									btn.textContent = _('Deleting...');
+									callDeleteProfile({ profile_id: p.ProfileID }).then(function (r) {
+										if (r && r.error == null) {
+											setTimeout(function () { window.location.reload(); }, 1500);
+										} else {
+											ui.addNotification(null, E('p', [_('Delete failed: ') + (r?.error || _('Unknown error'))]), 'error');
+											btn.disabled = false;
+											btn.textContent = _('Delete');
+										}
+									}).catch(function (err) {
+										ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+										btn.disabled = false;
+										btn.textContent = _('Delete');
+									});
+								}
+							}, [_('Delete')]));
+						}
+						if (!p.Default) {
+							actions.push(E('button', {
+								'class': 'cbi-button cbi-button-apply',
+								'style': 'font-size:0.8em;padding:2px 8px;',
+								'click': function (e) {
+									e.preventDefault();
+									if (!confirm(_('Set profile %s as default? Connection will be disconnected.').format(p.ProfileName))) return;
+									var btn = e.target;
+									btn.disabled = true;
+									btn.textContent = _('Setting...');
+									callSetDefaultProfile({ profile_id: p.ProfileID }).then(function (r) {
+										if (r && r.error == null) {
+											setTimeout(function () { window.location.reload(); }, 2000);
+										} else {
+											ui.addNotification(null, E('p', [_('Set failed: ') + (r?.error || _('Unknown error'))]), 'error');
+											btn.disabled = false;
+											btn.textContent = _('Set Default');
+										}
+									}).catch(function (err) {
+										ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+										btn.disabled = false;
+										btn.textContent = _('Set Default');
+									});
+								}
+							}, [_('Set Default')]));
+						}
+						var defaultBadge = p.Default ? E('span', { 'class': 'hh4x-mode-badge', 'style': 'width:auto;height:auto;padding:1px 6px;border-radius:3px;font-size:0.75em;' }, ['Default']) : null;
+						var predefinedBadge = p.IsPredefine ? E('span', { 'style': 'font-size:0.75em;color:var(--text-color-medium);margin-left:4px;' }, ['(Predefined)']) : null;
+						items.push(E('div', { 'class': 'hh4x-info-row', 'style': 'flex-wrap:wrap;gap:4px;' }, [
+							E('span', { 'class': 'hh4x-info-label', 'style': 'flex:0 0 auto;font-weight:600;' }, [p.ProfileName]),
+							E('span', { 'style': 'flex:1;text-align:left;color:var(--text-color-medium);font-size:0.9em;' }, ['APN: ' + (p.APN || '--')]),
+							E('span', { 'style': 'font-size:0.85em;color:var(--text-color-dim);' }, ['Auth: ' + authTypeLabel(p.AuthType)]),
+							defaultBadge,
+							predefinedBadge,
+							E('span', { 'style': 'display:flex;gap:4px;margin-left:auto;' }, actions)
+						]));
+					});
+				}
+				items.push(E('hr', { 'class': 'hh4x-divider' }));
+				items.push(E('button', {
+					'class': 'cbi-button cbi-button-action',
+					'id': 'add-profile-btn',
+					'click': function (e) {
+						e.preventDefault();
+						showProfileModal('add', null, profiles.ProfileList);
+					}
+				}, [_('Add New Profile')]));
+				return items;
+			}())
+		])
+	]);
+}
+
+function renderUsageTab(ctx) {
+	var usage = ctx.usage, conn = ctx.conn;
+	var usedBytes = usage.HUseData || 0;
+	var monthlyPlan = usage.MonthlyPlan || 0;
+	var dlBytes = conn.DlBytes || 0;
+	var ulBytes = conn.UlBytes || 0;
+	var connTime = conn.ConnectionTime || 0;
+	var totalDL = usage.HCurrUseDL || 0;
+	var totalUL = usage.HCurrUseUL || 0;
+	var roamData = usage.RoamUseData || 0;
+	var billingDay = conn.BillingDay || 1;
+
+	var usagePercent = monthlyPlan > 0 ? (usedBytes / monthlyPlan) * 100 : 0;
+	var usageColor = usagePercent < 50 ? 'usage-good' : (usagePercent < 80 ? 'usage-warn' : 'usage-critical');
+
+	var usageCardChildren = [
+		E('div', { 'class': 'hh4x-usage-main' }, [
+			E('div', { 'class': 'hh4x-usage-big-number' }, [
+				formatBytes(usedBytes)
+			]),
+			E('div', { 'class': 'hh4x-usage-sub' }, [
+				monthlyPlan > 0
+					? _('of %s monthly plan').format(formatBytes(monthlyPlan))
+					: _('No monthly plan set')
+			])
+		])
+	];
+
+	if (monthlyPlan > 0) {
+		usageCardChildren.push(createBar(usedBytes, monthlyPlan, _('Plan Usage'), usageColor));
+	}
+
+	usageCardChildren.push(
+		E('hr', { 'class': 'hh4x-divider' }),
+		createInfoRow(_('All Time Download'), formatBytes(totalDL)),
+		createInfoRow(_('All Time Upload'), formatBytes(totalUL)),
+		createInfoRow(_('Roaming Data'), formatBytes(roamData))
+	);
+
+	return E('div', {
+		'data-tab': 'usage',
+		'data-tab-title': _('Data Usage')
+	}, [
+		E('div', { 'class': 'hh4x-row hh4x-row-2col' }, [
+			createCard(_('Data Consumption'), usageCardChildren.concat([
+				E('hr', { 'class': 'hh4x-divider' }),
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('Plan Settings')]),
+					E('div', { 'style': 'display:flex;gap:4px;flex-direction:column;' }, [
+						E('label', {}, [_('Monthly Limit (GB):')]),
+						E('input', {
+							'type': 'number',
+							'class': 'cbi-input-text',
+							'id': 'plan-limit-input',
+							'value': monthlyPlan > 0 ? (monthlyPlan / 1073741824).toFixed(1) : '',
+							'placeholder': 'e.g. 10',
+							'style': 'width:100%;'
+						}),
+						E('label', {}, [_('Billing Day:')]),
+						E('input', {
+							'type': 'number',
+							'class': 'cbi-input-text',
+							'id': 'plan-day-input',
+							'value': billingDay,
+							'min': 1,
+							'max': 31,
+							'style': 'width:100%;'
+						})
+					]),
+					E('button', {
+						'class': 'cbi-button cbi-button-apply',
+						'style': 'margin-top:4px;',
+						'click': function (e) {
+							e.preventDefault();
+							var limitGB = parseFloat(document.getElementById('plan-limit-input').value) || 0;
+							var day = parseInt(document.getElementById('plan-day-input').value) || 1;
+							if (day < 1 || day > 31) { ui.addNotification(null, E('p', [_('Billing day must be 1-31.')]), 'info'); return; }
+							var btn = e.target;
+							btn.disabled = true;
+							btn.textContent = _('Saving...');
+							callSetUsageSettings({ settings: {
+								MonthlyPlan: Math.round(limitGB * 1073741824),
+								BillingDay: day
+							}}).then(function (r) {
+								if (r && r.error == null) {
+									btn.textContent = _('✓ Saved');
+									setTimeout(function () { window.location.reload(); }, 2000);
+								} else {
+									ui.addNotification(null, E('p', [_('Save failed: ') + (r?.error || _('Unknown error'))]), 'error');
+									btn.disabled = false;
+									btn.textContent = _('Save');
+								}
+							}).catch(function (err) {
+								ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Save');
+							});
+						}
+					}, [_('Save')])
+				])
+			])),
+			createCard(_('Current Session'), [
+				createInfoRow(_('Connection Time'), formatDuration(connTime)),
+				createInfoRow(_('Session Download'), formatBytes(dlBytes)),
+				createInfoRow(_('Session Upload'), formatBytes(ulBytes)),
+				createInfoRow(_('Total'), formatBytes(dlBytes + ulBytes)),
+				createInfoRow(_('Download Speed'), formatSpeed(conn.Speed_Dl)),
+				createInfoRow(_('Upload Speed'), formatSpeed(conn.Speed_Ul))
+			])
+		]),
+		E('div', { 'class': 'hh4x-row' }, [
+			createCard(_('Connection History'), [
+				createInfoRow(_('Total Connections'), usage.TConnTimes != null ? usage.TConnTimes.toLocaleString() : '--'),
+				createInfoRow(_('Monthly Connections'), usage.CurrConnTimes != null ? usage.CurrConnTimes.toLocaleString() : '--'),
+				createInfoRow(_('Monthly Plan'), monthlyPlan > 0 ? formatBytes(monthlyPlan) : _('Not set')),
+				createInfoRow(_('Billing Day'), billingDay),
+				E('hr', { 'class': 'hh4x-divider' }),
+				E('button', {
+					'class': 'cbi-button cbi-button-negative',
+					'id': 'clear-usage-btn',
+					'click': function (e) {
+						e.preventDefault();
+						if (!confirm(_('Clear all data usage statistics? This cannot be undone.'))) return;
+						var btn = e.target;
+						btn.disabled = true;
+						btn.textContent = _('Clearing...');
+						callClearUsage().then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Cleared');
+								setTimeout(function () { window.location.reload(); }, 2000);
+							} else {
+								ui.addNotification(null, E('p', [_('Clear failed: ') + (r?.error || _('Unknown error'))]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Clear Data');
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Clear Data');
+						});
+					}
+				}, [_('Clear Data')])
+			])
+		])
+	]);
+}
+
+function renderInfoTab(ctx) {
+	var status = ctx.status, network = ctx.network, sim = ctx.sim,
+		sysinfo = ctx.sysinfo, simPinLocked = ctx.simPinLocked,
+		simReady = ctx.simReady, simPinSet = ctx.simPinSet,
+		lan = ctx.lan, upnp = ctx.upnp, lang = ctx.lang;
+
+	var infoTab = E('div', {
+		'data-tab': 'info',
+		'data-tab-title': _('Info')
+	}, [
+		E('div', { 'class': 'hh4x-row hh4x-row-2col' }, [
+			createCard(_('Modem'), [
+				createInfoRow(_('Device Name'), sysinfo.DeviceName),
+				createInfoRow(_('Hardware Version'), sysinfo.HwVersion),
+				createInfoRow(_('Software Version'), (sysinfo.SwVersion || '').replace(/\n/g, '') || '--'),
+				createInfoRow(_('WebUI Version'), (sysinfo.WebUiVersion || '').replace(/\n/g, '') || '--'),
+				createInfoRow(_('IMEI'), sysinfo.IMEI || '--'),
+				createInfoRow(_('ICCID'), sysinfo.ICCID || '--'),
+				createInfoRow(_('Band'), sysinfo.band || '--'),
+				createInfoRow(_('Connection Status'), status.ConnectionStatus == 2 ? _('Connected') : _('Disconnected'))
+			]),
+			createCard(_('SIM Card'), [
+				createInfoRow(_('SIM State'), simStateLabel(sim.SIMState)),
+				createInfoRow(_('Provider'), sim.SPN || '--'),
+				createInfoRow(_('PLMN'), sim.PLMN || '--'),
+				createInfoRow(_('IMSI'), sysinfo.IMSI ? sysinfo.IMSI.replace(/(\d{4})\d{6}(\d{4})/, '$1******$2') : '--'),
+				createInfoRow(_('PIN State'), simPinLocked ? _('Required / Locked') : (simPinSet ? _('Enabled') : _('Not required'))),
+				createInfoRow(_('SIM Lock State'), sim.SIMState == 4 ? _('Locked (network/SIM lock)') : _('Unlocked')),
+				createInfoRow(
+					sim.SIMState == 3 ? _('PUK attempts left') : _('PIN attempts left'),
+					(sim.SIMState == 3
+						? (sim.PukRemainingTimes != null ? sim.PukRemainingTimes : '--')
+						: (sim.PinRemainingTimes != null ? sim.PinRemainingTimes : '--'))
+				)
+			]),
+			sim.SIMState == 4 ? createCard(_('Unlock SIM'), [
+				E('div', { 'class': 'hh4x-warning' }, [
+					E('span', { 'class': 'hh4x-warning-icon' }, ['⚠']),
+					E('span', {}, [_('The SIM card is network-locked. Enter the unlock code (NCK) below.')])
+				]),
+				E('br'),
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('Unlock Code:')]),
+					E('input', {
+						'type': 'text',
+						'class': 'cbi-input-text',
+						'id': 'unlock-code-input',
+						'placeholder': _('Enter NCK unlock code'),
+						'style': 'width:100%;'
+					})
+				]),
+				E('br'),
+				E('button', {
+					'class': 'cbi-button cbi-button-apply',
+					'id': 'unlock-btn',
+					'click': function (e) {
+						e.preventDefault();
+						var code = document.getElementById('unlock-code-input').value.trim();
+						if (!code) { ui.addNotification(null, E('p', [_('Please enter the unlock code.')]), 'info'); return; }
+						var btn = document.getElementById('unlock-btn');
+						btn.disabled = true;
+						btn.textContent = _('Unlocking...');
+						callUnlockSim({ code: code, lock_state: sim.SIMLockState || 0 }).then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Unlock command sent');
+								ui.addNotification(null, E('p', [_('Unlock command sent successfully. The modem may restart.')]), 'info');
+								setTimeout(function () { window.location.reload(); }, 3000);
+							} else {
+								btn.textContent = _('Unlock command sent (verifying...)');
+								btn.disabled = false;
+								ui.addNotification(null, E('p', [_('Unlock reported an error: %s. Re-checking SIM state...').format((r && r.error) || _('Unknown error'))]), 'warning');
+								setTimeout(function () { window.location.reload(); }, 3000);
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Unlock error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Unlock');
+						});
+					}
+				}, [_('Unlock')])
+			]) : null,
+			sim.SIMState == 3 ? createCard(_('Unlock PUK'), [
+				E('div', { 'class': 'hh4x-warning' }, [
+					E('span', { 'class': 'hh4x-warning-icon' }, ['⚠']),
+					E('span', {}, [_('The SIM is PUK-locked. Enter the PUK code and a new PIN (4-8 digits) to unlock. Unlocking erases all SIM data.')])
+				]),
+				E('br'),
+				E('div', { 'class': 'hh4x-form-group', 'style': 'margin-bottom:12px;' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('PUK code:')]),
+					E('input', {
+						'type': 'password',
+						'class': 'cbi-input-text',
+						'id': 'puk-unlock-input',
+						'placeholder': _('Enter PUK code'),
+						'style': 'width:100%;'
+					})
+				]),
+				E('div', { 'class': 'hh4x-form-group' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('New PIN (required, 4-8 digits):')]),
+					E('input', {
+						'type': 'password',
+						'class': 'cbi-input-text',
+						'id': 'puk-newpin-input',
+						'placeholder': _('New PIN (4-8 digits)'),
+						'style': 'width:100%;'
+					})
+				]),
+				E('br'),
+				E('button', {
+					'class': 'cbi-button cbi-button-apply',
+					'id': 'puk-unlock-btn',
+					'click': function (e) {
+						e.preventDefault();
+						var puk = document.getElementById('puk-unlock-input').value.trim();
+						if (!puk) { ui.addNotification(null, E('p', [_('Please enter the PUK code.')]), 'info'); return; }
+						var newPin = document.getElementById('puk-newpin-input').value.trim();
+						if (!newPin) { ui.addNotification(null, E('p', [_('A new PIN is required to unlock a PUK-locked SIM (4-8 digits).')]), 'info'); return; }
+						var btn = document.getElementById('puk-unlock-btn');
+						btn.disabled = true;
+						btn.textContent = _('Unlocking...');
+						callUnlockPuk({ puk: puk, new_pin: newPin }).then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Unlocked');
+								setTimeout(function () { window.location.reload(); }, 2000);
+							} else {
+								ui.addNotification(null, E('p', [_('Unlock failed: ') + (r?.error || _('Unknown error'))]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Unlock');
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Unlock');
+						});
+					}
+				}, [_('Unlock')])
+			]) : null,
+			(simPinLocked || simReady) ? createCard(_('SIM PIN'), [
+				simPinLocked ? E('div', { 'class': 'hh4x-form-group', 'style': 'margin-bottom:12px;' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [_('Enter PIN to unlock:')]),
+					E('input', {
+						'type': 'password',
+						'class': 'cbi-input-text',
+						'id': 'pin-unlock-input',
+						'placeholder': _('Current PIN'),
+						'style': 'width:100%;'
+					}),
+					E('button', {
+						'class': 'cbi-button cbi-button-apply',
+						'style': 'margin-top:4px;',
+						'click': function (e) {
+							e.preventDefault();
+							var pin = document.getElementById('pin-unlock-input').value.trim();
+							if (!pin) { ui.addNotification(null, E('p', [_('Please enter the PIN.')]), 'info'); return; }
+							var btn = e.target;
+							btn.disabled = true;
+							btn.textContent = _('Unlocking...');
+							callUnlockPin({ pin: pin }).then(function (r) {
+								if (r && r.error == null) {
+									btn.textContent = _('✓ Unlocked');
+									setTimeout(function () { window.location.reload(); }, 2000);
+								} else {
+									ui.addNotification(null, E('p', [_('Unlock failed: ') + (r?.error || _('Unknown error'))]), 'error');
+									btn.disabled = false;
+									btn.textContent = _('Unlock');
+								}
+							}).catch(function (err) {
+								ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Unlock');
+							});
+						}
+					}, [_('Unlock')])
+				]) : null,
+				simReady ? E('div', { 'class': 'hh4x-form-group', 'style': 'margin-bottom:12px;' }, [
+					E('label', { 'class': 'hh4x-form-label' }, [
+						simPinSet ? _('Disable PIN protection:') : _('Enable PIN protection:')
+					]),
+					E('input', {
+						'type': 'password',
+						'class': 'cbi-input-text',
+						'id': 'pin-toggle-input',
+						'placeholder': _('Current/default SIM PIN (e.g. 0000)'),
+						'style': 'width:100%;'
+					}),
+					E('button', {
+						'class': 'cbi-button cbi-button-apply',
+						'style': 'margin-top:4px;',
+						'click': function (e) {
+							e.preventDefault();
+							var pin = document.getElementById('pin-toggle-input').value.trim();
+							if (!pin) { ui.addNotification(null, E('p', [_('Please enter the SIM\'s current PIN.')]), 'info'); return; }
+							var enable = !simPinSet;
+							var btn = e.target;
+							btn.disabled = true;
+							btn.textContent = _('Setting...');
+							callChangePinState({ pin: pin, enable: enable }).then(function (r) {
+								if (r && r.error == null) {
+									btn.textContent = _('✓ Done');
+									setTimeout(function () { window.location.reload(); }, 2000);
+								} else {
+									ui.addNotification(null, E('p', [_('Failed: ') + (r && r.error != null ? r.error : JSON.stringify(r || 'null'))]), 'error');
+									btn.disabled = false;
+									btn.textContent = _('Apply');
+								}
+							}).catch(function (err) {
+								ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Apply');
+							});
+						}
+					}, [simPinSet ? _('Disable') : _('Enable')])
+				]) : null,
+				simPinSet ? E('div', {}, [
+					E('hr', { 'class': 'hh4x-divider' }),
+					E('div', { 'class': 'hh4x-form-group' }, [
+						E('label', { 'class': 'hh4x-form-label' }, [_('Change PIN:')]),
+						E('div', { 'style': 'display:flex;gap:4px;flex-direction:column;' }, [
+							E('input', {
+								'type': 'password',
+								'class': 'cbi-input-text',
+								'id': 'pin-old-input',
+								'placeholder': _('Current PIN'),
+								'style': 'width:100%;'
+							}),
+							E('input', {
+								'type': 'password',
+								'class': 'cbi-input-text',
+								'id': 'pin-new-input',
+								'placeholder': _('New PIN (4-8 digits)'),
+								'style': 'width:100%;'
+							})
+						]),
+						E('button', {
+							'class': 'cbi-button cbi-button-action',
+							'style': 'margin-top:4px;',
+							'click': function (e) {
+								e.preventDefault();
+								var oldPin = document.getElementById('pin-old-input').value.trim();
+								var newPin = document.getElementById('pin-new-input').value.trim();
+								if (!oldPin || !newPin) { ui.addNotification(null, E('p', [_('Please fill all fields.')]), 'info'); return; }
+								var btn = e.target;
+								btn.disabled = true;
+								btn.textContent = _('Changing...');
+								callChangePin({ old_pin: oldPin, new_pin: newPin }).then(function (r) {
+									if (r && r.error == null) {
+										btn.textContent = _('✓ Changed');
+										ui.addNotification(null, E('p', [_('PIN changed successfully.')]), 'info');
+										setTimeout(function () { window.location.reload(); }, 2000);
+									} else {
+										ui.addNotification(null, E('p', [_('Failed: ') + (r?.error || _('Unknown error'))]), 'error');
+										btn.disabled = false;
+										btn.textContent = _('Change');
+									}
+								}).catch(function (err) {
+									ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+									btn.disabled = false;
+									btn.textContent = _('Change');
+								});
+							}
+						}, [_('Change')])
+					])
+				]) : null
+			].filter(Boolean)) : null
+		].filter(Boolean)),
+		E('div', { 'class': 'hh4x-row hh4x-row-2col' }, [
+			createCard(_('LAN / Router'), [
+				createInfoRow(_('LAN IP'), lan.LanIp || lan.IPv4IPAddress || '--'),
+				createInfoRow(_('Subnet Mask'), lan.SubnetMask || '--'),
+				createInfoRow(_('DHCP'), lan.DHCPServerStatus == 1 ? _('Enabled') : _('Disabled')),
+				createInfoRow(_('DHCP Start'), lan.StartIPAddress || '--'),
+				createInfoRow(_('DHCP End'), lan.EndIPAddress || '--'),
+				createInfoRow(_('DNS'), lan.IPv4IPAddress || '--'),
+				E('hr', { 'class': 'hh4x-divider' }),
+				createInfoRow(_('UI Language'), lang.Language || '--'),
+				createInfoRow(_('UPnP'), upnp.upnp_switch == 1 ? _('Enabled') : _('Disabled'))
+			])
+		]),
+		E('div', { 'class': 'hh4x-row' }, [
+			createCard(_('Device Control'), [
+				E('div', { 'class': 'hh4x-warning' }, [
+					E('span', { 'class': 'hh4x-warning-icon' }, ['⚠']),
+					E('span', {}, [_('Rebooting the modem will also reboot the entire router. All connections will be lost temporarily.')])
+				]),
+				E('br'),
+				E('button', {
+					'class': 'cbi-button cbi-button-negative',
+					'id': 'reboot-btn',
+					'click': function (e) {
+						e.preventDefault();
+						if (!confirm(_('Are you sure you want to reboot the modem? The router will restart and all connections will be lost.'))) return;
+						var btn = document.getElementById('reboot-btn');
+						btn.disabled = true;
+						btn.textContent = _('Rebooting...');
+						callReboot().then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Reboot command sent');
+							} else {
+								ui.addNotification(null, E('p', [_('Reboot failed: ') + (r?.error || _('Unknown error'))]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Reboot Modem');
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Reboot error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Reboot Modem');
+						});
+					}
+				}, [_('Reboot Modem')]),
+				E('br'),
+				E('button', {
+					'class': 'cbi-button cbi-button-negative',
+					'id': 'reset-btn',
+					'style': 'margin-top:8px;',
+					'click': function (e) {
+						e.preventDefault();
+						if (!confirm(_('Factory reset will erase all modem settings and return to defaults. Continue?'))) return;
+						if (!confirm(_('This cannot be undone. Are you absolutely sure?'))) return;
+						var btn = document.getElementById('reset-btn');
+						btn.disabled = true;
+						btn.textContent = _('Resetting...');
+						callResetModem().then(function (r) {
+							if (r && r.error == null) {
+								btn.textContent = _('✓ Reset command sent');
+							} else {
+								ui.addNotification(null, E('p', [_('Reset failed: ') + (r?.error || _('Unknown error'))]), 'error');
+								btn.disabled = false;
+								btn.textContent = _('Factory Reset');
+							}
+						}).catch(function (err) {
+							ui.addNotification(null, E('p', [_('Reset error: ') + String(err)]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Factory Reset');
+						});
+					}
+				}, [_('Factory Reset')])
+			])
+		])
+	]);
+	return infoTab;
+}
+
+return view.extend({
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null,
+
+	load: function () {
+		return Promise.all([
+			callAllFull(),
+			uci.load('hh4xmodem').then(function () {
+				return uci.get('hh4xmodem', 'settings', 'refresh_interval');
+			})
+		]);
+	},
+
+	render: function (data) {
+		var modemData = data[0];
+		var refreshInterval = parseInt(data[1]) || 3;
+		var ctx = parseContext(modemData);
+
+		// ========== Build Tabs ==========
+		var statusTab  = renderStatusTab(ctx);
+		var networkTab = renderNetworkTab(ctx);
+		var usageTab   = renderUsageTab(ctx);
+		var infoTab    = renderInfoTab(ctx);
+
+		var paneContainer = E('div', { 'class': 'hh4x-tab-panes' }, [
+			statusTab, networkTab, usageTab, infoTab
+		]);
+
+		setTimeout(function () {
+			try {
+				ui.tabs.initTabGroup(paneContainer.childNodes);
+			} catch (e) {}
+			startPolling(refreshInterval);
+		}, 200);
+
+		return E('div', { 'class': 'hh4x-page' }, [ paneContainer ]);
+	}
+});
+

--- a/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/hh4xmodem.css
+++ b/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/hh4xmodem.css
@@ -1,0 +1,791 @@
+/*
+ * hh4xmodem.css - Modern UI styles for HH4xModem LuCI app
+ * Fully compatible with LuCI bootstrap-dark theme via official CSS variables.
+ * Copyright (C) 2026 HH4xModem
+ */
+
+/* ---- Page Layout ---- */
+.hh4x-dashboard,
+.hh4x-page {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0;
+}
+
+.hh4x-page-header {
+	margin-bottom: 1.5em;
+	padding-bottom: 1em;
+	border-bottom: 1px solid var(--border-color-low);
+}
+
+.hh4x-page-title {
+	font-size: 1.6em;
+	font-weight: 600;
+	color: var(--text-color-high);
+	background: none;
+	margin: 0 0 0.3em 0;
+	line-height: 1.3;
+}
+
+.hh4x-page-desc {
+	color: var(--text-color-medium);
+	font-size: 0.95em;
+	margin: 0;
+}
+
+/* ---- Card Grid ---- */
+.hh4x-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1.2em;
+	margin-bottom: 1.2em;
+}
+
+.hh4x-row-2col > .cbi-section {
+	flex: 1 1 calc(50% - 0.6em);
+	min-width: 320px;
+}
+
+@media (max-width: 800px) {
+	.hh4x-row-2col > .cbi-section {
+		flex: 1 1 100%;
+	}
+}
+
+/* ---- Card ---- */
+/* Use --background-color-low for cards - in light mode it's slightly darker than bg,
+   in dark mode it's slightly lighter than the dark bg, creating a subtle card effect */
+.hh4x-card {
+	background: var(--background-color-low);
+	border: 1px solid var(--border-color-low);
+	border-radius: 8px;
+	padding: 0;
+	overflow: hidden;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+	transition: box-shadow 0.2s ease;
+}
+
+.hh4x-card:hover {
+	box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.hh4x-card-header {
+	display: flex;
+	align-items: center;
+	gap: 0.6em;
+	padding: 1em 1.2em 0.6em;
+	border-bottom: 1px solid var(--border-color-low);
+}
+
+.hh4x-card-icon {
+	font-size: 1.2em;
+	line-height: 1;
+}
+
+.hh4x-card-title {
+	font-size: 1.1em;
+	font-weight: 600;
+	color: var(--text-color-high);
+	background: none;
+	margin: 0;
+	padding: 0;
+	line-height: 1.3;
+}
+
+.hh4x-card-body {
+	padding: 0.8em 1.2em 1.2em;
+	color: var(--text-color-high);
+	background: none;
+}
+
+/* ---- Connection Status ---- */
+.hh4x-status-indicator {
+	display: flex;
+	align-items: center;
+	gap: 0.6em;
+	padding: 0.6em 0.8em;
+	margin-bottom: 0.8em;
+	border-radius: 6px;
+	font-size: 1.1em;
+	font-weight: 500;
+}
+
+.status-connected {
+	background: color-mix(in srgb, var(--success-color-medium) 20%, transparent);
+	color: var(--success-color-high);
+}
+
+.status-disconnected {
+	background: color-mix(in srgb, var(--error-color-medium) 20%, transparent);
+	color: var(--error-color-high);
+}
+
+.hh4x-status-dot {
+	font-size: 1.4em;
+	line-height: 1;
+}
+
+/* ---- Info Rows ---- */
+.hh4x-info-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.4em 0;
+	border-bottom: 1px solid var(--border-color-low);
+	font-size: 0.92em;
+}
+
+.hh4x-info-row:last-child {
+	border-bottom: none;
+}
+
+.hh4x-info-label {
+	color: var(--text-color-high);
+	font-weight: 500;
+	flex: 0 0 45%;
+	opacity: 0.85;
+	max-width: 45%;
+}
+
+.hh4x-info-value {
+	color: var(--text-color-high);
+	background: none;
+	font-weight: 600;
+	text-align: right;
+	flex: 0 0 52%;
+	word-break: break-all;
+}
+
+/* ---- Signal Quality ---- */
+.hh4x-signal-grid {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4em;
+	margin-bottom: 0.6em;
+}
+
+.hh4x-signal-row {
+	display: flex;
+	align-items: center;
+	gap: 0.6em;
+	padding: 0.3em 0;
+}
+
+.hh4x-signal-label {
+	font-size: 0.85em;
+	font-weight: 600;
+	color: var(--text-color-medium);
+	min-width: 3.5em;
+}
+
+.hh4x-signal-bar-bg {
+	flex: 1;
+	height: 8px;
+	background: var(--border-color-low);
+	border-radius: 4px;
+	overflow: hidden;
+	min-width: 60px;
+}
+
+.hh4x-signal-bar {
+	height: 100%;
+	border-radius: 4px;
+	transition: width 0.3s ease, background 0.3s ease;
+}
+
+.hh4x-signal-value {
+	font-size: 0.85em;
+	font-weight: 600;
+	min-width: 5em;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+	color: var(--text-color-high);
+	background: none;
+}
+
+/* Signal Colors - bar background only */
+.signal-good {
+	background: var(--success-color-high);
+}
+
+.signal-fair {
+	background: var(--warn-color-high);
+}
+
+.signal-poor {
+	background: var(--error-color-high);
+}
+
+.signal-unknown {
+	background: var(--border-color-low);
+}
+
+/* Signal text values inherit --text-color-high by default,
+   but we tint them slightly for visual cue */
+.hh4x-signal-value.signal-good {
+	background: none;
+	color: var(--success-color-high);
+}
+.hh4x-signal-value.signal-fair {
+	background: none;
+	color: var(--warn-color-high);
+}
+.hh4x-signal-value.signal-poor {
+	background: none;
+	color: var(--error-color-high);
+}
+.hh4x-signal-value.signal-unknown {
+	background: none;
+	color: var(--text-color-medium);
+}
+
+/* ---- Divider ---- */
+.hh4x-divider {
+	border: none;
+	border-top: 1px solid var(--border-color-low);
+	margin: 0.8em 0;
+}
+
+/* ---- Network Mode ---- */
+.hh4x-current-mode {
+	display: flex;
+	align-items: center;
+	gap: 1em;
+	padding: 0.6em 0;
+}
+
+.hh4x-mode-badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.5em;
+	height: 2.5em;
+	border-radius: 50%;
+	background: var(--primary-color-high);
+	color: var(--on-primary-color);
+	font-size: 1.1em;
+	font-weight: 700;
+}
+
+.hh4x-mode-label {
+	font-size: 1em;
+	font-weight: 500;
+	color: var(--text-color-high);
+	background: none;
+}
+
+/* ---- Warning ---- */
+.hh4x-warning {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5em;
+	padding: 0.7em 0.9em;
+	background: color-mix(in srgb, var(--warn-color-medium) 20%, transparent);
+	border: 1px solid var(--warn-color-low);
+	border-radius: 6px;
+	color: var(--warn-color-high);
+	font-size: 0.9em;
+	line-height: 1.4;
+}
+
+.hh4x-warning-icon {
+	font-size: 1.2em;
+	line-height: 1;
+	flex-shrink: 0;
+}
+
+/* ---- Form Elements ---- */
+.hh4x-form-group {
+	margin: 0.5em 0;
+}
+
+.hh4x-form-label {
+	display: block;
+	font-size: 0.9em;
+	font-weight: 500;
+	color: var(--text-color-high);
+	background: none;
+	margin-bottom: 0.4em;
+}
+
+.hh4x-input-group {
+	display: flex;
+	gap: 0.6em;
+	align-items: center;
+}
+
+/* ---- USSD Output ---- */
+.ussd-output {
+	margin-top: 1em;
+	padding: 1em;
+	border-radius: 6px;
+	font-family: monospace;
+	font-size: 0.95em;
+	line-height: 1.6;
+	white-space: pre-wrap;
+	word-break: break-word;
+	background: var(--background-color-medium);
+	border: 1px solid var(--border-color-medium);
+	color: var(--text-color-high);
+	max-height: 400px;
+	overflow-y: auto;
+}
+
+/* ---- Data Usage ---- */
+.hh4x-usage-main {
+	text-align: center;
+	padding: 1em 0 0.5em;
+}
+
+.hh4x-usage-big-number {
+	font-size: 2em;
+	font-weight: 700;
+	color: var(--text-color-high);
+	background: none;
+	line-height: 1.2;
+}
+
+.hh4x-usage-sub {
+	font-size: 0.85em;
+	color: var(--text-color-medium);
+	margin-top: 0.3em;
+}
+
+.hh4x-usage-bar-group {
+	margin: 0.8em 0;
+}
+
+.hh4x-usage-bar-row {
+	display: flex;
+	justify-content: space-between;
+	font-size: 0.85em;
+	margin-bottom: 0.3em;
+}
+
+.hh4x-usage-bar-label {
+	color: var(--text-color-medium);
+}
+
+.hh4x-usage-bar-pct {
+	font-weight: 600;
+	color: var(--text-color-high);
+	background: none;
+}
+
+.hh4x-usage-bar-bg {
+	height: 12px;
+	background: var(--border-color-low);
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.hh4x-usage-bar {
+	height: 100%;
+	border-radius: 6px;
+	transition: width 0.5s ease;
+}
+
+.usage-good {
+	background: var(--success-color-high);
+}
+
+.usage-warn {
+	background: var(--warn-color-high);
+}
+
+.usage-critical {
+	background: var(--error-color-high);
+}
+
+/* ---- Call Log Styles ---- */
+.hh4x-summary-grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 0.8em;
+	padding: 0.5em 0;
+}
+
+.hh4x-summary-item {
+	text-align: center;
+	padding: 0.8em 0.3em;
+	background: var(--background-color-medium);
+	border-radius: 6px;
+}
+
+.hh4x-summary-count {
+	display: block;
+	font-size: 1.6em;
+	font-weight: 700;
+	color: var(--text-color-high);
+}
+
+.hh4x-summary-label {
+	display: block;
+	font-size: 0.85em;
+	color: var(--text-color-medium);
+	margin-top: 0.2em;
+}
+
+.hh4x-call-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.hh4x-call-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.6em 0.5em;
+	border-bottom: 1px solid var(--border-color-low);
+	gap: 0.8em;
+}
+
+.hh4x-call-row:last-child {
+	border-bottom: none;
+}
+
+.hh4x-call-left {
+	display: flex;
+	align-items: center;
+	gap: 0.6em;
+	flex: 1;
+	min-width: 0;
+}
+
+.hh4x-call-right {
+	display: flex;
+	align-items: center;
+	gap: 0.8em;
+	flex-shrink: 0;
+}
+
+.hh4x-call-type-badge {
+	padding: 0.15em 0.5em;
+	border-radius: 3px;
+	font-size: 0.75em;
+	font-weight: 600;
+	text-transform: uppercase;
+	min-width: 4.5em;
+	text-align: center;
+}
+
+.hh4x-call-type-badge.call-incoming {
+	background: var(--background-color-medium);
+	color: var(--success-color-high);
+}
+
+.hh4x-call-type-badge.call-outgoing {
+	background: var(--background-color-medium);
+	color: var(--primary-color-high);
+}
+
+.hh4x-call-type-badge.call-missed {
+	background: var(--background-color-medium);
+	color: var(--error-color-high);
+}
+
+.hh4x-call-number {
+	font-weight: 600;
+	color: var(--text-color-high);
+	font-size: 0.95em;
+}
+
+.hh4x-call-date {
+	font-size: 0.85em;
+	color: var(--text-color-medium);
+	white-space: nowrap;
+}
+
+.hh4x-call-duration {
+	font-size: 0.85em;
+	color: var(--text-color-medium);
+	min-width: 5em;
+	text-align: right;
+}
+
+/* ---- SMS Styles ---- */
+.hh4x-sms-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 1em;
+	padding: 0.5em 0.5em 0.7em;
+	border-bottom: 1px solid var(--border-color-low);
+}
+
+.hh4x-sms-toolbar-label {
+	display: flex;
+	align-items: center;
+	gap: 0.3em;
+	font-size: 0.9em;
+	color: var(--text-color-medium);
+	cursor: pointer;
+	user-select: none;
+}
+
+.hh4x-sms-toolbar-label input[type="checkbox"] {
+	margin: 0;
+}
+
+.hh4x-sms-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.hh4x-sms-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5em;
+	padding: 0.7em 0.5em;
+	border-bottom: 1px solid var(--border-color-low);
+	cursor: pointer;
+	transition: background 0.15s ease;
+}
+
+.hh4x-sms-check-cell {
+	flex-shrink: 0;
+	padding-top: 0.2em;
+}
+
+.hh4x-sms-check-cell input[type="checkbox"] {
+	margin: 0;
+	cursor: pointer;
+}
+
+.hh4x-sms-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.hh4x-sms-row:hover {
+	background: var(--background-color-medium);
+}
+
+.hh4x-sms-row:last-child {
+	border-bottom: none;
+}
+
+.hh4x-sms-unread {
+	border-left: 3px solid var(--primary-color-high);
+}
+
+.hh4x-sms-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 0.3em;
+}
+
+.hh4x-sms-sender {
+	font-weight: 600;
+	color: var(--text-color-high);
+	font-size: 0.95em;
+}
+
+.hh4x-sms-date {
+	font-size: 0.8em;
+	color: var(--text-color-medium);
+}
+
+.hh4x-sms-preview {
+	font-size: 0.88em;
+	color: var(--text-color-medium);
+	line-height: 1.4;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.hh4x-sms-id {
+	font-size: 0.75em;
+	color: var(--text-color-dim);
+	margin-top: 0.2em;
+}
+
+/* ---- SMS Modal ---- */
+.hh4x-modal-overlay {
+	position: fixed;
+	top: 0; left: 0; right: 0; bottom: 0;
+	background: rgba(0,0,0,0.55);
+	z-index: 1000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 1em;
+}
+
+.hh4x-modal {
+	background: var(--background-color);
+	border-radius: 6px;
+	box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+	max-width: 600px;
+	width: 100%;
+	max-height: 80vh;
+	overflow-y: auto;
+}
+
+.hh4x-modal-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.8em 1em;
+	border-bottom: 1px solid var(--border-color-low);
+}
+
+.hh4x-modal-title {
+	font-size: 1em;
+	font-weight: 600;
+	color: var(--text-color-high);
+}
+
+.hh4x-modal-close {
+	padding: 0.3em 0.8em !important;
+	font-size: 0.85em !important;
+}
+
+.hh4x-modal-body {
+	padding: 1em;
+}
+
+.hh4x-modal-meta {
+	margin-bottom: 1em;
+	padding-bottom: 0.8em;
+	border-bottom: 1px solid var(--border-color-low);
+}
+
+.hh4x-modal-info {
+	display: flex;
+	gap: 0.3em;
+	margin-bottom: 0.3em;
+	font-size: 0.9em;
+}
+
+.hh4x-modal-label {
+	color: var(--text-color-medium);
+	font-weight: 500;
+}
+
+.hh4x-modal-value {
+	color: var(--text-color-high);
+}
+
+.hh4x-modal-content {
+	font-size: 0.95em;
+	line-height: 1.6;
+	color: var(--text-color-high);
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.hh4x-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5em;
+	margin-top: 1em;
+	padding-top: 0.8em;
+	border-top: 1px solid var(--border-color-low);
+}
+
+.hh4x-delete-btn {
+	padding: 0.4em 1em !important;
+	font-size: 0.88em !important;
+}
+
+@media (max-width: 600px) {
+	.hh4x-summary-grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+	.hh4x-call-row {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+	.hh4x-call-right {
+		width: 100%;
+		justify-content: space-between;
+	}
+	.hh4x-modal {
+		max-height: 90vh;
+		margin: 0.5em;
+	}
+}
+
+/* ---- Buttons ---- */
+.hh4x-card .cbi-button {
+	border-radius: 4px;
+	font-weight: 500;
+	padding: 0.45em 1.2em;
+	transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.hh4x-card .cbi-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+/* ---- Tables inside cards ---- */
+.hh4x-card .table {
+	margin: 0;
+	width: 100%;
+}
+
+.hh4x-card .tr {
+	border-bottom: 1px solid var(--border-color-low);
+}
+
+/* ---- Responsive tweaks ---- */
+@media (max-width: 600px) {
+	.hh4x-row-2col > .cbi-section {
+		min-width: 100%;
+	}
+
+	.hh4x-info-row {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.15em;
+	}
+
+	.hh4x-info-label,
+	.hh4x-info-value {
+		flex: auto;
+		max-width: 100%;
+		text-align: left;
+	}
+
+	.hh4x-signal-row {
+		flex-wrap: wrap;
+	}
+}
+
+/* ---- CBI section overrides for smooth integration ---- */
+.hh4x-card.cbi-section {
+	margin-bottom: 0;
+}
+
+.hh4x-card .cbi-section-node {
+	border: none;
+	padding: 0;
+	margin: 0;
+	background: none;
+}
+
+.hh4x-card .cbi-value {
+	border: none;
+	padding: 0;
+	margin: 0;
+	background: none;
+}
+
+/* ---- SMS Tabs ---- */
+.hh4x-sms-tabs {
+	display: flex;
+	gap: 0.3em;
+	margin-bottom: 0.8em;
+}
+
+.hh4x-sms-tab {
+	padding: 0.4em 1em;
+	font-size: 0.9em;
+	cursor: pointer;
+}
+
+.hh4x-sms-tab-active {
+	font-weight: 600;
+}

--- a/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/sms.js
+++ b/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/sms.js
@@ -1,0 +1,390 @@
+/*
+ * sms.js - SMS inbox/sent viewer + compose for HH4xModem
+ * Copyright (C) 2026 HH4xModem
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+'use strict';
+'require rpc';
+'require view';
+'require ui';
+
+if (!document.querySelector('link[href*="hh4xmodem.css"]')) {
+	document.querySelector('head').appendChild(E('link', {
+		'rel': 'stylesheet',
+		'type': 'text/css',
+		'href': L.resource('view/hh4xmodem/hh4xmodem.css') + '?_=' + Date.now()
+	}));
+}
+
+const callSMSData = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'get_sms_list',
+	params: { key: 'inbox', page: 1 }
+});
+
+const callSendSMS = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'send_sms',
+	params: { phone: '', content: '' },
+	reject: true
+});
+
+const callSingleSMS = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'get_single_sms',
+	params: { id: null }
+});
+
+const callDeleteSMS = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'delete_sms',
+	params: { id: null },
+	reject: true
+});
+
+const callDeleteSMSBulk = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'delete_sms_bulk',
+	params: { ids: [] },
+	reject: true
+});
+
+function formatDate(dateStr) {
+	if (!dateStr) return '--';
+	return dateStr;
+}
+
+function truncate(str, len) {
+	if (!str) return '';
+	if (str.length <= len) return str;
+	return str.substring(0, len) + '...';
+}
+
+function createCard(title, content) {
+	return E('div', { 'class': 'cbi-section hh4x-card' }, [
+		E('div', { 'class': 'hh4x-card-header' }, [
+			E('h3', { 'class': 'hh4x-card-title' }, [title])
+		]),
+		E('div', { 'class': 'hh4x-card-body' }, content)
+	]);
+}
+
+function createInfoRow(label, value) {
+	return E('div', { 'class': 'hh4x-info-row' }, [
+		E('span', { 'class': 'hh4x-info-label' }, [label]),
+		E('span', { 'class': 'hh4x-info-value' }, [value != null ? String(value) : '--'])
+	]);
+}
+
+function createModalOverlay() {
+	let overlay = E('div', { 'class': 'hh4x-modal-overlay', 'style': 'display:none;' });
+	let modal = E('div', { 'class': 'hh4x-modal' }, [
+		E('div', { 'class': 'hh4x-modal-header' }, [
+			E('span', { 'class': 'hh4x-modal-title' }),
+			E('button', {
+				'class': 'hh4x-modal-close cbi-button',
+				'click': function () { overlay.style.display = 'none'; }
+			}, [_('Close')])
+		]),
+		E('div', { 'class': 'hh4x-modal-body' })
+	]);
+	overlay.appendChild(modal);
+	overlay.addEventListener('click', function (e) {
+		if (e.target === overlay) overlay.style.display = 'none';
+	});
+	return overlay;
+}
+
+let currentView = null;
+
+function reloadSMSList() {
+	if (currentView) {
+		currentView.load().then(function (newData) {
+			let newBody = currentView.render(newData);
+			let container = document.querySelector('.hh4x-page');
+			if (container && container.parentNode) {
+				container.parentNode.replaceChild(newBody, container);
+			}
+		}).catch(function (err) {
+			ui.addNotification(null, E('p', [_('Error loading SMS list: ') + String(err)]), 'error');
+		});
+	}
+}
+
+function showSMSModal(sms) {
+	let overlay = document.getElementById('hh4x-sms-modal');
+	if (!overlay) {
+		overlay = createModalOverlay();
+		overlay.id = 'hh4x-sms-modal';
+		document.body.appendChild(overlay);
+	}
+
+	let sender = Array.isArray(sms.PhoneNumber) ? sms.PhoneNumber[0] : (sms.PhoneNumber || '--');
+	let content = sms.SMSContent || _('(No content)');
+
+	overlay.querySelector('.hh4x-modal-title').textContent = sender;
+	overlay.querySelector('.hh4x-modal-body').innerHTML = '';
+
+	let body = overlay.querySelector('.hh4x-modal-body');
+	body.appendChild(E('div', { 'class': 'hh4x-modal-meta' }, [
+		E('div', { 'class': 'hh4x-modal-info' }, [
+			E('span', { 'class': 'hh4x-modal-label' }, [_('Number: ')]),
+			E('span', { 'class': 'hh4x-modal-value' }, [sender])
+		]),
+		E('div', { 'class': 'hh4x-modal-info' }, [
+			E('span', { 'class': 'hh4x-modal-label' }, [_('Date: ')]),
+			E('span', { 'class': 'hh4x-modal-value' }, [formatDate(sms.SMSTime)])
+		]),
+		E('div', { 'class': 'hh4x-modal-info' }, [
+			E('span', { 'class': 'hh4x-modal-label' }, [_('ID: ')]),
+			E('span', { 'class': 'hh4x-modal-value' }, [String(sms.SMSId)])
+		])
+	]));
+	body.appendChild(E('div', { 'class': 'hh4x-modal-content' }, [content]));
+
+	let deleteBtn = E('button', {
+		'class': 'cbi-button cbi-button-negative hh4x-delete-btn',
+		'click': function (e) {
+			e.stopPropagation();
+			if (!confirm(_('Delete this message?'))) return;
+			deleteBtn.disabled = true;
+			deleteBtn.textContent = _('Deleting...');
+			callDeleteSMS({ id: sms.SMSId }).then(function (result) {
+				if (result && typeof result === 'object' && result.error == null) {
+					overlay.style.display = 'none';
+					reloadSMSList();
+				} else {
+					ui.addNotification(null, E('p', [_('Delete failed: ') + (result?.error || _('Unknown error'))]), 'error');
+					deleteBtn.disabled = false;
+					deleteBtn.textContent = _('Delete');
+				}
+			}).catch(function (err) {
+				ui.addNotification(null, E('p', [_('Error: ') + String(err)]), 'error');
+				deleteBtn.disabled = false;
+				deleteBtn.textContent = _('Delete');
+			});
+		}
+	}, [_('Delete')]);
+
+	body.appendChild(E('div', { 'class': 'hh4x-modal-actions' }, [
+		deleteBtn
+	]));
+
+	overlay.style.display = 'flex';
+}
+
+function showComposeModal() {
+	let overlay = document.getElementById('hh4x-compose-modal');
+	if (!overlay) {
+		overlay = createModalOverlay();
+		overlay.id = 'hh4x-compose-modal';
+		document.body.appendChild(overlay);
+	}
+
+	overlay.querySelector('.hh4x-modal-title').textContent = _('Compose SMS');
+	overlay.querySelector('.hh4x-modal-body').innerHTML = '';
+
+	let body = overlay.querySelector('.hh4x-modal-body');
+	let phoneInput = E('input', {
+		'type': 'text',
+		'class': 'cbi-input-text',
+		'placeholder': _('Phone number'),
+		'style': 'width:100%;box-sizing:border-box;margin-bottom:8px;',
+		'id': 'compose-phone'
+	});
+	let msgInput = E('textarea', {
+		'class': 'cbi-input-text',
+		'placeholder': _('Message'),
+		'style': 'width:100%;box-sizing:border-box;min-height:100px;resize:vertical;margin-bottom:8px;',
+		'id': 'compose-msg'
+	});
+	let sendBtn = E('button', {
+		'class': 'cbi-button cbi-button-action',
+		'id': 'compose-send-btn',
+		'style': 'width:100%;',
+		'click': function () {
+			let phone = document.getElementById('compose-phone').value.trim();
+			let msg = document.getElementById('compose-msg').value.trim();
+			if (!phone) { ui.addNotification(null, E('p', [_('Enter a phone number.')]), 'info'); return; }
+			if (!msg) { ui.addNotification(null, E('p', [_('Enter a message.')]), 'info'); return; }
+			sendBtn.disabled = true;
+			sendBtn.textContent = _('Sending...');
+			callSendSMS({ phone: phone, content: msg }).then(function (result) {
+				if (result && typeof result === 'object' && result.error == null) {
+					overlay.style.display = 'none';
+					reloadSMSList();
+				} else {
+					ui.addNotification(null, E('p', [_('Send failed: ') + (result?.error || _('Unknown error'))]), 'error');
+					sendBtn.disabled = false;
+					sendBtn.textContent = _('Send');
+				}
+			}).catch(function (err) {
+				ui.addNotification(null, E('p', [_('Send error: ') + String(err)]), 'error');
+				sendBtn.disabled = false;
+				sendBtn.textContent = _('Send');
+			});
+		}
+	}, [_('Send')]);
+
+	body.appendChild(phoneInput);
+	body.appendChild(msgInput);
+	body.appendChild(sendBtn);
+
+	overlay.style.display = 'flex';
+	document.getElementById('compose-phone').focus();
+}
+
+let smsViewState = { key: 'inbox', page: 1 };
+
+let smsTabs = [
+	{ key: 'inbox', label: _('Inbox') },
+	{ key: 'send', label: _('Sent') }
+];
+
+return view.extend({
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null,
+
+	load: function () {
+		return callSMSData({ key: smsViewState.key, page: smsViewState.page });
+	},
+
+	render: function (data) {
+		currentView = this;
+		let smsResult = data || {};
+		let smsList = smsResult.SMSList || [];
+		let totalPages = smsResult.TotalPageCount || 1;
+
+		let currentKey = smsViewState.key;
+		let currentTab = smsTabs.find(function (t) { return t.key === currentKey; }) || smsTabs[0];
+		let tabTitle = currentTab ? currentTab.label : _('SMS');
+
+		let tabBar = E('div', { 'class': 'hh4x-sms-tabs' },
+			smsTabs.map(function (t) {
+				return E('button', {
+					'class': 'hh4x-sms-tab cbi-button' + (t.key === currentKey ? ' hh4x-sms-tab-active cbi-button-action' : ' cbi-button-neutral'),
+					'click': function () {
+						if (smsViewState.key !== t.key) {
+							smsViewState.key = t.key;
+							smsViewState.page = 1;
+							reloadSMSList();
+						}
+					}
+				}, [t.label]);
+			})
+		);
+
+		let body = E('div', { 'class': 'hh4x-page' }, [
+			E('div', { 'class': 'hh4x-page-header' }, [
+				tabBar,
+				E('h2', { 'class': 'hh4x-page-title' }, [_('SMS - ' + tabTitle)]),
+				E('p', { 'class': 'hh4x-page-desc' }, [
+					currentKey === 'inbox' ? _('View received SMS messages.') : _('View sent SMS messages.')
+				]),
+			])
+		]);
+
+		let composeBtn = E('button', {
+			'class': 'cbi-button cbi-button-action',
+			'style': 'margin-bottom:16px;',
+			'click': function () { showComposeModal(); }
+		}, [_('Compose')]);
+		body.appendChild(composeBtn);
+
+		let toolbar = E('div', { 'class': 'hh4x-sms-toolbar' }, [
+			E('label', { 'class': 'hh4x-sms-toolbar-label' }, [
+				E('input', {
+					'type': 'checkbox',
+					'id': 'select-all-check',
+					'change': function (e) {
+						let cbs = document.querySelectorAll('.hh4x-sms-check');
+						for (let j = 0; j < cbs.length; j++) cbs[j].checked = e.target.checked;
+					}
+				}),
+				_(' Select All')
+			]),
+			E('button', {
+				'class': 'cbi-button cbi-button-negative',
+				'id': 'delete-selected-btn',
+				'click': function (e) {
+					e.stopPropagation();
+					let checked = [];
+					let cbs = document.querySelectorAll('.hh4x-sms-check:checked');
+					for (let j = 0; j < cbs.length; j++) checked.push(parseInt(cbs[j].value));
+					if (checked.length === 0) { ui.addNotification(null, E('p', [_('No messages selected.')]), 'info'); return; }
+					if (!confirm(_('Delete ' + checked.length + ' selected message(s)?'))) return;
+					let btn = document.getElementById('delete-selected-btn');
+					btn.disabled = true;
+					btn.textContent = _('Deleting...');
+					callDeleteSMSBulk({ ids: checked }).then(function (result) {
+						if (result && typeof result === 'object' && result.error == null) {
+							reloadSMSList();
+						} else {
+							ui.addNotification(null, E('p', [_('Delete failed: ') + (result?.error || _('Unknown error'))]), 'error');
+							btn.disabled = false;
+							btn.textContent = _('Delete Selected');
+						}
+					}).catch(function (err) {
+						ui.addNotification(null, E('p', [_('Delete error: ') + String(err)]), 'error');
+						btn.disabled = false;
+						btn.textContent = _('Delete Selected');
+					});
+				}
+			}, [_('Delete Selected')])
+		]);
+
+		if (smsList.length === 0) {
+			body.appendChild(createCard(_('Messages'), [
+				E('p', { 'style': 'text-align:center;color:var(--text-color-medium);padding:2em 0;' }, [_('No messages in ' + smsViewState.key + '.')])
+			]));
+		} else {
+			let rows = [];
+
+			for (let i = 0; i < smsList.length; i++) {
+				let sms = smsList[i];
+				let sender = Array.isArray(sms.PhoneNumber) ? sms.PhoneNumber[0] : (sms.PhoneNumber || '--');
+				let content = sms.SMSContent || '';
+
+				let checkCell = E('div', { 'class': 'hh4x-sms-check-cell' }, [
+					E('input', {
+						'type': 'checkbox',
+						'class': 'hh4x-sms-check',
+						'value': sms.SMSId,
+						'click': function (e) { e.stopPropagation(); }
+					})
+				]);
+
+				let row = E('div', { 'class': 'hh4x-sms-row' }, [
+					checkCell,
+					E('div', { 'class': 'hh4x-sms-body' }, [
+						E('div', { 'class': 'hh4x-sms-header' }, [
+							E('span', { 'class': 'hh4x-sms-sender' }, [sender]),
+							E('span', { 'class': 'hh4x-sms-date' }, [formatDate(sms.SMSTime)])
+						]),
+						E('div', { 'class': 'hh4x-sms-preview' }, [truncate(content, 100)]),
+						E('div', { 'class': 'hh4x-sms-id' }, [
+							E('span', {}, ['ID: ' + sms.SMSId])
+						])
+					])
+				]);
+
+				row.addEventListener('click', (function(smsData) {
+					return function (e) {
+						if (e.target.type !== 'checkbox') showSMSModal(smsData);
+					};
+				})(sms));
+
+				rows.push(row);
+			}
+
+			body.appendChild(createCard(_('Messages (' + smsList.length + ')'), [
+				toolbar,
+				E('div', { 'class': 'hh4x-sms-list' }, rows)
+			]));
+		}
+
+		return body;
+	}
+});

--- a/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/ussd.js
+++ b/applications/luci-app-hh4xmodem/htdocs/luci-static/resources/view/hh4xmodem/ussd.js
@@ -1,0 +1,161 @@
+/*
+ * ussd.js - USSD code sender for HH4xModem
+ * Copyright (C) 2026 HH4xModem
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+'require rpc';
+'require ui';
+'require view';
+
+const callSendUssd = rpc.declare({
+	object: 'hh4xmodem',
+	method: 'send_ussd',
+	params: { code: '' },
+	reject: true
+});
+
+return view.extend({
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null,
+
+	load: function() {
+		return L.resolveDefault(null);
+	},
+
+	render: function() {
+		return E('div', { 'class': 'cbi-map' }, [
+			E('h2', {}, [_('USSD Codes')]),
+			E('div', { 'class': 'cbi-map-descr' }, [
+				_('Send USSD codes to your network operator (e.g., balance check, data plans).')
+			]),
+			E('hr'),
+			E('div', { 'class': 'cbi-section' }, [
+				E('div', { 'class': 'cbi-section-node' }, [
+					E('div', { 'class': 'cbi-value' }, [
+						E('label', { 'class': 'cbi-value-title' }, [_('USSD Code')]),
+						E('div', { 'class': 'cbi-value-field' }, [
+							E('input', {
+								'type': 'text',
+								'id': 'ussd-code',
+								'class': 'cbi-input-text',
+								'style': 'width: 100%; direction: ltr; font-family: monospace; font-size: 1.1em;',
+								'placeholder': '*100#',
+								'autofocus': null,
+								'keydown': function(ev) {
+									if (ev.keyCode === 13) {
+										var btn = document.getElementById('ussd-send');
+										if (btn) btn.click();
+									}
+								}
+							})
+						])
+					]),
+					E('div', { 'class': 'cbi-value' }, [
+						E('label', { 'class': 'cbi-value-title' }, [_('Keypad')]),
+						E('div', { 'class': 'cbi-value-field', 'style': 'display: flex; flex-wrap: wrap; gap: 4px;' },
+							['1','2','3','4','5','6','7','8','9','*','0','#'].map(function(ch) {
+								return E('button', {
+									'class': 'btn cbi-button',
+									'style': 'min-width: 2.8em; font-size: 1.2em; text-align: center;',
+									'click': function() {
+										var inp = document.getElementById('ussd-code');
+										if (inp) {
+											var start = inp.selectionStart || inp.value.length;
+											inp.value = inp.value.slice(0, start) + ch + inp.value.slice(inp.selectionEnd || start);
+											inp.focus();
+											inp.selectionStart = inp.selectionEnd = start + 1;
+										}
+									}
+								}, [ch]);
+							})
+						)
+					]),
+					E('div', { 'class': 'cbi-value' }, [
+						E('label', { 'class': 'cbi-value-title' }, ['']),
+						E('div', { 'class': 'cbi-value-field' }, [
+							E('button', {
+								'id': 'ussd-send',
+								'class': 'cbi-button cbi-button-action important',
+								'click': function(ev) {
+									ev.preventDefault();
+									var code = document.getElementById('ussd-code');
+									if (!code || !code.value.trim()) {
+										ui.addNotification(null, E('p', [_('Please enter a USSD code.')]), 'info');
+										return;
+									}
+									sendUssdCode(code.value.trim());
+								}
+							}, [_('Send')]),
+							' ',
+							E('button', {
+								'class': 'cbi-button cbi-button-neutral',
+								'click': function() {
+									clearUssd();
+								}
+							}, [_('Clear')])
+						])
+					])
+				])
+			]),
+			E('div', { 'id': 'ussd-output', 'class': 'ussd-output', 'style': 'display:none;' })
+		]);
+	}
+});
+
+function setButtonsEnabled(enabled) {
+	var send = document.getElementById('ussd-send');
+	var code = document.getElementById('ussd-code');
+	if (send) send.disabled = !enabled;
+	if (code) code.disabled = !enabled;
+}
+
+function showOutput(msg) {
+	var out = document.getElementById('ussd-output');
+	if (!out) return;
+	out.style.display = 'block';
+	out.textContent = msg;
+}
+
+function clearUssd() {
+	var code = document.getElementById('ussd-code');
+	var out = document.getElementById('ussd-output');
+	if (code) code.value = '';
+	if (out) { out.style.display = 'none'; out.textContent = ''; }
+	if (code) code.focus();
+}
+
+function sendUssdCode(code) {
+	showOutput(_('Sending...'));
+	setButtonsEnabled(false);
+
+	callSendUssd({ code: code }).then(function(r) {
+		if (!r) { showOutput(_('No response from modem.')); return; }
+		if (r.error == null && r.text) {
+			showOutput(r.text);
+		} else if (r.error) {
+			showOutput(r.error);
+		} else {
+			showOutput(_('No response from modem.'));
+		}
+	}).catch(function(err) {
+		showOutput(_('Error: ') + String(err));
+	}).finally(function() {
+		setButtonsEnabled(true);
+		var send = document.getElementById('ussd-send');
+		if (send) send.textContent = _('Send');
+	});
+}

--- a/applications/luci-app-hh4xmodem/root/etc/uci-defaults/80_hh4xmodem
+++ b/applications/luci-app-hh4xmodem/root/etc/uci-defaults/80_hh4xmodem
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# UCI defaults for luci-app-hh4xmodem
+#
+
+# Create config file with default settings
+touch /etc/config/hh4xmodem
+
+# Set default modem IP and port
+uci set hh4xmodem.settings=settings
+uci set hh4xmodem.settings.modem_ip='192.168.225.1'
+uci set hh4xmodem.settings.modem_port='2016'
+uci set hh4xmodem.settings.refresh_interval='3'
+uci commit hh4xmodem
+
+# Restart rpcd to load ucode plugin
+if pidof rpcd >/dev/null 2>&1; then
+	/etc/init.d/rpcd reload 2>/dev/null || /etc/init.d/rpcd restart 2>/dev/null
+fi
+
+exit 0

--- a/applications/luci-app-hh4xmodem/root/usr/bin/hh4xmodem-get-all
+++ b/applications/luci-app-hh4xmodem/root/usr/bin/hh4xmodem-get-all
@@ -1,0 +1,81 @@
+#!/bin/sh
+# hh4xmodem-get-all - Run pack methods in parallel batches and combine results
+# Usage:
+#   hh4xmodem-get-all              - core methods (Status page, 1 batch, ~4s)
+#   hh4xmodem-get-all full         - all methods (About+Network, 2-3 batches)
+
+core_methods="GetNetworkInfo GetSystemInfo GetSystemStatus GetConnectionState GetSimStatus GetUsageRecord"
+batch2="GetAutoValidatePinState GetSMSSettings GetSMSStorageState GetLanSettings GetUpnpSettings GetCurrentLanguage"
+batch3="GetNetworkSettings GetNetworkRegisterState GetConnectionSettings GetProfileList getCurrentProfile"
+
+if [ "${1:-}" = "full" ]; then
+    all_methods="$core_methods $batch2 $batch3"
+else
+    all_methods="$core_methods"
+fi
+
+TMPDIR=$(mktemp -d /tmp/hh4xall.XXXXXX 2>/dev/null)
+trap "rm -rf \"$TMPDIR\"" EXIT
+
+run_batch() {
+    for method in "$@"; do
+        (
+            /usr/bin/hh4xmodem-pack "$method" > "$TMPDIR/$method.raw" 2>/dev/null
+        ) &
+    done
+    wait
+}
+
+if [ "${1:-}" = "full" ]; then
+    run_batch $core_methods
+    run_batch $batch2
+    run_batch $batch3
+else
+    run_batch $core_methods
+fi
+
+# Clean each response: extract only the JSON object
+for method in $all_methods; do
+    if [ -f "$TMPDIR/$method.raw" ]; then
+        CLEAN=$(awk '
+        {
+            line = $0
+            start = index(line, "{")
+            if (start > 0) {
+                rest = substr(line, start)
+                depth = 0
+                result = ""
+                for (i = 1; i <= length(rest); i++) {
+                    c = substr(rest, i, 1)
+                    if (c == "{") depth++
+                    if (c == "}") {
+                        depth--
+                        if (depth == 0) {
+                            result = result c
+                            break
+                        }
+                    }
+                    result = result c
+                }
+                if (depth == 0 && length(result) > 0) {
+                    print result
+                }
+            }
+        }' "$TMPDIR/$method.raw" 2>/dev/null)
+        echo "$CLEAN" > "$TMPDIR/$method.json"
+    fi
+done
+
+echo '{'
+first=true
+for method in $all_methods; do
+    if [ -f "$TMPDIR/$method.json" ] && [ -s "$TMPDIR/$method.json" ]; then
+        content=$(cat "$TMPDIR/$method.json" | tr -d '\n\r')
+        if [ -n "$content" ]; then
+            if $first; then first=false; else echo ','; fi
+            printf '"%s": %s' "$method" "$content"
+        fi
+    fi
+done
+echo ''
+echo '}'

--- a/applications/luci-app-hh4xmodem/root/usr/bin/hh4xmodem-pack
+++ b/applications/luci-app-hh4xmodem/root/usr/bin/hh4xmodem-pack
@@ -1,0 +1,109 @@
+#!/usr/bin/ucode
+// hh4xmodem-pack - Pack protocol client for HH40V/HH41V MDM9207 modem
+// Usage: hh4xmodem-pack <method> [params]
+// Example: hh4xmodem-pack GetNetworkInfo "{}"
+// Example: hh4xmodem-pack SetNetworkSettings '{"NetworkMode":6}'
+
+import * as socket from 'socket';
+
+let modem_ip = getenv("MODEM_IP") || "192.168.225.1";
+let modem_port = int(getenv("MODEM_PORT")) || 2016;
+
+if (length(ARGV) < 1) {
+    printf("Usage: %s <method> [params]\n", ARGV[0] || "hh4xmodem-pack");
+    exit(1);
+}
+
+let method = ARGV[0];
+let params = length(ARGV) >= 2 ? ARGV[1] : "{}";
+
+// Pack protocol header layout:
+//   "pack" magic (4 bytes) + total_length (4 bytes big-endian) +
+//   reserved (4 bytes) + padding (32 bytes) = 44-byte pack header
+//   + 28-byte legacy ack prefix = 72 bytes before the JSON payload.
+const ACK_PREFIX_LEN  = 28;  // legacy ack prefix sent by the modem
+const PACK_HEADER_LEN = 44;  // "pack" magic + length + reserved + padding
+const PAYLOAD_START   = ACK_PREFIX_LEN + PACK_HEADER_LEN;
+
+let json = sprintf('{"jsonrpc":"2.0","method":"%s","params":%s,"id":"1.1"}', method, params);
+let json_len = length(json);
+let total_len = PACK_HEADER_LEN + json_len;
+
+// Build pack header (44 bytes) + JSON payload
+let request = "pack";
+request += sprintf("%c%c%c%c",
+    total_len >> 24 & 0xFF, total_len >> 16 & 0xFF,
+    total_len >> 8 & 0xFF, total_len & 0xFF);
+request += sprintf("%c%c%c%c", 0, 0, 0, 1);
+for (let i = 0; i < 32; i++) request += "\x00";
+request += json;
+
+// Connect to modem via TCP
+let addr = socket.sockaddr({
+    family: socket.AF_INET,
+    address: modem_ip,
+    port: modem_port
+});
+
+let sock = socket.create(socket.AF_INET, socket.SOCK_STREAM);
+if (!sock) {
+    printf('{"error":"Failed to create socket"}');
+    exit(2);
+}
+
+if (!sock.connect(addr)) {
+    printf('{"error":"Failed to connect to %s:%d"}', modem_ip, modem_port);
+    exit(2);
+}
+
+sock.send(request);
+
+// Read response. The modem first sends a 28-byte prefix ("ack"), then the
+// actual JSON payload may arrive a moment later (or the modem is briefly busy
+// processing a SET). Bound each recv with a timeout so we never block rpcd
+// indefinitely, and loop until we have a complete JSON object (balanced
+// braces) or the budget runs out.
+sock.setopt(socket.SOL_SOCKET, socket.SO_RCVTIMEO, [1, 0]);
+let response = '';
+let complete = false;
+let payload_start = PAYLOAD_START;
+for (let i = 0; i < 8 && !complete; i++) {
+    let chunk = "";
+    try { chunk = sock.recv(65536) || ""; } catch (e) { chunk = ""; }
+    response += chunk;
+    if (length(response) >= payload_start) {
+        // Scan the JSON payload (past the known binary header) for a
+        // balanced object. Track string context so braces inside string
+        // values (e.g. an SMS body "hi {") are ignored, and start after
+        // the header so a stray 0x7b byte in the ack prefix can't shift
+        // the match offset.
+        let start = index(substr(response, payload_start), '{');
+        if (start >= 0) {
+            start += payload_start;
+            let depth = 0, in_str = false, esc = false, end = -1;
+            for (let j = start; j < length(response); j++) {
+                let c = substr(response, j, 1);
+                if (in_str) {
+                    if (esc) esc = false;
+                    else if (c == '\\') esc = true;
+                    else if (c == '"') in_str = false;
+                    continue;
+                }
+                if (c == '"') in_str = true;
+                else if (c == '{') depth++;
+                else if (c == '}') { depth--; if (depth == 0) { end = j; break; } }
+            }
+            if (end >= 0) complete = true;
+        }
+    }
+    if (!complete && length(chunk) == 0) sleep(200);
+}
+sock.close();
+
+if (!complete || length(response) <= payload_start) {
+    printf('{"error":"No response or too short (%d bytes)"}', length(response));
+    exit(2);
+}
+
+// Skip ACK_PREFIX_LEN + PACK_HEADER_LEN bytes to reach the JSON payload
+printf("%s", substr(response, payload_start));

--- a/applications/luci-app-hh4xmodem/root/usr/share/luci/menu.d/luci-app-hh4xmodem.json
+++ b/applications/luci-app-hh4xmodem/root/usr/share/luci/menu.d/luci-app-hh4xmodem.json
@@ -1,0 +1,48 @@
+{
+	"admin/hh4xmodem/": {
+		"title": "Modem",
+		"order": 60,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-hh4xmodem" ]
+		}
+	},
+
+	"admin/hh4xmodem/dashboard": {
+		"title": "Dashboard",
+		"order": 1,
+		"action": {
+			"type": "view",
+			"path": "hh4xmodem/dashboard"
+		}
+	},
+
+	"admin/hh4xmodem/sms": {
+		"title": "SMS",
+		"order": 2,
+		"action": {
+			"type": "view",
+			"path": "hh4xmodem/sms"
+		}
+	},
+
+	"admin/hh4xmodem/calllog": {
+		"title": "Call Log",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "hh4xmodem/calllog"
+		}
+	},
+
+	"admin/hh4xmodem/ussd": {
+		"title": "USSD",
+		"order": 4,
+		"action": {
+			"type": "view",
+			"path": "hh4xmodem/ussd"
+		}
+	}
+}

--- a/applications/luci-app-hh4xmodem/root/usr/share/rpcd/acl.d/luci-app-hh4xmodem.json
+++ b/applications/luci-app-hh4xmodem/root/usr/share/rpcd/acl.d/luci-app-hh4xmodem.json
@@ -1,0 +1,73 @@
+{
+	"luci-app-hh4xmodem": {
+		"description": "Grant access to HH40V/HH41V modem management RPC methods",
+		"read": {
+			"ubus": {
+				"hh4xmodem": [
+					"get_system_info",
+					"get_status",
+					"get_signal",
+					"get_network_settings",
+					"get_usage",
+					"get_usage_settings",
+					"get_connection_state",
+					"get_sim_status",
+					"get_sms_storage",
+					"get_sms_settings",
+					"get_lan_settings",
+					"get_upnp",
+					"get_language",
+					"get_connection_settings",
+					"get_registration_state",
+					"get_profile_list",
+					"get_current_profile",
+					"get_pin_state",
+					"get_sms_data",
+					"get_sms_list",
+					"get_single_sms",
+					"get_send_sms_result",
+					"get_calllog_data",
+					"get_call_log_list",
+					"get_call_log_count",
+					"get_dashboard",
+					"get_all",
+					"get_all_full"
+				]
+			},
+			"uci": [
+				"hh4xmodem"
+			]
+		},
+		"write": {
+			"ubus": {
+				"hh4xmodem": [
+					"set_network_mode",
+					"send_connect",
+					"disconnect_modem",
+					"unlock_sim",
+					"unlock_pin",
+					"unlock_puk",
+					"change_pin",
+					"change_pin_state",
+					"clear_usage",
+					"clear_call_log",
+					"send_ussd",
+					"ussd_end_session",
+					"set_usage_settings",
+					"send_sms",
+					"delete_sms",
+					"delete_sms_bulk",
+					"reboot_modem",
+					"reset_modem",
+					"set_connection_settings",
+					"edit_profile",
+					"delete_profile",
+					"set_default_profile"
+				]
+			},
+			"uci": [
+				"hh4xmodem"
+			]
+		}
+	}
+}

--- a/applications/luci-app-hh4xmodem/root/usr/share/rpcd/ucode/hh4xmodem.uc
+++ b/applications/luci-app-hh4xmodem/root/usr/share/rpcd/ucode/hh4xmodem.uc
@@ -1,0 +1,485 @@
+#!/usr/bin/ucode
+'use strict';
+import { popen } from 'fs';
+import * as uci from 'uci';
+
+function shellquote(value) {
+	if (value == null) value = '';
+	return "'" + replace(value, "'", "'\\''") + "'";
+}
+
+const PACK_HELPER = '/usr/bin/hh4xmodem-pack';
+
+function get_modem_env() {
+	let ctx = uci.cursor();
+	let ip = ctx.get('hh4xmodem', 'settings', 'modem_ip') || '192.168.225.1';
+	let port = ctx.get('hh4xmodem', 'settings', 'modem_port') || '2016';
+	ctx.unload();
+	return sprintf('MODEM_IP=%s MODEM_PORT=%s', shellquote(ip), shellquote(port));
+}
+
+function pack_call(method, params) {
+	params = params || '{}';
+	let env = get_modem_env();
+	let cmd = sprintf('%s %s %s %s 2>/dev/null', env, PACK_HELPER, shellquote(method), shellquote(params));
+	let fd = popen(cmd);
+	if (!fd) return { error: 'Failed to execute pack helper', code: -1 };
+	let output = '';
+	let line;
+	while ((line = fd.read('line')) != null) output += line;
+	fd.close();
+	output = trim(output);
+	if (!length(output)) return { error: 'Empty response from modem', code: -1 };
+	let start = index(output, '{');
+	if (start < 0) return { error: 'No JSON object in response', raw: output, code: -1 };
+	let depth = 0;
+	let end = -1;
+	for (let i = start; i < length(output); i++) {
+		let c = substr(output, i, 1);
+		if (c == '{') depth++;
+		if (c == '}') {
+			depth--;
+			if (depth == 0) { end = i; break; }
+		}
+	}
+	if (end < 0) return { error: 'Unclosed JSON object', raw: output, code: -1 };
+	let clean = substr(output, start, end - start + 1);
+	let result = json(clean);
+	if (result == null) return { error: 'Failed to parse JSON', raw: clean, code: -1 };
+	return result;
+}
+
+function get_system_info() { return pack_call('GetSystemInfo'); }
+function get_status() { return pack_call('GetSystemStatus'); }
+function get_signal() { return pack_call('GetNetworkInfo'); }
+function get_network_settings() { return pack_call('GetNetworkSettings'); }
+function get_usage() { return pack_call('GetUsageRecord'); }
+function get_connection_state() { return pack_call('GetConnectionState'); }
+function get_sim_status() { return pack_call('GetSimStatus'); }
+function get_lan_settings() { return pack_call('GetLanSettings'); }
+function get_sms_storage() { return pack_call('GetSMSStorageState'); }
+function get_sms_settings() { return pack_call('GetSMSSettings'); }
+function get_upnp() { return pack_call('GetUpnpSettings'); }
+function get_language() { return pack_call('GetCurrentLanguage'); }
+function get_connection_settings() { return pack_call('GetConnectionSettings'); }
+function get_registration_state() { return pack_call('GetNetworkRegisterState'); }
+function get_profile_list() { return pack_call('GetProfileList'); }
+function get_current_profile() { return pack_call('getCurrentProfile'); }
+function get_pin_state() { return pack_call('GetAutoValidatePinState'); }
+function get_usage_settings() { return pack_call('GetUsageSettings'); }
+function reboot_modem() {
+	let r = pack_call('SetDeviceReboot');
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null, response: r };
+	if (type(r) == 'object' && length(r) == 0) return { error: null };
+	return r || { error: 'Reboot failed', code: -1 };
+}
+
+function send_connect() {
+	let r = pack_call('Connect');
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null, response: r };
+	if (type(r) == 'object' && length(r) == 0) return { error: null };
+	return r || { error: 'Connect failed', code: -1 };
+}
+
+function disconnect_modem() {
+	let r = pack_call('DisConnect');
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null, response: r };
+	if (type(r) == 'object' && length(r) == 0) return { error: null };
+	return r || { error: 'Disconnect failed', code: -1 };
+}
+
+// The modem reports success as {} or {error:0}; only a real (truthy,
+// non-zero) error is an actual failure.
+function pack_ok(r) {
+	return r != null && (r.error == null || r.error == 0 || r.error == '0' || length(r) == 0);
+}
+
+function unlock_pin(pin) {
+	if (pin == null) return { error: 'Missing PIN', code: -1 };
+	pin = trim(pin);
+	if (!length(pin)) return { error: 'Empty PIN', code: -1 };
+	let r = pack_call('UnlockPin', sprintf('{"PIN":%J}', pin));
+	if (pack_ok(r)) return { error: null };
+	return r || { error: 'Unlock failed', code: -1 };
+}
+
+function unlock_puk(puk, new_pin) {
+	if (puk == null || new_pin == null) return { error: 'Missing PUK or new PIN', code: -1 };
+	puk = trim(puk);
+	new_pin = trim(new_pin);
+	if (!length(puk) || !length(new_pin)) return { error: 'Empty PUK or PIN', code: -1 };
+	// Per the stock WebUI (build.js): UnlockPuk takes {"Pin":<new PIN>,"Puk":<PUK>}
+	// (CamelCase: Pin/Puk — NOT "PUK"/"NewPin"). A wrong PIN new value or a
+	// rejected PUK makes the modem return {} or an error; an empty/ignored
+	// response must NOT be reported as success.
+	let r = pack_call('UnlockPuk', sprintf('{"Pin":%J,"Puk":%J}', new_pin, puk));
+	if (!pack_ok(r)) return r || { error: 'Unlock failed', code: -1 };
+	// Verify the lock actually cleared: the modem may echo {} on a bad PUK
+	// (pack_ok would accept it). Re-query the SIM state to confirm.
+	let s = get_sim_status();
+	let st = (s && s.SIMState != null) ? s.SIMState : null;
+	// Success only if the SIM actually left the locked states. A wrong/exhausted
+	// PUK leaves it at 3 (PUK required), 4 (SIM lock) or 5 (PUK blocked); all must
+	// fail, since pack_ok() accepts the empty {} the modem echoes on a bad PUK.
+	// State 2 (PIN required) is expected right after a successful PUK unlock
+	// (the new PIN is prompted on next boot), and 7 means Ready.
+	if (st == 7 || st == 2) return { error: null };
+	return { error: 'PUK rejected, still locked, or blocked', code: -1 };
+}
+
+function change_pin(old_pin, new_pin) {
+	if (old_pin == null || new_pin == null) return { error: 'Missing old or new PIN', code: -1 };
+	old_pin = trim(old_pin);
+	new_pin = trim(new_pin);
+	if (!length(old_pin) || !length(new_pin)) return { error: 'Empty old or new PIN', code: -1 };
+	let r = pack_call('ChangePinCode', sprintf('{"CurrentPin":%J,"NewPin":%J}', old_pin, new_pin));
+	if (pack_ok(r)) return { error: null };
+	return r || { error: 'Change PIN failed', code: -1 };
+}
+
+function change_pin_state(pin, enable) {
+	if (pin == null) return { error: 'Missing PIN', code: -1 };
+	pin = trim(pin);
+	if (!length(pin)) return { error: 'Empty PIN', code: -1 };
+	// Per the stock WebUI: enabling PIN protection sends State:1 and
+	// disabling it sends State:0. The Pin must be the SIM's current PIN;
+	// a wrong PIN decrements PinRemainingTimes.
+	let state = enable ? 1 : 0;
+	let r = pack_call('ChangePinState', sprintf('{"Pin":%J,"State":%d}', pin, state));
+	if (pack_ok(r)) return { error: null };
+	return r || { error: enable ? 'Set PIN failed' : 'Disable PIN failed', code: -1 };
+}
+
+function clear_usage() {
+	let r = pack_call('SetUsageRecordClear');
+	if (r != null && r.error == null) return { error: null };
+	return r || { error: 'Clear failed', code: -1 };
+}
+
+function clear_call_log() {
+	let ids = '';
+	let page = 1, total_pages = 1;
+	while (page <= total_pages) {
+		let r = pack_call('GetCallLogList', sprintf('{"Page":%d,"ListType":0}', page));
+		if (r == null || r.error != null) break;
+		let list = r.CallLogList || [];
+		for (let c in list) {
+			if (c.Id != null) {
+				if (length(ids) > 0) ids += ',';
+				ids += int(c.Id);
+			}
+		}
+		total_pages = int(r.TotalPageCount || 1);
+		page++;
+	}
+
+	if (length(ids) == 0) return { error: null };
+
+	let r = pack_call('DeleteCallLog', sprintf('{"Id":[%s],"ListType":0}', ids));
+	if (r != null && r.error == null) return { error: null };
+	return r || { error: 'Clear failed', code: -1 };
+}
+
+
+function send_ussd(code) {
+	if (code == null) return { error: 'Missing USSD code', code: -1 };
+	code = trim(code);
+	if (!length(code)) return { error: 'Empty USSD code', code: -1 };
+	// end any lingering session so we start a fresh request
+	pack_call('SetUSSDEnd', '{}');
+	sleep(2000);
+	let r = pack_call('SendUSSD', sprintf('{"UssdType":0,"UssdContent":%J}', code));
+	if (r == null || r.error != null) return r || { error: 'Send failed', code: -1 };
+	let res;
+	let end_session = function() { pack_call('SetUSSDEnd', '{}'); };
+	// The modem caches the last USSD reply in g_ussd_data and only updates it
+	// when a *new* indication arrives. Right after SendUSSD, the first polls
+	// still return that stale cache with UssdType:0. A genuine result arrives
+	// only with UssdType 1 (DONE) or 2 (MORE), so we must skip UssdType:0.
+	let is_real = function(r) {
+		return r && r.error == null && (r.UssdType == 1 || r.UssdType == 2) && r.UssdContent;
+	};
+	for (let i = 0; i < 20; i++) {
+		if (i > 0) sleep(1000);
+		res = pack_call('GetUSSDSendResult');
+		if (is_real(res)) {
+			end_session();
+			return { error: null, text: res.UssdContent, more: res.UssdType == 2 };
+		}
+	}
+	if (is_real(res)) { end_session(); return { error: null, text: res.UssdContent, more: res.UssdType == 2 }; }
+	return { error: 'No USSD response from network', code: -1 };
+}
+
+function ussd_end_session() {
+	pack_call('SetUSSDEnd', '{}');
+	return { error: null };
+}
+
+function set_usage_settings(settings) {
+	if (settings == null) return { error: 'Missing settings', code: -1 };
+	let r = pack_call('SetUsageSettings', json(settings));
+	if (r != null && r.error == null) return { error: null };
+	return r || { error: 'Set failed', code: -1 };
+}
+
+function unlock_sim(code, lock_state) {
+	if (code == null) return { error: 'Missing unlock code', code: -1 };
+	code = trim(code);
+	if (!length(code)) return { error: 'Empty unlock code', code: -1 };
+	let r = pack_call('UnlockSimlock', sprintf('{"SIMLockCode":%J,"SIMLockState":%d}', code, int(lock_state || 0)));
+	if (pack_ok(r)) return { error: null };
+	// A structured error (has "message", e.g. a wrong NCK code) is a real
+	// failure — normalize it to { error: ... } so the JS caller's
+	// r.error == null test actually catches it.
+	if (type(r) == 'object' && r.message != null)
+		return { error: sprintf('SIM unlock failed: %s', r.message), code: r.code ?? -1 };
+	// pack_call-level error (connection dropped after sending the unlock).
+	// The modem reboots after accepting a valid unlock code, so a dropped
+	// connection here is expected on success — but we must not mask genuine
+	// connectivity failures (e.g. modem was never reachable). Return the
+	// actual error so the caller can show it; the UI reloads and re-checks
+	// SIM state to confirm whether the unlock took effect.
+	return r;
+}
+
+function set_network_mode(mode) {
+	if (mode == null) return { error: 'Missing mode', code: -1 };
+	mode = int(mode);
+	if (mode < 0 || mode > 6) return { error: 'Invalid mode', code: -1 };
+	let cur = pack_call('GetNetworkSettings') || {};
+	let params = sprintf('{"NetworkMode":%d,"NetselectionMode":%d,"NetworkBand":%d,"DomesticRoam":%d,"DomesticRoamGuard":%d}',
+		mode, cur.NetselectionMode ?? 0, cur.NetworkBand ?? 255, cur.DomesticRoam ?? 0, cur.DomesticRoamGuard ?? 0);
+	let r = pack_call('SetNetworkSettings', params);
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null, mode: mode, response: r };
+	if (type(r) == 'object' && length(r) == 0) return { error: null, mode: mode };
+	return r || { error: 'Set failed', code: -1 };
+}
+
+function get_sms_data(key, page) {
+	key = key || 'inbox';
+	page = page || 1;
+	let sms = pack_call('GetSMSListByContactNum', sprintf('{"Page":%d,"key":%J}', page, key)) || { SMSList: [] };
+	let storage = pack_call('GetSMSStorageState') || {};
+	return { GetSMSListByContactNum: sms, GetSMSStorageState: storage };
+}
+
+function get_sms_list(key, page) {
+	key = key || 'inbox';
+	page = page || 1;
+	return pack_call('GetSMSListByContactNum', sprintf('{"Page":%d,"key":%J}', page, key)) || { error: 'No result', SMSList: [] };
+}
+
+function get_single_sms(id) {
+	id = int(id || 0);
+	if (id < 1) return { error: 'Invalid SMS ID', code: -1 };
+	return pack_call('GetSingleSMS', sprintf('{"SMSId":%d}', id)) || { error: 'No result' };
+}
+
+function send_sms(phone, content) {
+	if (phone == null || content == null) return { error: 'Missing phone or content', code: -1 };
+	phone = trim(phone);
+	content = trim(content);
+	if (!length(phone) || !length(content)) return { error: 'Empty phone or content', code: -1 };
+	let r = pack_call('SendSMS', sprintf('{"PhoneNumber":%J,"SMSContent":%J,"SMSId":-1}',
+		phone, content));
+	if (r == null) return { error: 'Send SMS failed: no response', code: -1 };
+	if (type(r) == 'object' && r.message != null && r.code != null)
+		return { error: sprintf('Send SMS failed: %s (%s)', r.message, r.code), code: -1 };
+	return { error: null, response: r };
+}
+
+function delete_sms(id) {
+	id = int(id || 0);
+	if (id < 1) return { error: 'Invalid SMS ID', code: -1 };
+	let r = pack_call('DeleteSMS', sprintf('{"DelFlag":3,"SMSArray":[%d]}', id));
+	if (r != null && r.error == null) return { error: null };
+	return r || { error: "Delete failed", code: -1 };
+}
+
+function delete_sms_bulk(ids) {
+	if (type(ids) != 'array' || length(ids) == 0) return { error: 'No SMS IDs provided', code: -1 };
+	let arr = '';
+	for (let i = 0; i < length(ids); i++) {
+		let n = int(ids[i]);
+		if (n < 1) return { error: 'Invalid SMS ID', code: -1 };
+		if (length(arr) > 0) arr += ',';
+		arr += n;
+	}
+	let params = sprintf('{"DelFlag":3,"SMSArray":[%s]}', arr);
+	let r = pack_call('DeleteSMS', params);
+	if (r != null && r.error == null) return { error: null, count: length(ids) };
+	return r || { error: "Delete failed", code: -1 };
+}
+
+function get_send_sms_result() { return pack_call('GetSendSMSResult') || { error: 'No result' }; }
+
+function get_calllog_data(list_type, page) {
+	list_type = int(list_type || 0);
+	page = page || 1;
+	let logs = pack_call('GetCallLogList', sprintf('{"Page":%d,"ListType":%d}', page, list_type)) || { CallLogList: [] };
+	let counts = pack_call('GetCallLogCountInfo') || {};
+	return { GetCallLogList: logs, GetCallLogCountInfo: counts };
+}
+
+function get_call_log_list(list_type, page) {
+	list_type = int(list_type || 0);
+	page = page || 1;
+	return pack_call('GetCallLogList', sprintf('{"Page":%d,"ListType":%d}', page, list_type)) || { error: 'No result', CallLogList: [] };
+}
+
+function get_call_log_count() { return pack_call('GetCallLogCountInfo') || { error: 'No result' }; }
+
+function run_script(script) {
+	let env = get_modem_env();
+	let cmd = sprintf('%s %s 2>/dev/null', env, script);
+	let fd = popen(cmd);
+	if (!fd) return { error: 'Failed to execute helper', code: -1 };
+	let output = '';
+	let line;
+	while ((line = fd.read('line')) != null) output += line;
+	fd.close();
+	output = trim(output);
+	if (!length(output)) return { error: 'Empty response', code: -1 };
+	let data = json(output);
+	if (data == null) return { error: 'Failed to parse JSON', code: -1 };
+	let result = {};
+	for (let k, v in data) {
+		if (type(v) == 'object' && v.result != null)
+			result[k] = v.result;
+		else
+			result[k] = v;
+	}
+	return result;
+}
+
+function get_all() { return run_script('/usr/bin/hh4xmodem-get-all'); }
+function get_all_full() { return run_script('/usr/bin/hh4xmodem-get-all full'); }
+
+function get_dashboard() {
+	return {
+		device: get_system_info(),
+		status: get_status(),
+		signal: get_signal(),
+		connection: get_connection_state(),
+		network: get_network_settings(),
+		sim: get_sim_status(),
+		usage: get_usage(),
+		timestamp: time()
+	};
+}
+
+function reset_modem() {
+	let r = pack_call('SetDeviceReset');
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null, response: r };
+	if (type(r) == 'object' && length(r) == 0) return { error: null };
+	return r || { error: 'Reset failed', code: -1 };
+}
+
+function set_connection_settings(settings) {
+	if (settings == null) return { error: 'Missing settings', code: -1 };
+	if (type(settings) != 'object') return { error: 'Settings must be an object', code: -1 };
+	// Read current settings so we echo back ALL fields the modem expects.
+	// Bail out on failure: pack_call always returns an object, so a failed read
+	// would otherwise be overwritten with hardcoded defaults.
+	let cur = pack_call('GetConnectionSettings');
+	if (type(cur) != 'object' || cur.error != null)
+		return { error: 'Failed to read current connection settings', code: -1 };
+	for (let k, v in settings) cur[k] = v;
+	// Fallbacks match the UI preselects (0 = Manual / IPv4, 600 s idle).
+	let connectMode = int(cur.ConnectMode ?? 0);
+	let pdpType = int(cur.PdpType ?? 0);
+	let roamingConnect = int(cur.RoamingConnect ?? 1);
+	let idleTime = int(cur.IdleTime ?? 600);
+	let params = sprintf('{"ConnectMode":%d,"PdpType":%d,"RoamingConnect":%d,"IdleTime":%d}',
+		connectMode, pdpType, roamingConnect, idleTime);
+	let r = pack_call('SetConnectionSettings', params);
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null, response: r };
+	if (type(r) == 'object' && length(r) == 0) return { error: null };
+	return r || { error: 'Set failed', code: -1 };
+}
+
+function edit_profile(profile) {
+	if (profile == null) return { error: 'Missing profile', code: -1 };
+	if (type(profile) != 'object') return { error: 'Profile must be an object', code: -1 };
+	let method = profile.ProfileID ? 'EditProfile' : 'AddNewProfile';
+	let profileId = profile.ProfileID ? sprintf(',"ProfileID":%d', int(profile.ProfileID)) : '';
+	let params = sprintf('{"ProfileName":%J,"APN":%J,"UserName":%J,"Password":%J,"AuthType":%d,"DailNumber":%J%s}',
+		profile.ProfileName, profile.APN, profile.UserName, profile.Password,
+		int(profile.AuthType ?? 0), profile.DailNumber, profileId);
+	let r = pack_call(method, params);
+	if (r != null && type(r) == 'object' && r.error == null) return { error: null };
+	if (type(r) == 'object' && length(r) == 0) return { error: null };
+	return r || { error: 'Set failed', code: -1 };
+}
+
+function delete_profile(profile_id) {
+	profile_id = int(profile_id || 0);
+	if (profile_id < 1) return { error: 'Invalid ProfileID', code: -1 };
+	let r = pack_call('DeleteProfile', sprintf('{"ProfileID":%d}', profile_id));
+	if (pack_ok(r)) return { error: null };
+	return r || { error: 'Delete failed', code: -1 };
+}
+
+function set_default_profile(profile_id) {
+	profile_id = int(profile_id || 0);
+	if (profile_id < 1) return { error: 'Invalid ProfileID', code: -1 };
+	let r = pack_call('SetDefaultProfile', sprintf('{"ProfileID":%d}', profile_id));
+	if (pack_ok(r)) return { error: null };
+	return r || { error: 'Set failed', code: -1 };
+}
+
+const methods = {
+	get_system_info:        { call: function() { return get_system_info(); } },
+	get_status:             { call: function() { return get_status(); } },
+	get_signal:             { call: function() { return get_signal(); } },
+	get_network_settings:   { call: function() { return get_network_settings(); } },
+	set_network_mode:       { args: { mode: 0 }, call: function(request) { return set_network_mode(request.args.mode); } },
+	get_usage:              { call: get_usage },
+	get_usage_settings:     { call: get_usage_settings },
+	get_connection_state:   { call: get_connection_state },
+	get_sim_status:         { call: get_sim_status },
+	get_sms_storage:        { call: get_sms_storage },
+	get_sms_settings:       { call: get_sms_settings },
+	get_lan_settings:       { call: get_lan_settings },
+	get_upnp:               { call: get_upnp },
+	get_language:           { call: get_language },
+	get_connection_settings:{ call: get_connection_settings },
+	get_registration_state: { call: get_registration_state },
+	get_profile_list:       { call: get_profile_list },
+	get_current_profile:    { call: get_current_profile },
+	get_pin_state:          { call: get_pin_state },
+	reboot_modem:           { call: reboot_modem },
+	send_connect:           { call: send_connect },
+	disconnect_modem:       { call: disconnect_modem },
+	unlock_pin:             { args: { pin: '' }, call: function(request) { return unlock_pin(request.args.pin); } },
+	unlock_puk:             { args: { puk: '', new_pin: '' }, call: function(request) { return unlock_puk(request.args.puk, request.args.new_pin); } },
+	change_pin:             { args: { old_pin: '', new_pin: '' }, call: function(request) { return change_pin(request.args.old_pin, request.args.new_pin); } },
+	change_pin_state:       { args: { pin: '', enable: true }, call: function(request) { return change_pin_state(request.args.pin, request.args.enable); } },
+	clear_usage:            { call: clear_usage },
+	clear_call_log:         { call: clear_call_log },
+	send_ussd:              { args: { code: '' }, call: function(request) { return send_ussd(request.args.code); } },
+	ussd_end_session:       { call: ussd_end_session },
+	set_usage_settings:     { args: { settings: {} }, call: function(request) { return set_usage_settings(request.args.settings); } },
+	unlock_sim:             { args: { code: '', lock_state: 0 }, call: function(request) { return unlock_sim(request.args.code, request.args.lock_state); } },
+	get_sms_data:           { args: { key: 'inbox', page: 1 }, call: function(request) { return get_sms_data(request.args.key, request.args.page); } },
+	get_sms_list:           { args: { key: 'inbox', page: 1 }, call: function(request) { return get_sms_list(request.args.key, request.args.page); } },
+	get_single_sms:         { args: { id: 0 }, call: function(request) { return get_single_sms(request.args.id); } },
+	send_sms:               { args: { phone: '', content: '' }, call: function(request) { return send_sms(request.args.phone, request.args.content); } },
+	delete_sms:             { args: { id: 0 }, call: function(request) { return delete_sms(request.args.id); } },
+	delete_sms_bulk:        { args: { ids: [] }, call: function(request) { return delete_sms_bulk(request.args.ids); } },
+	get_send_sms_result:    { call: get_send_sms_result },
+	get_calllog_data:       { args: { list_type: 0, page: 1 }, call: function(request) { return get_calllog_data(request.args.list_type, request.args.page); } },
+	get_call_log_list:      { args: { list_type: 0, page: 1 }, call: function(request) { return get_call_log_list(request.args.list_type, request.args.page); } },
+	get_call_log_count:     { call: get_call_log_count },
+	get_dashboard:          { call: get_dashboard },
+	get_all:                { call: get_all },
+	get_all_full:           { call: get_all_full },
+	set_connection_settings: { args: { settings: {} }, call: function(request) { return set_connection_settings(request.args.settings); } },
+	edit_profile:            { args: { profile: {} }, call: function(request) { return edit_profile(request.args.profile); } },
+	delete_profile:          { args: { profile_id: 0 }, call: function(request) { return delete_profile(request.args.profile_id); } },
+	set_default_profile:     { args: { profile_id: 0 }, call: function(request) { return set_default_profile(request.args.profile_id); } },
+	reset_modem:            { call: reset_modem },
+};
+
+return { 'hh4xmodem': methods };


### PR DESCRIPTION
### Description
New LuCI application to monitor and control the Qualcomm MDM9207 modem found in Alcatel/Hub HH40V and HH41V routers.

Features:
  - Dashboard: signal quality, network registration, data usage, device info, LAN/router status
  - SMS: view (inbox/sent), compose/send, and delete messages
  - Call Log: view call history and clear it
  - USSD: send codes and view responses (pack protocol)
  - Connect/Disconnect: manual modem connection control
  - Reboot: restart the modem from the dashboard
  - SIM PIN/PUK: unlock, enable/disable, and change PIN
  - NCK SIM Unlock: unlock network-locked SIMs
  - Monthly Usage Plan: configurable billing day and data limit
  - Clear Usage / Clear Call Log
  - Factory Reset: reset the modem to factory defaults
  - APN/Profile Management: view/edit/delete APN profiles, set the default profile, and configure connection mode

Architecture:
The backend is a ucode plugin running under rpcd. It communicates with the modem's management interface over TCP (192.168.225.1:2016) using the vendor "pack" protocol, through a small helper (hh4xmodem-pack) built on ucode-mod-socket. USSD is handled over the same pack protocol (SendUSSD / GetUSSDSendResult), so no sms-tool / serial AT dependency is required.

Rationale for the pack protocol over raw AT:
  - Structured JSON responses instead of fragile AT text parsing
  - A single TCP request can batch multiple queries
  - TCP is multi-client-safe, unlike the single /dev/ttyUSB serial port

This is an initial submission — no prior package exists.

### Screenshot
<img width="1467" height="640" alt="hh4x" src="https://github.com/user-attachments/assets/c0bca11e-a695-41c5-85cb-0ee30d299049" />

### Maintainer
@devopnem

---

## Tested on
**OpenWrt version:** OpenWrt 25.12.5
**LuCI version:** LuCI openwrt-25.12 branch
**Web browser(s):** librewolf 151.0.1-2

---

## Checklist
- [x] This PR is not from my *main* or *master* branch, but a *separate* branch.
- [x] Each commit has a valid `Signed-off-by: Devon Openheim <devopenm@proton.me>` row.
- [x] Each commit and PR title has a valid `<package name>: title` first line subject for packages.
- [ ] Incremented any `PKG_VERSION` in the Makefile. (N/A — initial package, no prior version)


