### PR TITLE
luci-base: fix empty data-page attribute and login redirect on root URL

### DIFF
--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -1044,7 +1044,7 @@ dispatch = function(_http, path) {
 				    cookie_secure = (http.getenv('HTTPS') == 'on') ? '; secure' : '';
 
 				http.header('Set-Cookie', `${cookie_name}=${session.sid}; path=${build_url()}; SameSite=strict; HttpOnly${cookie_secure}`);
-				http.redirect(build_url(...resolved.ctx.request_path));
+				http.redirect(build_url(...(length(resolved.ctx.request_path) ? resolved.ctx.request_path : resolved.ctx.path)));
 
 				return;
 			}

--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -45,7 +45,7 @@
 		<script src="{{ resource }}/cbi.js"></script>
 	</head>
 
-	<body class="lang_{{ dispatcher.lang }} {{ entityencode(striptags(node?.title ?? ''), true) }}" data-page="{{ entityencode(join('-', ctx.request_path), true) }}">
+	<body class="lang_{{ dispatcher.lang }} {{ entityencode(striptags(node?.title ?? ''), true) }}" data-page="{{ entityencode(join('-', length(ctx.request_path) ? ctx.request_path : ctx.path), true) }}">
 		{% if (!blank_page): %}
 		<header>
 			<a class="brand" href="/">{{ striptags(boardinfo.hostname ?? '?') }}</a>

--- a/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut
+++ b/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut
@@ -26,7 +26,7 @@
 <style title="text/css">{{ css }}</style>
 {% endif %}
 </head>
-<body class="lang_{{ dispatcher.lang }}" data-page="{{ entityencode(join('-', ctx.request_path), true) }}">
+<body class="lang_{{ dispatcher.lang }}" data-page="{{ entityencode(join('-', length(ctx.request_path) ? ctx.request_path : ctx.path), true) }}">
 
 <p class="skiplink">
 <span id="skiplink1"><a href="#navigation">{{ _('Skip to navigation') }}</a></span>

--- a/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
+++ b/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
@@ -30,7 +30,7 @@
 
 <title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>
 </head>
-<body class="lang_{{ dispatcher.lang }}" data-page="{{ entityencode(join('-', ctx.request_path), true) }}">
+<body class="lang_{{ dispatcher.lang }}" data-page="{{ entityencode(join('-', length(ctx.request_path) ? ctx.request_path : ctx.path), true) }}">
 
 <p class="skiplink">
 <span id="skiplink1"><a href="#navigation">{{ _('Skip to navigation') }}</a></span>


### PR DESCRIPTION
## Pull request details

### Description
When accessing LuCI via /cgi-bin/luci/ without a full path,
ctx.request_path is empty because firstchild resolution only
populates ctx.path. This causes two issues:

1. After login, http.redirect() sends the user back to the root
   URL instead of the resolved overview page (dispatcher.uc).
2. The data-page attribute in the HTML body is empty, breaking
   any CSS or JS that relies on it (header.ut in all themes).

Fix: fall back to ctx.path when ctx.request_path is empty in
both the redirect and the data-page attribute.

luci-theme-material already uses ctx.path correctly and is
unaffected.

Fixes openwrt/luci#8534.


### Screenshot or video of changes _(if applicable)_


### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection. luci-theme-material already
uses ctx.path and serves as reference implementation.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes openwrt/luci#8534