### PR TITLE
luci-mod-network: hide incompatible encryption modes for 6 GHz

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1360,6 +1360,7 @@ return view.extend({
 
 
 				const crypto_modes = [];
+				const is_6ghz = uci.get('wireless', radioNet.getWifiDeviceName(), 'band') == '6g';
 
 				if (hwtype == 'mac80211') {
 					const has_supplicant = L.hasSystemFeature('wpasupplicant');
@@ -1386,9 +1387,11 @@ return view.extend({
 					const has_sta_wep = L.hasSystemFeature('wpasupplicant', 'wep');
 
 					if (has_hostapd || has_supplicant) {
-						crypto_modes.push(['psk2',      'WPA2-PSK',                    35]);
-						crypto_modes.push(['psk-mixed', 'WPA-PSK/WPA2-PSK Mixed Mode', 22]);
-						crypto_modes.push(['psk',       'WPA-PSK',                     12]);
+						if (!is_6ghz) {
+							crypto_modes.push(['psk2',      'WPA2-PSK',                    35]);
+							crypto_modes.push(['psk-mixed', 'WPA-PSK/WPA2-PSK Mixed Mode', 22]);
+							crypto_modes.push(['psk',       'WPA-PSK',                     12]);
+						}
 					}
 					else {
 						encr.description = _('WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP and ad-hoc mode) to be installed.');
@@ -1396,14 +1399,15 @@ return view.extend({
 
 					if (has_ap_sae || has_sta_sae) {
 						crypto_modes.push(['sae',       'WPA3-SAE',                     31]);
-						crypto_modes.push(['sae-mixed', 'WPA2-PSK/WPA3-SAE Mixed Mode', 30]);
+						if (!is_6ghz)
+							crypto_modes.push(['sae-mixed', 'WPA2-PSK/WPA3-SAE Mixed Mode', 30]);
 					}
 
 					// WPA3-Personal Compatibility Mode uses RSN overriding, which is an AP-only feature
-					if (has_ap_sae)
+					if (has_ap_sae && !is_6ghz)
 						crypto_modes.push(['sae-compat', 'WPA2-PSK/WPA3-SAE Compatibility Mode', 30]);
 
-					if (has_ap_wep || has_sta_wep) {
+					if (!is_6ghz && (has_ap_wep || has_sta_wep)) {
 						crypto_modes.push(['wep-open',   _('WEP Open System'), 11]);
 						crypto_modes.push(['wep-shared', _('WEP Shared Key'),  10]);
 					}
@@ -1411,12 +1415,15 @@ return view.extend({
 					if (has_ap_eap || has_sta_eap) {
 						if (has_ap_eap192 || has_sta_eap192) {
 							crypto_modes.push(['wpa3', 'WPA3-EAP', 33]);
-							crypto_modes.push(['wpa3-mixed', 'WPA2-EAP/WPA3-EAP Mixed Mode', 32]);
+							if (!is_6ghz)
+								crypto_modes.push(['wpa3-mixed', 'WPA2-EAP/WPA3-EAP Mixed Mode', 32]);
 							crypto_modes.push(['wpa3-192', 'WPA3-EAP 192-bit Mode', 36]);
 						}
 
-						crypto_modes.push(['wpa2', 'WPA2-EAP', 34]);
-						crypto_modes.push(['wpa',  'WPA-EAP',  20]);
+						if (!is_6ghz) {
+							crypto_modes.push(['wpa2', 'WPA2-EAP', 34]);
+							crypto_modes.push(['wpa',  'WPA-EAP',  20]);
+						}
 					}
 
 					if (has_ap_owe || has_sta_owe) {
@@ -1501,7 +1508,8 @@ return view.extend({
 					crypto_modes.push(['wep-shared', _('WEP Shared Key'),         10]);
 				}
 
-				crypto_modes.push(['none',       _('No Encryption'),   0]);
+				if (!is_6ghz)
+					crypto_modes.push(['none',       _('No Encryption'),   0]);
 
 				crypto_modes.sort(function(a, b) { return b[2] - a[2]; });
 


### PR DESCRIPTION
The WiFi 6E (6 GHz) standard mandates WPA3 and management frame
protection.  While wifi-scripts already silently upgrades mixed modes
(psk-sae → sae) on 6 GHz radios, the LuCI encryption dropdown still
offers all WPA2/WPA/WEP options, leading to confusing hostapd failures
when users pick an unsupported mode.

When the radio band is 6 GHz, hide encryption options that are
incompatible with the standard:
- WPA2-PSK, WPA-PSK, WPA-PSK/WPA2-PSK Mixed Mode
- WPA2-PSK/WPA3-SAE Mixed Mode (6 GHz does not allow WPA2 fallback)
- WPA2-EAP, WPA-EAP, WPA2-EAP/WPA3-EAP Mixed Mode
- WEP

This leaves WPA3-SAE, WPA3-EAP, WPA3-EAP 192-bit, OWE, and No
Encryption as the available choices for 6 GHz interfaces.

There is a companion fix for openwrt/openwrt wifi-scripts that extends
the existing 6 GHz auth_type override to also cover pure WPA2 modes
(psk, eap), upgrading them to their WPA3 equivalents as a safety net.