### PR TITLE
github: modernize GitHub Pages deployment

### DIFF
--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -11,16 +11,22 @@ on:
       - 'modules/luci-base/htdocs/luci-static/resources/**'
       - 'docs/**'
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build:
-    if: endsWith( github.repository, 'luci' )
+    if: endsWith(github.repository, 'luci')
     runs-on: ubuntu-latest
-    # permissions:
-    #   pages: write
-    #   id-token: write
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -31,27 +37,11 @@ jobs:
       - name: Build
         run: npm run doc
 
-      - name: Archive docs as artifact
+      - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          name: docs
           path: ./docs/
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/
-          enable_jekyll: false
-
-      # Deploy step depends on the repo settings->pages config: choose Branch
-      # "gh-pages", path "/". Deploy creates a commit on the gh-pages branch,
-      # with the content of built docs folder "/docs" in repo root "/".
-      # This is the "luci" repo, so the result of gh-pages is deployed to
-      # "<githubid>.github.io/luci"
-
-      # - name: Deploy to GitHub Pages
-      #   id: deployment
-      #   uses: actions/deploy-pages@v4
-      #   with:
-      #     artifact_name: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Migrate the `jsdoc.yml` workflow from the legacy, branch-based Pages deployment (using `peaceiris/actions-gh-pages`) to GitHub's native, artifact-based Pages deployment.

This eliminates git commit pollution on the `gh-pages` branch and uses the officially recommended Actions-based Pages deployment flow.

Let's finish what was started here: https://github.com/openwrt/luci/commit/74f5bbdc116f8a1a46d0040f762e3182523f5875 as it was not properly configured (cc: @systemcrash). This was tested in my forked repository - https://github.com/BKPepe/luci/deployments/github-pages and it works.

Here is the run: https://github.com/BKPepe/luci/actions/runs/28397355806/job/84139466311 to verify it

Once this is merged, I will provide details to @Ansuel to change one option in this repository.