### PR TITLE
luci-lua-runtime: fix missing nixio.fs import in dispatcher

### DIFF
--- a/modules/luci-lua-runtime/luasrc/dispatcher.lua
+++ b/modules/luci-lua-runtime/luasrc/dispatcher.lua
@@ -5,6 +5,7 @@
 module("luci.dispatcher", package.seeall)
 
 local http = _G.L.http
+local fs     = require "nixio.fs"
 
 context = setmetatable({}, {
 	__index = function(t, k)


### PR DESCRIPTION
## Pull request details

### Description
process_lua_controller() calls fs.stat() on line 135 to resolve
file_depends entries, but nixio.fs was never imported in
dispatcher.lua. The call always fails silently, making
file_depends processing non-functional.

Fix: add the missing local fs = require "nixio.fs" import,
consistent with how luci/sys.lua uses it.

Fixes openwrt/luci#8142.


### Screenshot or video of changes _(if applicable)_


### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection. nixio.fs import pattern matches
luci-lua-runtime/luasrc/sys.lua line 7.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch
- [x] Each commit has a valid Signed-off-by
- [x] Each commit and PR title has a valid <package name>: title
- [x] _(Optional)_ Includes what Issue it closes openwrt/luci#8142
