### PR TITLE
luci.mk: add reproducibility by setting specific version hash length

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -126,7 +126,7 @@ PKG_GITBRANCH?=$(if $(DUMP),x,$(strip $(shell \
 	variant="LuCI"; \
 	if git log -1 >/dev/null 2>/dev/null; then \
 		branch=$$(git branch --format='%(refname:strip=3)' --remote --no-abbrev --contains 2>/dev/null | tail -n1); \
-		branch=$${branch:-$$(git branch --format='%(refname:strip=2)' --no-abbrev --contains 2>/dev/null | tail -n1)}; \
+		branch=$${branch:-$$(git -c core.abbrev=7 branch --format='%(refname:strip=2)' --contains 2>/dev/null | tail -n1)}; \
 		if [ "$$branch" != "master" ]; then \
 			variant="LuCI $${branch:-unknown} branch"; \
 		else \


### PR DESCRIPTION
The `git branch` feature may return different hash length, resulting in reproducibility issues.

```
│ │ ├── ./usr/share/ucode/luci/version.uc
│ │ │ @@ -1 +1 @@
│ │ │ -export const revision = '26.133.20346~e9ebca7', branch = 'LuCI (HEAD detached at e9ebca7) branch';
│ │ │ +export const revision = '26.133.20346~e9ebca7', branch = 'LuCI (HEAD detached at e9ebca75) branch';
```

Since `git branch` does not support `--abbrev=7` like `git log` does, use `-c core.abbrev=7`.