### PR TITLE
luci-mod-network: fix DNS forward validation rejecting interface-only spec

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
@@ -64,19 +64,19 @@ function validateServerSpec(sid, s) {
 	if (m[2] == '' || m[2] == '#')
 		return true;
 
-	// ipaddr%scopeid#srvport@source@interface#srcport
+	// ipaddr%scopeid#srvport[@source[@interface]]#srcport or ipaddr%scopeid#srvport@interface
 
-	m = m[2].match(/^([0-9a-f:.]+)(?:%[^#@]+)?(?:#(\d+))?(?:@([0-9a-f:.]+)(?:@[^#]+)?(?:#(\d+))?)?$/);
+	m = m[2].match(/^([0-9a-f:.]+)(?:%[^#@]+)?(?:#(\d+))?(?:@([0-9a-f:.]+)(?:@[^#]+)?(?:#(\d+))?|@[^#@0-9][^#@]*)?$/);
 
 	if (!m)
 		return _('Expecting: %s').format(_('valid IP address'));
 
 	if (validation.parseIPv4(m[1])) {
-		if (m[3] != null && !validation.parseIPv4(m[3]))
+		if (m[3] != null && !validation.parseIPv4(m[3]) && !validation.parseIPv6(m[3]))
 			return _('Expecting: %s').format(_('valid IPv4 address'));
 	}
 	else if (validation.parseIPv6(m[1])) {
-		if (m[3] != null && !validation.parseIPv6(m[3]))
+		if (m[3] != null && !validation.parseIPv4(m[3]) && !validation.parseIPv6(m[3]))
 			return _('Expecting: %s').format(_('valid IPv6 address'));
 	}
 	else {


### PR DESCRIPTION


## Pull request details

### Description
dnsmasq supports server=1.2.3.4@eth0 (server IP bound to interface without source IP), but the regex in validateServerSpec() required a source IP address before the interface name, causing valid entries to fail with 'Expecting: valid IP address'.

Allow @interface without preceding @source in the server spec.

Fixes openwrt/luci#7888.



### Screenshot or video of changes _(if applicable)_



### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection against dnsmasq documentation.
---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes openwrt/luci#7888.

