### PR TITLE
luci-mod-network: make firewall uci load optional in dns view

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dns.js
@@ -93,7 +93,7 @@ return view.extend({
 	load() {
 		return Promise.all([
 			callHostHints(),
-			uci.load('firewall')
+			L.resolveDefault(uci.load('firewall'))
 		]);
 	},
 


### PR DESCRIPTION
## Pull request details

### Description
uci.load('firewall') in dns.js load() was called unconditionally inside
Promise.all(), causing the entire DNS configuration page to fail with
'RPC call to uci/get failed with ubus code 4' when /etc/config/firewall
is absent (e.g. on systems without fw4 installed).

Make the load optional with .catch(() => {}) so the page loads correctly
regardless of whether firewall config exists. The ipset dropdown simply
shows no existing sets when firewall is absent, which is the correct
behavior.

Fixes #7609.


### Screenshot or video of changes _(if applicable)_


### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes #7609.

