### PR TITLE
luci-app-olsr: fix blank olsr pages

### DIFF
--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd.js
@@ -483,6 +483,7 @@ return view.extend({
 		};
 
 		ifs.handleAdd = function (ev) {
+			uci.add('olsrd', 'Interface');
 			uci
 				.save()
 				.then(function () {

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd6.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/frontend/olsrd6.js
@@ -462,6 +462,7 @@ return view.extend({
 		ifs.template = 'cbi/tblsection';
 
 		ifs.handleAdd = function (ev) {
+			uci.add('olsrd6', 'Interface');
 			uci
 				.save()
 				.then(function () {

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/hna.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/hna.js
@@ -173,7 +173,7 @@ return olsr.olsrview.extend({
 				let statusOlsrCommonJs = null;
 
 				if (has_v4 && has_v6) {
-					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('common/common_js.js') });
+					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('olsr/common_js.js') });
 				}
 
 				const fresult = E([], {}, [h2, divToggleButtons, fieldset, statusOlsrCommonJs]);

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/interfaces.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/interfaces.js
@@ -90,7 +90,7 @@ return olsr.olsrview.extend({
 				let statusOlsrCommonJs = null;
 
 				if (has_v4 && has_v6) {
-					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('common/common_js.js') });
+					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('olsr/common_js.js') });
 				}
 
 				const fresult = E([], {}, [h2, divToggleButtons, fieldset, statusOlsrCommonJs]);

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/mid.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/mid.js
@@ -81,7 +81,7 @@ return olsr.olsrview.extend({
 				let statusOlsrCommonJs = null;
 
 				if (has_v4 && has_v6) {
-					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('common/common_js.js') });
+					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('olsr/common_js.js') });
 				}
 
 				const fresult = E([], {}, [h2, divToggleButtons, fieldset, statusOlsrCommonJs]);

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/neighbors.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/neighbors.js
@@ -449,7 +449,7 @@ return olsr.olsrview.extend({
 				if (has_v4 && has_v6) {
 					statusOlsrCommonJs = E('script', {
 						type: 'text/javascript',
-						src: L.resource('common/common_js.js'),
+						src: L.resource('olsr/common_js.js'),
 					});
 				}
 

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/neighbors.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/neighbors.js
@@ -174,8 +174,8 @@ return olsr.olsrview.extend({
 					if (link.linkCost == 4194304) {
 						link.linkCost = 0;
 					}
-					const color = etx_color(link.linkCost);
-					const snr_color = snr_colors(link.snr);
+					const color = olsr.etx_color(link.linkCost);
+					const snr_color = olsr.snr_colors(link.snr);
 					let defaultgw_color = '';
 					if (link.defaultgw === 1) {
 						defaultgw_color = '#ffff99';
@@ -299,8 +299,8 @@ return olsr.olsrview.extend({
 						link.linkCost = 0;
 					}
 
-					const color = etx_color(link.linkCost);
-					const snr_color = snr_colors(link.snr);
+					const color = olsr.etx_color(link.linkCost);
+					const snr_color = olsr.snr_colors(link.snr);
 
 					if (link.snr === 0) {
 						link.snr = '?';

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/routes.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/routes.js
@@ -222,7 +222,7 @@ return olsr.olsrview.extend({
 				let statusOlsrCommonJs = null;
 
 				if (has_v4 && has_v6) {
-					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('common/common_js.js') });
+					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('olsr/common_js.js') });
 				}
 
 				const fresult = E([], {}, [h2, divToggleButtons, fieldset, statusOlsrLegend, statusOlsrCommonJs]);

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/routes.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/routes.js
@@ -105,7 +105,7 @@ return olsr.olsrview.extend({
 						interface: route.networkInterface,
 						metric: route.metric,
 						etx: ETX,
-						color: etx_color(parseFloat(ETX)),
+						color: olsr.etx_color(parseFloat(ETX)),
 					});
 				}
 
@@ -172,7 +172,7 @@ return olsr.olsrview.extend({
 
 				for (let route of routes_res) {
 					const ETX = parseInt(route.etx) || 0;
-					const color = etx_color(ETX);
+					const color = olsr.etx_color(ETX);
 
 					const tr = E('div', { 'class': 'tr cbi-section-table-row cbi-rowstyle-' + i + ' proto-' + route.proto }, [
 						E('div', { 'class': 'td cbi-section-table-cell left' }, route.destination + '/' + route.genmask),

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/smartgw.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/smartgw.js
@@ -191,7 +191,7 @@ return olsr.olsrview.extend({
 					let statusOlsrCommonJs = null;
 
 					if (has_v4 && has_v6) {
-						statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('common/common_js.js') });
+						statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('olsr/common_js.js') });
 					}
 
 					const fresult = E([], {}, [h2, divToggleButtons, fieldset, statusOlsrCommonJs]);

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/topology.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/topology.js
@@ -64,7 +64,7 @@ return olsr.olsrview.extend({
 
 				for (let route of routes_res) {
 					const cost = (parseInt(route.tcEdgeCost) || 0).toFixed(3);
-					const color = etx_color(parseInt(cost));
+					const color = olsr.etx_color(parseInt(cost));
 					const lq = (parseInt(route.linkQuality) || 0).toFixed(3);
 					const nlq = (parseInt(route.neighborLinkQuality) || 0).toFixed(3);
 

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/topology.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/topology.js
@@ -117,7 +117,7 @@ return olsr.olsrview.extend({
 				let statusOlsrCommonJs = null;
 
 				if (has_v4 && has_v6) {
-					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('common/common_js.js') });
+					statusOlsrCommonJs = E('script', { 'type': 'text/javascript', 'src': L.resource('olsr/common_js.js') });
 				}
 
 				const fresult = E([], {}, [h2, divToggleButtons, fieldset, statusOlsrLegend, statusOlsrCommonJs]);

--- a/applications/luci-app-olsr/root/usr/libexec/rpcd/olsrinfo
+++ b/applications/luci-app-olsr/root/usr/libexec/rpcd/olsrinfo
@@ -56,13 +56,13 @@ call)
 		json_get_var v4_port v4_port
 		json_get_var v6_port v6_port
 
-		jsonreq4=$(echo "/${otable}" | nc 127.0.0.1 "${v4_port}" | sed -n '/^[}{ ]/p' 2>/dev/null)
-		jsonreq6=$(echo "/${otable}" | nc ::1 "${v6_port}" | sed -n '/^[}{ ]/p' 2>/dev/null)
-
-		json_init
-		json_add_string "jsonreq4" "$jsonreq4"
-		json_add_string "jsonreq6" "$jsonreq6"
-		json_dump
+		{
+			printf '{"jsonreq4":"'
+			echo "/${otable}" | nc 127.0.0.1 "${v4_port}" | sed -n '/^[}{ ]/p' | sed 's/\\/\\\\/g; s/"/\\"/g'
+			printf '","jsonreq6":"'
+			echo "/${otable}" | nc ::1 "${v6_port}" | sed -n '/^[}{ ]/p' | sed 's/\\/\\\\/g; s/"/\\"/g'
+			printf '"}\n'
+		} 2>/dev/null
 		;;
 	hasipip)
 		result=$(ls /etc/modules.d/ | grep -E "[0-9]*-ipip")

--- a/applications/luci-app-olsr/root/usr/libexec/rpcd/olsrinfo
+++ b/applications/luci-app-olsr/root/usr/libexec/rpcd/olsrinfo
@@ -33,6 +33,19 @@ load_hosts() {
 	json_dump
 }
 
+json_stringescape() {
+	awk '
+		NR>1 { r = r "\\n" }
+		{
+			gsub(/["\\]/, "\\\\&");
+			gsub(/\t/, "\\t");
+			gsub(/\r/, "\\r");
+			r = r $0
+		}
+		END  { print r }
+	' | tr -d '\n'
+}
+
 case "$1" in
 list)
 	json_init
@@ -58,9 +71,9 @@ call)
 
 		{
 			printf '{"jsonreq4":"'
-			echo "/${otable}" | nc 127.0.0.1 "${v4_port}" | sed -n '/^[}{ ]/p' | sed 's/\\/\\\\/g; s/"/\\"/g'
+			echo "/${otable}" | nc 127.0.0.1 "${v4_port}" | sed -n '/^[}{ ]/p' | json_stringescape
 			printf '","jsonreq6":"'
-			echo "/${otable}" | nc ::1 "${v6_port}" | sed -n '/^[}{ ]/p' | sed 's/\\/\\\\/g; s/"/\\"/g'
+			echo "/${otable}" | nc ::1 "${v6_port}" | sed -n '/^[}{ ]/p' | json_stringescape
 			printf '"}\n'
 		} 2>/dev/null
 		;;


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
On OpenWrt 25.12.4 some OLSR Status pages (Neighbours, Routes, Topology), as well as the settings page when adding a new interface, are completely blank.
This PR introduces three fixes to restore functionality:
- correctly reference `etx_color` and `snr_colors` from `olsr/common_js` (these functions were previously moved, but their call sites had not been updated to match)
  additionally, some code still referenced `common/common_js`. this is now updated to `olsr/common_js`.
- avoid a shell "too long argument list" error when processing huge olsr-jsoninfo data with jshn.sh (in my case the Topology status page tried to process ~370KB of JSON data). The workaround is to not use jshn.sh and instead escape the string manually.
- When adding a new interface on the settings page it resulted in a blank page with no obvious error. c567bfc removed the call to actually create the config section for the interface. This has now been re-added.
<!-- Describe the changes proposed in this PR. -->


### Screenshot or video of changes _(if applicable)_
| Page | before | after |
|:----:|:------:|:-----:|
| OLSR/Neighbours | <img width="778" height="347" alt="before" src="https://github.com/user-attachments/assets/1be92650-3d29-4231-8291-545ebfd6a37e" /> | <img width="1208" height="503" alt="after" src="https://github.com/user-attachments/assets/7c162569-c456-4a6e-8ae6-e73305171cd1" /> |
| Services/OLSR IPv(4\|6) -> Interfaces -> Add | <img width="1194" height="288" alt="before2" src="https://github.com/user-attachments/assets/8f1bd4b4-42db-4357-aded-efbbe64a7419" /> | <img width="1194" height="754" alt="after2" src="https://github.com/user-attachments/assets/457aa03e-5d7e-4734-ac50-0ed541744121" /> |

<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
unsure who I should ping here.
last person to touch the Makefile was @systemcrash.

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.4 (r32933-4ccb782af7) <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** LuCI openwrt-25.12 branch (26.167.08537~9ccd99b) <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** LibreWolf 152.0-1 <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
