### PR TITLE
luci-mod-dashboard: fix word-break causing mid-word line breaks in system info

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
@@ -119,7 +119,8 @@
 
 .Dashboard .settings-info p span:nth-child(2){
 	display: inline-block;
-	word-break: break-all;
+	overflow-wrap: break-word;
+	word-break: normal;
 }
 
 .Dashboard .settings-info p span:nth-child(2).label {


### PR DESCRIPTION
## Pull request details

### Description
word-break: break-all in .Dashboard .settings-info p span:nth-child(2)
caused firmware version, model and architecture strings to break at
arbitrary character positions. Replace with overflow-wrap: break-word
and word-break: normal so strings only break when they cannot fit on
a single line.

Fixes openwrt/luci#7468.


### Screenshot or video of changes _(if applicable)_


### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes openwrt/luci#7468.
