### PR TITLE
luci-app-snmpd: check against snmpd

### DIFF
--- a/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
+++ b/applications/luci-app-snmpd/htdocs/luci-static/resources/view/snmpd/snmpd.js
@@ -9,7 +9,7 @@
 'require view';
 
 var testlibsslv3 = function() {
-	return fs.exec('/usr/bin/ldd', [ '/usr/lib/libnetsnmp.so' ]).then(function (res) {
+	return fs.exec('/usr/bin/ldd', [ '/usr/sbin/snmpd' ]).then(function (res) {
 		return res.stdout.includes('libssl');
 	});
 };

--- a/applications/luci-app-snmpd/root/usr/share/rpcd/acl.d/luci-app-snmpd.json
+++ b/applications/luci-app-snmpd/root/usr/share/rpcd/acl.d/luci-app-snmpd.json
@@ -5,7 +5,7 @@
 			"uci": [ "snmpd" ],
 			"file": {
 				"/usr/share/snmp/mibs/*": [ "read", "stat" ],
-				"/usr/bin/ldd /usr/lib/libnetsnmp.so": [ "exec" ]
+				"/usr/bin/ldd /usr/sbin/snmpd": [ "exec" ]
 			}
 		},
 		"write": {


### PR DESCRIPTION
## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
To keep forward compatibility, the check for libnetsnmp library is changed to probe `/usr/sbin/snmpd` for libssl.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@jow- @feckert @systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12 <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** luci openwrt-25.12 <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** firefox <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.

