### PR TITLE
luci-mod-network: add link speed column to the devices tab

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -358,6 +358,7 @@ return view.extend({
 			network.getDSLModemType(),
 			network.getDevices(),
 			fs.lines('/etc/iproute2/rt_tables'),
+			L.resolveDefault(callNetworkDeviceStatus(), {}),
 			uci.changes()
 		]);
 	},
@@ -456,7 +457,7 @@ return view.extend({
 		]);
 	},
 
-	render([dslModemType, netDevs, rtTables]) {
+	render([dslModemType, netDevs, rtTables, devStatus]) {
 
 		if (this.interfaceBridgeWithIfnameSections().length)
 			return this.renderBridgeMigration();
@@ -1737,6 +1738,41 @@ return view.extend({
 		o = s.option(form.DummyValue, 'type', _('Type'));
 		o.textvalue = getDevTypeDesc;
 		o.modalonly = false;
+
+		o = s.option(form.DummyValue, '_speed', _('Link Speed'));
+		o.modalonly = false;
+		o.textvalue = function(section_id) {
+			const dev = getDevice(section_id);
+
+			if (!dev || !dev.getCarrier())
+				return '-';
+
+			const cur = dev.getSpeed();
+
+			/* getSpeed() returns Mbit/s, -1 with carrier but no negotiated rate, or null if unsupported */
+			if (!(cur > 0))
+				return '-';
+
+			/* %1000mBit/s would render 1 Gbit as "1000.00 MBit/s" (strict scale step + forced decimals), so format directly */
+			const fmt = (mbit) => (mbit >= 1000) ? (mbit / 1000) + ' Gbit/s' : mbit + ' Mbit/s';
+
+			/* distinct ethtool-supported link speeds, e.g. 1000baseT-F => 1000, sorted ascending */
+			const st = devStatus ? devStatus[dev.getName()] : null;
+			const supported = (st ? L.toArray(st['link-supported']) : []).reduce(function(speeds, mode) {
+				const n = mode.match(/^(\d+)base/);
+				if (n && speeds.indexOf(+n[1]) < 0)
+					speeds.push(+n[1]);
+				return speeds;
+			}, []).sort((a, b) => a - b);
+
+			/* current speed in the cell; all supported speeds in the tooltip when known */
+			if (supported.length)
+				return E('span', {
+					'data-tooltip': _('Supported link speeds: %s').format(supported.map(fmt).join(', '))
+				}, [ fmt(cur) ]);
+
+			return fmt(cur);
+		};
 
 		o = s.option(form.DummyValue, 'macaddr', _('MAC Address'));
 		o.modalonly = false;

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -14,7 +14,8 @@
 			"ubus": {
 				"file": [ "exec" ],
 				"iwinfo": [ "assoclist", "countrylist", "freqlist", "txpowerlist" ],
-				"luci": [ "getSwconfigFeatures", "getSwconfigPortState" ]
+				"luci": [ "getSwconfigFeatures", "getSwconfigPortState" ],
+				"network.device": [ "status" ]
 			},
 			"uci": [ "dhcp", "firewall", "luci", "network", "wireless", "system" ]
 		},


### PR DESCRIPTION
## Description

While investigating a link that had negotiated down from 1 Gbit/s to 100 Mbit/s, I noticed LuCI surfaces the current link speed only in the topology-driven "Port status" widget on Status → Overview, which shows nothing for plain network devices. The negotiated speed isn't shown on the Network → Interfaces / Devices pages, so a link stuck below its capability is not visible in LuCI.

This adds a **Link Speed** column to the Devices tab showing:

- the negotiated speed (e.g. `1 Gbit/s`), or `-` when the device has no carrier or reports no speed (ppp / tunnel interfaces, etc.);
- the device's supported link speeds in a tooltip (e.g. `Supported link speeds: 10 Mbit/s, 100 Mbit/s, 1 Gbit/s`) when it exposes ethtool link modes.

This makes it possible to spot a device that isn't at its expected link speed.

The current speed comes from the device link state; the supported speeds are the distinct `network.device status` `link-supported` modes, fetched once in `load()`. The `network.device "status"` ACL grant is required for the view to call that method.

### Related PRs

- #8282 adds the same `network.device "status"` ACL grant (for a speed-selection config field). If it lands first, this PR's ACL hunk can be dropped on rebase.
- #8662 / #8270 add speed / duplex / auto-negotiation *configuration* in the same files. This change is read-only *display* and is complementary.

---

Developed with LLM assistance; reviewed and tested by me.

## Checklist

- [x] Not from my *main* / *master* branch, but a separate branch.
- [x] Each commit has a valid `Signed-off-by`.
- [x] Commit and PR title use the `<package>: title` form.
- [ ] Incremented `PKG_VERSION` — n/a (`luci.mk` auto-versions).
