### PR TITLE
luci-app-poe: add PoE control application

### DIFF
--- a/applications/luci-app-poe/Makefile
+++ b/applications/luci-app-poe/Makefile
@@ -1,0 +1,14 @@
+# Copyright 2026 Pieter Hollander (openwrt@pieterhollander.nl)
+# This is free software, licensed under the Apache License, Version 2.0
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for realtek-poe (PoE control)
+LUCI_DEPENDS:=+realtek-poe
+LUCI_PKGARCH:=all
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Pieter Hollander <openwrt@pieterhollander.nl>
+
+include $(TOPDIR)/feeds/luci/luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-poe/README.md
+++ b/applications/luci-app-poe/README.md
@@ -1,0 +1,38 @@
+# luci-app-poe
+
+A LuCI web interface for controlling Power over Ethernet (PoE) on OpenWrt
+switches driven by the [`realtek-poe`](https://github.com/Hurricos/realtek-poe)
+daemon (e.g. the HPE 1920 PoE models on the `realtek` target).
+
+It adds two pages:
+
+- **Status → PoE** — live per-port status (mode, status, priority, power
+  consumption) plus the global power budget and total consumption, refreshed
+  automatically. Each port has an immediate on/off toggle (via the `poe` ubus
+  `manage` method — note this is **temporary** and resets on reload/reboot).
+- **Network → PoE** — edit the persistent configuration in `/etc/config/poe`
+  (per-port enable, priority, PoE+) through a normal Save & Apply form.
+
+## Requirements
+
+- OpenWrt 25.x (LuCI 26.x / client-side JS)
+- `realtek-poe` installed and running (provides the `poe` ubus object)
+
+## Quick install for development
+
+The view, menu and ACL are interpreted at runtime, so you can copy them straight
+onto a running switch:
+
+```sh
+cd applications/luci-app-poe   # from the repository root
+
+SW=root@192.168.1.1
+ssh $SW 'mkdir -p /www/luci-static/resources/view/poe'
+scp -O htdocs/luci-static/resources/view/poe/overview.js $SW:/www/luci-static/resources/view/poe/
+scp -O htdocs/luci-static/resources/view/poe/status.js   $SW:/www/luci-static/resources/view/poe/
+scp -O root/usr/share/luci/menu.d/luci-app-poe.json      $SW:/usr/share/luci/menu.d/
+scp -O root/usr/share/rpcd/acl.d/luci-app-poe.json       $SW:/usr/share/rpcd/acl.d/
+ssh $SW '/etc/init.d/rpcd restart; rm -f /tmp/luci-indexcache*; rm -rf /tmp/luci-modulecache'
+```
+
+Then open the LuCI web interface and hard-refresh

--- a/applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js
+++ b/applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+'require view';
+'require uci';
+'require form';
+
+function portNum(name) {
+	var m = String(name).match(/(\d+)/);
+	return m ? +m[1] : 0;
+}
+
+return view.extend({
+	load: function() {
+		return uci.load('poe');
+	},
+
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('poe', _('Power over Ethernet'),
+			_('These settings are written to <code>/etc/config/poe</code> and persist across reboots. ' +
+			  'After editing a port, click <em>Save</em> in that port\'s dialog to record the change, then ' +
+			  '<em>Save &amp; Apply</em> at the bottom of the page to propagate it to the switch.' +
+			  '<br /><br />' +
+			  '<em>Save &amp; Apply</em> reloads the configuration without restarting the PoE daemon, so ports that ' +
+			  'stay enabled keep delivering power — connected devices will not be power-cycled. Only a port whose own ' +
+			  'settings you changed (or one you switch off) is affected.' +
+			  '<br /><br />' +
+			  'Live per-port status and an immediate on/off toggle are under ' +
+			  '<a href="%s">Status → PoE</a>.').format(L.url('admin/status/poe')));
+
+		/* The global power budget is fixed by the switch hardware (PSU rating)
+		   and shipped in /etc/config/poe; it is shown read-only on the Status →
+		   PoE page and is intentionally not editable here. */
+
+		s = m.section(form.GridSection, 'port');
+		s.anonymous = true;
+		s.addremove = false;
+		s.sortable = false;
+
+		/* /etc/config/poe lists the ports in hardware PSE id order (e.g.: id 1 = lan8
+		   … id 8 = lan1), so the grid would otherwise render lan8→lan1. Order
+		   the rows by port label instead, to match the Status table. */
+		s.cfgsections = function() {
+			return uci.sections('poe', 'port')
+				.sort(function(a, b) { return portNum(a.name) - portNum(b.name); })
+				.map(function(s) { return s['.name']; });
+		};
+
+		s.option(form.DummyValue, 'name', _('Port'));
+
+		o = s.option(form.Flag, 'enable', _('Enabled'),
+			_('Deliver power on this port.'));
+		o.default = '1';
+		o.rmempty = false;
+
+		o = s.option(form.ListValue, 'priority', _('Priority'),
+			_('Lower-priority ports are shed first when the power budget is exceeded.'));
+		o.value('', _('Unset (0)'));
+		o.value('1', _('Low (1)'));
+		o.value('2', _('Medium (2)'));
+		o.value('3', _('High (3)'));
+		o.optional = true;
+
+		o = s.option(form.Flag, 'poe_plus', _('PoE+'),
+			_('Allow higher power (PoE+ / 802.3at) on this port.'));
+		o.optional = true;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js
+++ b/applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+'require view';
+'require rpc';
+'require ui';
+'require poll';
+'require dom';
+
+var callPoeInfo = rpc.declare({
+	object: 'poe',
+	method: 'info'
+});
+
+var callPoeManage = rpc.declare({
+	object: 'poe',
+	method: 'manage',
+	params: [ 'port', 'enable' ]
+});
+
+function portNum(name) {
+	var m = String(name).match(/(\d+)/);
+	return m ? +m[1] : 0;
+}
+
+/* realtek-poe reports a per-port status string such as
+   "Disabled", "Searching", "Delivering", "Fault". Anything other than
+   "Disabled" means power delivery is enabled on the port. */
+function portIsOn(port) {
+	return String((port && port.status) || '').toLowerCase() != 'disabled';
+}
+
+/* realtek-poe reports priority 0 when no explicit priority has been set on a
+   port; values 1-3 map to the Low/Medium/High choices in the config form. */
+function priorityLabel(prio) {
+	if (prio == null)
+		return '-';
+	switch (+prio) {
+	case 0: return _('Unset (0)');
+	case 1: return _('Low (1)');
+	case 2: return _('Medium (2)');
+	case 3: return _('High (3)');
+	default: return String(prio);
+	}
+}
+
+/* The daemon includes a per-port "consumption" field while the port is
+   actually delivering power; the field is absent when idle. */
+function consumptionLabel(port) {
+	return (port && port.consumption != null) ? '%.1f W'.format(port.consumption) : '-';
+}
+
+return view.extend({
+	/* No cbi form on this page, so suppress the Save/Save&Apply/Reset footer
+	   the base view would otherwise render (cf. status/processes.js). */
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+
+	handleToggle: function(port, enable) {
+		/* Mark the port as transitioning and repaint at once, so the row shows a
+		   pending state with no RPC/MCU latency. The pending entry is cleared in
+		   renderStatus once the daemon reports a status matching the intent. */
+		this.pending[port] = enable;
+		this.repaint();
+
+		return callPoeManage(port, enable).then(L.bind(function() {
+			/* The MCU takes ~1-2s to settle; poll faster than the steady 5s cadence
+			   so the pending label clears promptly. */
+			this.reconcile();
+		}, this)).catch(L.bind(function(err) {
+			delete this.pending[port];
+			this.repaint();
+			ui.addNotification(null, E('p', {},
+				_('Failed to switch PoE on %s: %s').format(port, err.message || err)), 'error');
+		}, this));
+	},
+
+	/* Re-render the status table from the last fetched info without a new RPC. */
+	repaint: function() {
+		if (this.statusNode)
+			dom.content(this.statusNode, this.renderStatus(this.lastInfo));
+	},
+
+	refreshStatus: function() {
+		return L.resolveDefault(callPoeInfo(), {}).then(L.bind(function(info) {
+			this.lastInfo = info;
+			if (this.statusNode)
+				dom.content(this.statusNode, this.renderStatus(info));
+		}, this));
+	},
+
+	/* Short burst of refreshes after a toggle to reconcile the pending state
+	   quickly, rather than waiting for the next 5s poll. */
+	reconcile: function() {
+		[ 500, 1000, 2000, 3500 ].forEach(L.bind(function(delay) {
+			window.setTimeout(L.bind(function() {
+				if (this.statusNode)
+					this.refreshStatus();
+			}, this), delay);
+		}, this));
+	},
+
+	renderStatus: function(info) {
+		info = info || {};
+		this.lastInfo = info;
+		var ports = info.ports || {};
+		var names = Object.keys(ports).sort(function(a, b) { return portNum(a) - portNum(b); });
+
+		var rows = names.map(L.bind(function(name) {
+			var p = ports[name] || {};
+			var actualOn = portIsOn(p);
+
+			/* A port is "pending" between a toggle click and the daemon reporting
+			   the intended state. Clear the pending flag once they agree. */
+			var pending = (name in this.pending);
+			if (pending && this.pending[name] === actualOn) {
+				delete this.pending[name];
+				pending = false;
+			}
+
+			var statusText, actionCell;
+			if (pending) {
+				var want = this.pending[name];
+				statusText = want ? _('Enabling…') : _('Disabling…');
+				actionCell = E('button', {
+					'class': 'btn cbi-button ' + (want ? 'cbi-button-apply' : 'cbi-button-remove'),
+					'disabled': 'disabled'
+				}, [ E('span', { 'class': 'spinning' }, want ? _('Turning on…') : _('Turning off…')) ]);
+			}
+			else {
+				statusText = p.status || '-';
+				actionCell = E('button', {
+					'class': 'btn cbi-button ' + (actualOn ? 'cbi-button-remove' : 'cbi-button-apply'),
+					'click': ui.createHandlerFn(this, 'handleToggle', name, !actualOn)
+				}, actualOn ? _('Turn off') : _('Turn on'));
+			}
+
+			return E('tr', { 'class': 'tr' }, [
+				E('td', { 'class': 'td', 'data-title': _('Port') }, name),
+				E('td', { 'class': 'td', 'data-title': _('Mode') }, p.mode || '-'),
+				E('td', { 'class': 'td', 'data-title': _('Status') }, statusText),
+				E('td', { 'class': 'td', 'data-title': _('Priority') }, priorityLabel(p.priority)),
+				E('td', { 'class': 'td', 'data-title': _('Consumption') }, consumptionLabel(p)),
+				E('td', { 'class': 'td cbi-section-actions' }, [ actionCell ])
+			]);
+		}, this));
+
+		if (!rows.length)
+			rows = [ E('tr', { 'class': 'tr placeholder' }, [
+				E('td', { 'class': 'td' }, _('No PoE ports reported. Is the realtek-poe daemon running?'))
+			]) ];
+
+		var header = E('p', {}, [
+			E('strong', {}, _('Power budget: ')), '%.1f W'.format(info.budget || 0),
+			' — ', E('strong', {}, _('Consumption: ')), '%.1f W'.format(info.consumption || 0),
+			info.firmware ? (' — ' + _('MCU firmware: ') + info.firmware) : ''
+		]);
+
+		var table = E('table', { 'class': 'table cbi-section-table' }, [
+			E('tr', { 'class': 'tr table-titles' }, [
+				E('th', { 'class': 'th' }, _('Port')),
+				E('th', { 'class': 'th' }, _('Mode')),
+				E('th', { 'class': 'th' }, _('Status')),
+				E('th', { 'class': 'th' }, _('Priority')),
+				E('th', { 'class': 'th' }, _('Consumption')),
+				E('th', { 'class': 'th cbi-section-actions' }, _('Control'))
+			])
+		].concat(rows));
+
+		return [ header, table ];
+	},
+
+	load: function() {
+		return L.resolveDefault(callPoeInfo(), {});
+	},
+
+	render: function(info) {
+		/* pending: ports mid-toggle (name -> intended on/off); lastInfo: most
+		   recent `poe info` snapshot, used to repaint without a fresh RPC. */
+		this.pending = {};
+		this.lastInfo = info || {};
+
+		this.statusNode = E('div', {}, this.renderStatus(info));
+
+		/* keep the live status table fresh (interval follows luci.main.pollinterval) */
+		poll.add(L.bind(this.refreshStatus, this));
+
+		return E('div', {}, [
+			E('h2', {}, _('Power over Ethernet')),
+			E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, _('Live status')),
+				E('p', {}, _('This table refreshes automatically.')),
+				E('p', {}, _('The <em>Turn on</em> / <em>Turn off</em> buttons toggle a port\'s power ' +
+					'immediately. These changes are temporary and revert on the next reboot or ' +
+					'<em>Save &amp; Apply</em>. To make a setting permanent, edit it under ' +
+					'<a href="%s">Network → PoE</a>.').format(L.url('admin/network/poe'))),
+				this.statusNode
+			])
+		]);
+	}
+});

--- a/applications/luci-app-poe/po/templates/poe.pot
+++ b/applications/luci-app-poe/po/templates/poe.pot
@@ -1,0 +1,164 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:66
+msgid "Allow higher power (PoE+ / 802.3at) on this port."
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:143
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:165
+msgid "Consumption"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:155
+msgid "Consumption:"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:166
+msgid "Control"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:53
+msgid "Deliver power on this port."
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:124
+msgid "Disabling…"
+msgstr ""
+
+#: applications/luci-app-poe/root/usr/share/rpcd/acl.d/luci-app-poe.json:3
+msgid "Edit PoE configuration"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:52
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:124
+msgid "Enabling…"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:74
+msgid "Failed to switch PoE on %s: %s"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:62
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:41
+msgid "High (3)"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:191
+msgid "Live status"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:60
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:39
+msgid "Low (1)"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:58
+msgid "Lower-priority ports are shed first when the power budget is exceeded."
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:156
+msgid "MCU firmware:"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:61
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:40
+msgid "Medium (2)"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:140
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:162
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:150
+msgid "No PoE ports reported. Is the realtek-poe daemon running?"
+msgstr ""
+
+#: applications/luci-app-poe/root/usr/share/luci/menu.d/luci-app-poe.json:3
+#: applications/luci-app-poe/root/usr/share/luci/menu.d/luci-app-poe.json:15
+msgid "PoE"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:65
+msgid "PoE+"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:50
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:139
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:161
+msgid "Port"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:154
+msgid "Power budget:"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:20
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:189
+msgid "Power over Ethernet"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:57
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:142
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:164
+msgid "Priority"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:141
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:163
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:193
+msgid ""
+"The <em>Turn on</em> / <em>Turn off</em> buttons toggle a port's power "
+"immediately. These changes are temporary and revert on the next reboot or "
+"<em>Save &amp; Apply</em>. To make a setting permanent, edit it under <a "
+"href=\"%s\">Network → PoE</a>."
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:21
+msgid ""
+"These settings are written to <code>/etc/config/poe</code> and persist "
+"across reboots. After editing a port, click <em>Save</em> in that port's "
+"dialog to record the change, then <em>Save &amp; Apply</em> at the bottom of "
+"the page to propagate it to the switch.<br /><br /><em>Save &amp; Apply</em> "
+"reloads the configuration without restarting the PoE daemon, so ports that "
+"stay enabled keep delivering power — connected devices will not be power-"
+"cycled. Only a port whose own settings you changed (or one you switch off) "
+"is affected.<br /><br />Live per-port status and an immediate on/off toggle "
+"are under <a href=\"%s\">Status → PoE</a>."
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:192
+msgid "This table refreshes automatically."
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:135
+msgid "Turn off"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:135
+msgid "Turn on"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:128
+msgid "Turning off…"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:128
+msgid "Turning on…"
+msgstr ""
+
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/overview.js:59
+#: applications/luci-app-poe/htdocs/luci-static/resources/view/poe/status.js:38
+msgid "Unset (0)"
+msgstr ""
+
+#: applications/luci-app-poe/root/usr/share/rpcd/acl.d/luci-app-poe.json:13
+msgid "View PoE status and toggle ports"
+msgstr ""

--- a/applications/luci-app-poe/root/usr/share/luci/menu.d/luci-app-poe.json
+++ b/applications/luci-app-poe/root/usr/share/luci/menu.d/luci-app-poe.json
@@ -1,0 +1,25 @@
+{
+	"admin/network/poe": {
+		"title": "PoE",
+		"order": 60,
+		"action": {
+			"type": "view",
+			"path": "poe/overview"
+		},
+		"depends": {
+			"acl": [ "luci-app-poe" ]
+		}
+	},
+
+	"admin/status/poe": {
+		"title": "PoE",
+		"order": 80,
+		"action": {
+			"type": "view",
+			"path": "poe/status"
+		},
+		"depends": {
+			"acl": [ "luci-app-poe-status" ]
+		}
+	}
+}

--- a/applications/luci-app-poe/root/usr/share/rpcd/acl.d/luci-app-poe.json
+++ b/applications/luci-app-poe/root/usr/share/rpcd/acl.d/luci-app-poe.json
@@ -1,0 +1,25 @@
+{
+	"luci-app-poe": {
+		"description": "Edit PoE configuration",
+		"read": {
+			"uci": [ "poe" ]
+		},
+		"write": {
+			"uci": [ "poe" ]
+		}
+	},
+
+	"luci-app-poe-status": {
+		"description": "View PoE status and toggle ports",
+		"read": {
+			"ubus": {
+				"poe": [ "info" ]
+			}
+		},
+		"write": {
+			"ubus": {
+				"poe": [ "manage" ]
+			}
+		}
+	}
+}


### PR DESCRIPTION
LuCI view under Status -> PoE driven by the realtek-poe ubus object: live per-port status/consumption, an immediate temporary on/off toggle.

Under Network -> PoE a Save & Apply form for persistent /etc/config/poe settings (enable, priority, PoE+).

Signed-off-by: Pieter Hollander <git@pieterhollander.nl>

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
A LuCI web interface for controlling Power over Ethernet (PoE) on OpenWrt
switches driven by the [`realtek-poe`](https://github.com/Hurricos/realtek-poe)
daemon (e.g. the HPE 1920 PoE models on the `realtek` target).

It adds **Status → POE** and **Network → PoE** pages that let you:

- view live per-port status (mode, status, priority, power consumption) plus the
  global power budget and total consumption;
- switch power on individual ports on/off immediately (via the `poe` ubus
  `manage` method — note this is **temporary** and resets on reload/reboot);
- edit the persistent configuration in `/etc/config/poe` (per-port enable,
  priority, PoE+) through a normal Save & Apply form.

If this gets merged, I'd like to back port it to 25.12 as well, so I have a GUI to configure and toggle my PoE ports.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->

Status -> PoE

<img width="2940" height="1678" alt="Screenshot 2026-06-28 at 13-05-13 OpenWrt PoE" src="https://github.com/user-attachments/assets/552251c7-a128-417c-b2ec-5e0121d5492f" />

Network -> PoE

<img width="2940" height="1678" alt="Screenshot 2026-06-28 at 13-07-10 OpenWrt PoE" src="https://github.com/user-attachments/assets/14b48b29-2082-468b-9844-ef8de8569472" />

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.4 r32933-4ccb782af7
**LuCI version:** LuCI (HEAD detached at e9ebca7) branch 26.133.20346~e9ebca7
**Web browser(s):** Safari Version 26.5 (21624.2.5.11.4)

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile.
- [x] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [x] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
