### PR TITLE
luci-theme-material: fix dark-light manual switching

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material-dark
+++ b/themes/luci-theme-material/htdocs/luci-static/material-dark
@@ -1,0 +1,1 @@
+material

--- a/themes/luci-theme-material/htdocs/luci-static/material-light
+++ b/themes/luci-theme-material/htdocs/luci-static/material-light
@@ -1,0 +1,1 @@
+material

--- a/themes/luci-theme-material/ucode/template/themes/material-dark
+++ b/themes/luci-theme-material/ucode/template/themes/material-dark
@@ -1,0 +1,1 @@
+material

--- a/themes/luci-theme-material/ucode/template/themes/material-light
+++ b/themes/luci-theme-material/ucode/template/themes/material-light
@@ -1,0 +1,1 @@
+material


### PR DESCRIPTION
## Pull request details

### Description
Add a symlink for `material-light` and `material-dark`. 
Fixed manual switching themes.

### Maintainer _(preferred)_
@systemcrash

---

## Tested on
**OpenWrt version:** OpenWrt SNAPSHOT r34985+3-000a6149d6 
**LuCI version:** LuCI Master 26.155.67145~1583b09

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.