### PR TITLE
luci-theme-bootstrap: handle null board info in container environments

### DIFF
--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -8,7 +8,7 @@
 {%
 	import { getuid, getspnam } from 'luci.core';
 
-	const boardinfo = ubus.call('system', 'board');
+	const boardinfo = ubus.call('system', 'board') ?? {};
 	const darkpref = (theme == 'bootstrap-dark' ? 'true' : (theme == 'bootstrap-light' ? 'false' : null));
 
 	http.prepare_content('text/html; charset=UTF-8');


### PR DESCRIPTION
## Pull request details

### Description
ubus.call('system', 'board') returns null in minimal container
runtimes without procd. Subsequent accesses to boardinfo.hostname
and boardinfo.rootfs_type in header.ut crash with
"left-hand side expression is null". Add ?? {} fallback so
boardinfo is always an object.

Fixes openwrt/luci#8726.

### Screenshot or video of changes _(if applicable)_
<img width="1920" height="1080" alt="Снимок экрана от 2026-06-27 02-56-30" src="https://github.com/user-attachments/assets/fd23e748-2efe-4ebc-bd3e-59749b381480" />


### Maintainer _(preferred)_
@jow-

---

## Tested on
OpenWrt version: snapshot x86-64 (openwrt/rootfs:latest, June 2026)
LuCI version: 26.176.73524~c3bb510
Web browser: Google Chrome
---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes openwrt/luci#8726 ✅.
