### PR TITLE
luci-mod-status: guard against null l3 device in addDhcpv6Stats

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
@@ -40,7 +40,7 @@ function renderbox(ifc, ipv6, dhcpv6_stats) {
 	}
 
 	function addDhcpv6Stats() {
-		if (ipv6 && ifc.getProtocol() === 'dhcpv6' && dhcpv6_stats && dhcpv6_stats[dev.device]) {
+		if (ipv6 && ifc.getProtocol() === 'dhcpv6' && dhcpv6_stats && dev && dhcpv6_stats[dev.device]) {
 			const arr = [];
 			for (const [pkt_type, count] of Object.entries(dhcpv6_stats[dev.device]))
 				arr.push(pkt_type.replace('dhcp_', _('DHCPv6') + ' '), `${count} ${_('pkts', 'packets, abbreviated')}`);


### PR DESCRIPTION
## Pull request details

### Description
`addDhcpv6Stats()` calls `dev.device` without checking if `dev` is null.
`getL3Device()` returns null when a DHCPv6 interface is configured but
not yet up, causing a crash when rendering the network status box.

Fix: add a `dev` null check before accessing `dev.device`.


### Screenshot or video of changes _(if applicable)_


### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.

