### PR TITLE
luci-app-babeld: remove dead load() referencing deleted babeld.js

### DIFF
--- a/applications/luci-app-babeld/htdocs/luci-static/resources/view/babeld/babeld-view.js
+++ b/applications/luci-app-babeld/htdocs/luci-static/resources/view/babeld/babeld-view.js
@@ -229,15 +229,6 @@ return view.extend({
 		});
 	},
 
-	load() {
-		return new Promise(function (resolve, reject) {
-			const script = E('script', { 'type': 'text/javascript' });
-			script.onload = resolve;
-			script.onerror = reject;
-			script.src = L.resource('babeld.js');
-			document.querySelector('head').appendChild(script);
-		});
-	},
 	render() {
 		return this.action_babeld()
 			.then(function (result) {


### PR DESCRIPTION


## Pull request details

### Description
b62a318 moved all render functions (renderTableInfo, renderTableXRoutes,
renderTableRoutes, renderTableNeighbours) into babeld-view.js but left
the load() method that dynamically loaded the now-deleted babeld.js
script. This caused a JS error on the status page preventing it from
loading.

Remove the obsolete load() entirely since all required functions are
already defined in babeld-view.js.

Fixes openwrt/luci#8721.


### Screenshot or video of changes _(if applicable)_

### Maintainer _(preferred)_
@newtwen

---

## Tested on
Verified by code inspection: all functions referenced in render()
are defined in babeld-view.js since b62a318.

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes openwrt/luci#8721.
