### PR TITLE
luci-base: clean up unused legacy 'flash_keep' section from config

### DIFF
--- a/modules/luci-base/root/etc/config/luci
+++ b/modules/luci-base/root/etc/config/luci
@@ -3,25 +3,16 @@ config core main
 	option mediaurlbase /luci-static/bootstrap
 	option resourcebase /luci-static/resources
 	option ubuspath /ubus/
-	
-config extern flash_keep
-	option uci 		"/etc/config/"
-	option dropbear "/etc/dropbear/"
-	option openvpn	"/etc/openvpn/"
-	option passwd	"/etc/passwd"
-	option opkg		"/etc/opkg.conf"
-	option firewall	"/etc/firewall.user"
-	option uploads	"/lib/uci/upload/"
-	
+
 config internal languages
-	
+
 config internal sauth
 	option sessionpath "/tmp/luci-sessions"
 	option sessiontime 3600
-	
+
 config internal ccache
 	option enable 1
-		
+
 config internal themes
 
 config internal apply


### PR DESCRIPTION
Remove the long obsolete 'flash_keep' section of LuCI's main config file that has no users (and maybe never did).

Fixes: #8750