### PR TITLE
luci-base: don't crash in String.format() on an undefined argument

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -726,15 +726,15 @@ String.prototype.format = function()
 				param = arguments[numSubstitutions++];
 		}
 
-		if (param !== undefined) {
-			pad = '';
-			if (pPad && pPad.substr(0,1) == "'")
-				pad = pPad.substr(1,1);
-			else if (pPad)
-				pad = pPad;
-			else
-				pad = ' ';
+		pad = '';
+		if (pPad && pPad.substr(0,1) == "'")
+			pad = pPad.substr(1,1);
+		else if (pPad)
+			pad = pPad;
+		else
+			pad = ' ';
 
+		if (param !== undefined) {
 			precision = -1;
 			if (pPrecision && pType == 'f')
 				precision = +pPrecision.substring(1);
@@ -835,6 +835,16 @@ String.prototype.format = function()
 					pMinLength = null;
 					break;
 			}
+		}
+		else {
+			subst = '';
+
+			/* %m reuses the min-length slot as the metric divisor rather
+			   than a field width, so clear it here as the defined-argument
+			   %m path does; keep it for every other conversion so the
+			   padding below still applies, e.g. '%10s'.format(undefined). */
+			if (pType == 'm')
+				pMinLength = null;
 		}
 
 		if (pMinLength) {


### PR DESCRIPTION
## Pull request details

Supersedes #8727. GitHub no longer allows reopening that PR after its source
branch was recreated, so this is the replacement PR with the corrected follow-up
from the review discussion there.

### Description

The status Overview "Ports" widget (`view/status/include/29_ports.js`) can
crash with `TypeError: Cannot read properties of undefined (reading 'toString')`
when a port's netdev reports no statistics. In that case `stats.rx_bytes` and
similar values are `undefined`, and the widget formats them through:

```js
'%1024mB'.format(stats.rx_bytes)
```

This aborts the entire Overview render.

Root cause: `String.prototype.format()` runs its conversion switch only when the
argument is defined (`if (param !== undefined)`). For `%m`, the parsed
`pMinLength` slot is used as the metric divisor (`%1024m`), not as a field
width, and the `%m` switch case clears it afterwards. With an undefined argument
the switch is skipped, so `pMinLength` stays set while `subst` stays undefined;
the common padding block then calls `subst.toString()` and throws.

Fix undefined arguments by using an empty substitution. Preserve the parsed
field width for normal conversions, so e.g. `'%10s'.format(undefined)` renders
ten spaces as padding plus an empty string. Keep `%m` special by clearing
`pMinLength` for undefined `%m` conversions too, since that slot is the metric
divisor rather than a field width. Also move pad initialization before the
undefined-argument check so the common padding block has a valid pad character
in both paths.

### Tested on

**OpenWrt version:** OpenWrt SNAPSHOT r34203 (target `econet/en751221`, EcoNet
EN751221) - TP-Link Archer XR500v

**LuCI version:** master `26.151.60149~1bffbf4`

**Web browser(s):** Chromium (used to capture the console stack trace)

Before: the Overview throws `Cannot read properties of undefined (reading
'toString')` and renders nothing.

After: the Ports panel renders normally, and formatter checks behave as expected:

```text
'%10s'.format(undefined)       -> ten spaces
'%s'.format(undefined)         -> ""
'%1024m'.format(undefined)     -> ""
'%1024mB'.format(undefined)    -> "B"
'%10s'.format('hi')            -> "        hi"
'%-10s'.format('hi')           -> "hi        "
'%1024m'.format(2097152)       -> "2.00 Mi"
```

### Maintainer

@jow-

---

## Checklist

- [x] This PR is not from my *main*/*master* branch, but a separate branch (`fix-string-format-undefined-crash`).
- [x] Each commit has a valid `Signed-off-by: Cristian Papa <pcristian292@gmail.com>` row.
- [x] Each commit and the PR title have a valid `<package name>: title` first-line subject (`luci-base: ...`).
- [x] `PKG_VERSION`: N/A - `luci-base` has no `PKG_VERSION`; it is versioned via `luci.mk`/git.
