### PR TITLE
luci-app-usteer: Fix formatting of band_steering_signal_threshold option

### DIFF
--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -754,7 +754,7 @@ return view.extend({
 		}
 
 		if (Initscript.includes('band_steering_signal_threshold')) {
-			o = s.taboption('settings', form.Value, 'band_steering_signal_threshold ', _('Band steering signal threshold'), 
+			o = s.taboption('settings', form.Value, 'band_steering_signal_threshold', _('Band steering signal threshold'), 
 				_('SNR difference that the signal must be better compared to signal was on connection to node.')+' '+
 				_('Avoids conflicts between roaming and band-steering policies.')+' '+
 				_('A value of 0 disables threshold.')


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
There is an extra space after band_steering_signal_threshold, keeping luci from reading the option in the configuration file and causing a uci/set error when trying to change it when using luci.

### Screenshot or video of changes _(if applicable)_
n/a

### Maintainer _(preferred)_
@Ramon00 (Ramon Van Gorkom <Ramon00c00@gmail.com>)

---

## Tested on
**OpenWrt version:** OpenWrt 25.12.4 (r32933-4ccb782af7)
**LuCI version:** LuCI (HEAD detached at e9ebca7) branch (26.133.20346~e9ebca7)
**Web browser(s):** Chrome 149.0.7827.114

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
