### PR TITLE
luci-app-commands: add optional description field for commands

### DIFF
--- a/applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js
+++ b/applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js
@@ -15,8 +15,12 @@ return view.extend({
 		s.anonymous = true;
 		s.addremove = true;
 
-		o = s.option(form.Value, 'name', _('Description'),
-			_('A short textual description of the configured command'));
+		o = s.option(form.Value, 'name', _('Name'),
+			_('A short name for the configured command'));
+
+		o = s.option(form.Value, 'description', _('Description'),
+			_('An optional longer description to display on the execution page'));
+		o.optional = true;
 
 		o = s.option(form.Value, 'command', _('Command'), _('Command line to execute'));
 		o.textvalue = function(section_id) {

--- a/applications/luci-app-commands/ucode/template/commands.ut
+++ b/applications/luci-app-commands/ucode/template/commands.ut
@@ -141,6 +141,9 @@
 				<div class="commandbox">
 					<h3>{{ entityencode(command.name) }}</h3>
 					<p>{{ _('Command:') }} <code>{{ entityencode(command.command) }}</code></p>
+					{% if (command.description): %}
+						<p><em>{{ entityencode(command.description) }}</em></p>
+					{% endif %}
 					{% if (command.param == "1"): %}
 						<p>{{ _('Arguments:') }} <input type="text" id="{{ command['.name'] }}" /></p>
 					{% endif %}


### PR DESCRIPTION
Add an optional `description` UCI attribute that is displayed below the command line on the Custom Commands execution page. This allows administrators to provide a human-readable explanation of what a command does, visible before executing it.

Also rename the existing `name` field label from "Description" to "Name" in the configuration page to avoid confusion with the new description field.

**Example UCI config:**
```
config command
    option name 'Disable IPv6'
    option command 'disable_ipv6_support'
    option description 'Permanently remove IPv6 support and restart the network.'
    option param '1'
```

**Screenshot-equivalent rendering:**
- **Disable IPv6** (h3)
- Command: `disable_ipv6_support` (code)
- *Permanently remove IPv6 support and restart the network.* (italic description)
- Arguments: `[___]` (input field)
- `[Run]` `[Download]` (buttons)

The description is optional — commands without it render exactly as before.