### PR TITLE
luci-mod-network: fix capitalization of "WLAN Roaming" tab

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -14333,7 +14333,7 @@ msgid "WEP passphrase"
 msgstr "عبارة مرور WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN تجوال"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ast/base.po
+++ b/modules/luci-base/po/ast/base.po
@@ -13868,7 +13868,7 @@ msgid "WEP passphrase"
 msgstr "Clave d'accesu WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/az/base.po
+++ b/modules/luci-base/po/az/base.po
@@ -13845,7 +13845,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/be/base.po
+++ b/modules/luci-base/po/be/base.po
@@ -13849,7 +13849,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -13918,7 +13918,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/bn/base.po
+++ b/modules/luci-base/po/bn/base.po
@@ -13842,7 +13842,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -13853,7 +13853,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -13995,7 +13995,7 @@ msgid "WEP passphrase"
 msgstr "Contrasenya WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -14780,7 +14780,7 @@ msgid "WEP passphrase"
 msgstr "WEP heslová fráze"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN roaming"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -14404,7 +14404,7 @@ msgid "WEP passphrase"
 msgstr "WEP adgangssætning"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN-roaming"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -14771,7 +14771,7 @@ msgid "WEP passphrase"
 msgstr "WEP Schlüssel"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN-Roaming"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -13968,7 +13968,7 @@ msgid "WEP passphrase"
 msgstr "Κωδική φράση WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -14898,7 +14898,7 @@ msgid "WEP passphrase"
 msgstr "Contraseña WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Itinerancia"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/fa/base.po
+++ b/modules/luci-base/po/fa/base.po
@@ -13858,7 +13858,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -14125,7 +14125,7 @@ msgid "WEP passphrase"
 msgstr "WEP-tunnuslause"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN-verkkovierailu"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/fil/base.po
+++ b/modules/luci-base/po/fil/base.po
@@ -13929,7 +13929,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -14504,7 +14504,7 @@ msgid "WEP passphrase"
 msgstr "Mot de passe WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Itinérance Wi-Fi"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ga/base.po
+++ b/modules/luci-base/po/ga/base.po
@@ -14837,7 +14837,7 @@ msgid "WEP passphrase"
 msgstr "Frása Pasfhocal WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Fánaíocht WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -13878,7 +13878,7 @@ msgid "WEP passphrase"
 msgstr "סיסמת WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -13850,7 +13850,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -14757,7 +14757,7 @@ msgid "WEP passphrase"
 msgstr "WEP jelmondat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN barangolás"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/id/base.po
+++ b/modules/luci-base/po/id/base.po
@@ -13848,7 +13848,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -14601,7 +14601,7 @@ msgid "WEP passphrase"
 msgstr "Password WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Roaming WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -14180,7 +14180,7 @@ msgid "WEP passphrase"
 msgstr "WEP 暗号フレーズ"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN ローミング"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ka/base.po
+++ b/modules/luci-base/po/ka/base.po
@@ -13848,7 +13848,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -14409,7 +14409,7 @@ msgid "WEP passphrase"
 msgstr "WEP 암호"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "무선랜 로밍"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/lo/base.po
+++ b/modules/luci-base/po/lo/base.po
@@ -14293,7 +14293,7 @@ msgid "WEP passphrase"
 msgstr "ລະຫັດຜ່ານ WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN roaming"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/lt/base.po
+++ b/modules/luci-base/po/lt/base.po
@@ -14851,7 +14851,7 @@ msgid "WEP passphrase"
 msgstr "„WEP“ slaptafrazė"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "„WLAN“ klajojimas"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/lv/base.po
+++ b/modules/luci-base/po/lv/base.po
@@ -13872,7 +13872,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ml/base.po
+++ b/modules/luci-base/po/ml/base.po
@@ -13842,7 +13842,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -13849,7 +13849,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -13880,7 +13880,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -13975,7 +13975,7 @@ msgid "WEP passphrase"
 msgstr "WEP passord"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -14462,7 +14462,7 @@ msgid "WEP passphrase"
 msgstr "WEP-wachtwoordzin"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN-roaming"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -14821,7 +14821,7 @@ msgid "WEP passphrase"
 msgstr "Hasło WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Roaming WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -14812,7 +14812,7 @@ msgid "WEP passphrase"
 msgstr "Palavra-Passe WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Roaming WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -14871,7 +14871,7 @@ msgid "WEP passphrase"
 msgstr "Senha WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Roaming WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -14610,7 +14610,7 @@ msgid "WEP passphrase"
 msgstr "Parola WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Roaming WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -15176,7 +15176,7 @@ msgid "WEP passphrase"
 msgstr "Пароль WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN роуминг"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -14103,7 +14103,7 @@ msgid "WEP passphrase"
 msgstr "Heslo WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -13887,7 +13887,7 @@ msgid "WEP passphrase"
 msgstr "WEP-lösenordsfras"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ta/base.po
+++ b/modules/luci-base/po/ta/base.po
@@ -14530,7 +14530,7 @@ msgid "WEP passphrase"
 msgstr "Wep கடவுச்சொல்"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Wlan ரோமிங்"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -13839,7 +13839,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -14514,7 +14514,7 @@ msgid "WEP passphrase"
 msgstr "WEP parolası"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN dolaşımı"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -14799,7 +14799,7 @@ msgid "WEP passphrase"
 msgstr "Парольна фраза WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN роумінг"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -13848,7 +13848,7 @@ msgid "WEP passphrase"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -14490,7 +14490,7 @@ msgid "WEP passphrase"
 msgstr "Mật khẩu WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Roaming WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/yua/base.po
+++ b/modules/luci-base/po/yua/base.po
@@ -14600,7 +14600,7 @@ msgid "WEP passphrase"
 msgstr "Contraseña WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "Itinerancia WLAN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -14248,7 +14248,7 @@ msgid "WEP passphrase"
 msgstr "WEP 密钥"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN 漫游"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -14167,7 +14167,7 @@ msgid "WEP passphrase"
 msgstr "WEP 密碼"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1053
-msgid "WLAN roaming"
+msgid "WLAN Roaming"
 msgstr "WLAN 漫遊"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1212

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1074,7 +1074,7 @@ return view.extend({
 				ss.tab('encryption', _('Wireless Security'));
 				ss.tab('macfilter', _('MAC-Filter'));
 				ss.tab('advanced', _('Advanced Settings'));
-				ss.tab('roaming', _('WLAN roaming'), _('Settings for assisting wireless clients in roaming between multiple APs: 802.11r, 802.11k and 802.11v'));
+				ss.tab('roaming', _('WLAN Roaming'), _('Settings for assisting wireless clients in roaming between multiple APs: 802.11r, 802.11k and 802.11v'));
 
 				o = ss.taboption('general', form.ListValue, 'mode', _('Mode') , !have_mesh ? '<a id="installmesh" href="%s" target="_blank" rel="noreferrer">%s</a>'
 						.format(L.url('admin/system/package-manager') + '?query=wpad-mesh', _('802.11s? Install mesh wpad') ) : '');


### PR DESCRIPTION
The WLAN roaming tab label used a lowercase "r" in "roaming", inconsistent with the title-case convention used by other tabs (e.g. "MAC-Filter", "Advanced Settings"). Capitalize it to "WLAN Roaming" and update the msgid in all translation files.

Signed-off-by: Michael Pfeifroth <michael.pfeifroth@westermo.com>