### PR TITLE
luci-mod-network: hide wifi modes unsupported by the driver

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -69,6 +69,12 @@ const callLuciHostHints = rpc.declare({
 	expect: { '': {} }
 });
 
+const callLuciWifiIftypes = rpc.declare({
+	object: 'luci.wifi',
+	method: 'iftypes',
+	expect: { '': {} }
+});
+
 const callIwinfoAssoclist = rpc.declare({
 	object: 'iwinfo',
 	method: 'assoclist',
@@ -360,16 +366,18 @@ function initNetworkState(refresh) {
 			L.resolveDefault(callLuciBoardJSON(), {}),
 			L.resolveDefault(callLuciNetworkDevices(), {}),
 			L.resolveDefault(callLuciWirelessDevices(), {}),
+			hasWifi ? L.resolveDefault(callLuciWifiIftypes(), {}) : L.resolveDefault({}),
 			L.resolveDefault(callLuciHostHints(), {}),
 			getProtocolHandlers(),
 			L.resolveDefault(uci.load('network')),
 			hasWifi ? L.resolveDefault(uci.load('wireless')) : L.resolveDefault(),
 			L.resolveDefault(uci.load('luci'))
-		]).then(function([netifd_ifaces, board_json, luci_devs, radios, hosts]) {
+		]).then(function([netifd_ifaces, board_json, luci_devs, radios, wifi_iftypes, hosts]) {
 
 			const s = {
 				isTunnel: {}, isBridge: {}, isSwitch: {}, isWifi: {},
 				ifaces: netifd_ifaces, radios: radios, hosts: hosts,
+				wifi_iftypes: wifi_iftypes,
 				netdevs: {}, bridges: {}, switches: {}, hostapd: {}
 			};
 
@@ -3721,6 +3729,49 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 				return null;
 
 		return v;
+	},
+
+	/**
+	 * Check whether a given UCI wireless `mode` value is supported
+	 * by the underlying PHY.
+	 *
+	 * @param {string} mode
+	 * The UCI `mode` value to test.
+	 *
+	 * @returns {boolean}
+	 * Returns `true` if supported, or if support information is
+	 * unavailable; `false` only when the driver explicitly does not
+	 * advertise the matching iftype.
+	 */
+	isModeSupported: function(mode) {
+		const uciModeToIftype = {
+			ap:        'ap',
+			'ap-wds':  'ap',
+			sta:       'managed',
+			'sta-wds': 'managed',
+			adhoc:     'ibss',
+			ahdemo:    'ibss',
+			mesh:      'mesh_point',
+			monitor:   'monitor',
+			wds:       'wds'
+		};
+
+		const want = uciModeToIftype[mode];
+		if (want == null)
+			return true;
+
+		const radioname = this.ubus('radio');
+		const dev = radioname ? _state.radios[radioname] : null;
+		const phy = (dev && L.isObject(dev.iwinfo)) ? dev.iwinfo.phy : null;
+
+		if (!phy || !L.isObject(_state.wifi_iftypes))
+			return true;
+
+		const entry = _state.wifi_iftypes[phy];
+		if (!L.isObject(entry) || !Array.isArray(entry.iftypes))
+			return true;
+
+		return entry.iftypes.includes(want);
 	},
 
 	/**

--- a/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
@@ -37,6 +37,7 @@
 		"description": "Grant access to network status information",
 		"read": {
 			"ubus": {
+				"luci.wifi": [ "iftypes" ],
 				"luci-rpc": [ "getBoardJSON", "getHostHints", "getNetworkDevices", "getWirelessDevices" ],
 				"network": [ "get_proto_handlers" ],
 				"network.device": [ "status" ],

--- a/modules/luci-mod-network/Makefile
+++ b/modules/luci-mod-network/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Network Administration
-LUCI_DEPENDS:=+luci-base +rpcd-mod-iwinfo +luci-lib-uqr
+LUCI_DEPENDS:=+luci-base +rpcd-mod-iwinfo +luci-lib-uqr +ucode-mod-nl80211
 
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1078,9 +1078,12 @@ return view.extend({
 
 				o = ss.taboption('general', form.ListValue, 'mode', _('Mode') , !have_mesh ? '<a id="installmesh" href="%s" target="_blank" rel="noreferrer">%s</a>'
 						.format(L.url('admin/system/package-manager') + '?query=wpad-mesh', _('802.11s? Install mesh wpad') ) : '');
-				o.value('ap', _('Access Point'));
-				o.value('sta', _('Client'));
-				o.value('adhoc', _('Ad-Hoc'));
+				if (radioNet.isModeSupported('ap'))
+					o.value('ap', _('Access Point'));
+				if (radioNet.isModeSupported('sta'))
+					o.value('sta', _('Client'));
+				if (radioNet.isModeSupported('adhoc'))
+					o.value('adhoc', _('Ad-Hoc'));
 
 				o = ss.taboption('general', form.Value, 'mesh_id', _('Mesh Id'));
 				o.depends('mode', 'mesh');
@@ -1165,9 +1168,9 @@ return view.extend({
 					const mode = ss.children.find(obj => obj.option === 'mode');
 					const bssid = ss.children.find(obj => obj.option === 'bssid');
 
-					if (have_mesh) mode.value('mesh', '802.11s');
-					mode.value('ahdemo', _('Pseudo Ad-Hoc (ahdemo)'));
-					mode.value('monitor', _('Monitor'));
+					if (have_mesh && radioNet.isModeSupported('mesh')) mode.value('mesh', '802.11s');
+					if (radioNet.isModeSupported('ahdemo')) mode.value('ahdemo', _('Pseudo Ad-Hoc (ahdemo)'));
+					if (radioNet.isModeSupported('monitor')) mode.value('monitor', _('Monitor'));
 
 					bssid.depends('mode', 'adhoc');
 					bssid.depends('mode', 'sta');
@@ -1195,8 +1198,10 @@ return view.extend({
 						}, this));
 					};
 
-					mode.value('ap-wds', '%s (%s)'.format(_('Access Point'), _('WDS')));
-					mode.value('sta-wds', '%s (%s)'.format(_('Client'), _('WDS')));
+					if (radioNet.isModeSupported('ap-wds'))
+						mode.value('ap-wds', '%s (%s)'.format(_('Access Point'), _('WDS')));
+					if (radioNet.isModeSupported('sta-wds'))
+						mode.value('sta-wds', '%s (%s)'.format(_('Client'), _('WDS')));
 
 					mode.write = function(section_id, value) {
 						switch (value) {

--- a/modules/luci-mod-network/root/usr/share/rpcd/ucode/luci.wifi-iftypes
+++ b/modules/luci-mod-network/root/usr/share/rpcd/ucode/luci.wifi-iftypes
@@ -1,0 +1,46 @@
+#!/usr/bin/env ucode
+//
+// luci.wifi-iftypes -- expose per-PHY supported nl80211 interface modes.
+//
+//   ubus call luci.wifi iftypes
+//     -> { "phy0": { "iftypes": ["managed","ap","monitor","mesh_point"] }, ... }
+//
+// Consumed by LuCI's wireless mode UI to hide modes the driver does not
+// advertise in wiphy->interface_modes (e.g. STA disabled by the driver
+// for AP-only SKUs, or mesh/monitor unavailable on fullmac chips).
+//
+
+'use strict';
+
+import * as nl80211 from 'nl80211';
+
+function collect() {
+	let out = {};
+
+	let dumps = nl80211.request(
+		nl80211.const.NL80211_CMD_GET_WIPHY,
+		nl80211.const.NLM_F_DUMP,
+		{ split_wiphy_dump: true });
+
+	for (let d in filter(dumps ?? [], d => d.wiphy_name != null)) {
+		let phy = replace(d.wiphy_name, /^wiphy/, 'phy');
+		out[phy] ??= { iftypes: [] };
+		if (type(d.supported_iftypes) == 'object')
+			out[phy].iftypes = uniq([
+				...out[phy].iftypes,
+				...filter(keys(d.supported_iftypes), t => d.supported_iftypes[t])
+			]);
+	}
+
+	return out;
+}
+
+return {
+	'luci.wifi': {
+		iftypes: {
+			call: function() {
+				return collect();
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Summary

Hide wifi mode entries in the wireless UI that the underlying driver does
not advertise in `wiphy->interface_modes`.

Today the "Mode" dropdown on the radio/interface edit page lists every
mode LuCI knows about (AP, Client, Mesh, Monitor, Ad-Hoc, ...), regardless
of whether the running driver actually supports them. Selecting an
unsupported mode silently fails at netifd/hostapd time.

This series:

1. Adds a tiny rpcd ucode plugin `luci.wifi iftypes` that queries
   nl80211 `GET_WIPHY` and returns per-PHY supported `iftypes`.
2. Fetches that map once in `network.js#initNetworkState()` and stores it
   on `_state.wifi_iftypes`. Adds `Network.WifiDevice#isModeSupported(mode)`
   that maps each UCI `mode` value to the corresponding nl80211 iftype
   (`sta`/`sta-wds` → `managed`, `ap`/`ap-wds` → `ap`,
   `adhoc`/`ahdemo` → `ibss`, `mesh` → `mesh_point`, ...).
3. Gates each entry in the wireless mode dropdown on
   `radioNet.isModeSupported(...)`.

Fail-open: if the ubus call returns nothing (plugin not installed, old
rpcd, query error) `isModeSupported()` returns `true`, so the UI behaves
exactly as today.

## Motivation

Two concrete cases:

- **AP-only product variants** where the driver masks
  `NL80211_IFTYPE_STATION` out of `wiphy->interface_modes` (e.g. for
  certification reasons). Users could still pick "Client" in LuCI and
  end up with a non-functional radio. With this series, "Client" and
  the WDS-client variant disappear from the dropdown while AP / Mesh /
  Monitor remain.
- **fullmac chips** that don't advertise `monitor` or `mesh_point` no
  longer show those entries.

## Testing

- Stock build (no AP-only restriction): all existing entries still
  present, no behavior change.
- AP-only build (driver masks `NL80211_IFTYPE_STATION`):
  `ubus call luci.wifi iftypes` →
  `{"phy0":{"iftypes":["ap","monitor","mesh_point"]}, ...}`
  Mode dropdown: Client + Client (WDS) + Ad-Hoc + Pseudo Ad-Hoc are
  hidden; AP, AP (WDS), Mesh, Monitor remain.
- Removing the rpcd plugin: dropdown shows all modes again (fail-open
  verified).
