### PR TITLE
Fix iptables xss target iface

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
@@ -165,10 +165,10 @@ return view.extend({
 						'data-format': '%.2mB',
 						'data-value': bytes
 					}, (raw ? '%d' : '%.2mB').format(bytes)),
-					target ? '<span class="target">%s</span>'.format(target) : '-',
+					target ? E('span', { 'class': 'target' }, [ target ]) : '-',
 					proto,
-					(indev !== '*') ? '<span class="ifacebadge nowrap">%s</span>'.format(indev) : '*',
-					(outdev !== '*') ? '<span class="ifacebadge nowrap">%s</span>'.format(outdev) : '*',
+					(indev !== '*') ? E('span', { 'class': 'ifacebadge nowrap' }, [ indev ]) : '*',
+					(outdev !== '*') ? E('span', { 'class': 'ifacebadge nowrap' }, [ outdev ]) : '*',
 					srcnet,
 					dstnet,
 					options,


### PR DESCRIPTION
## Pull request details

### Description
`target`, `indev` and `outdev` entries in the iptables status view were interpolated into raw HTML strings via `%s`.format(), causing the values to be assigned via `innerHTML` when rendered by `cbi_update_table()`.

Both fields ultimately come from `iptables -L` output and aren't sanitized upstream, so a crafted chain or interface name could inject markup into the status page.

Replace the HTML string interpolation with `E('span', ...)`, which appends the value via `createTextNode()` instead of `innerHTML` — matching the idiomatic pattern already used for `ifacebadge` spans elsewhere (`routes.js`, `routesj.js`, `wireless.js`).

Loosely related to the discussion in #8749 about making `cbi_update_table()` safe by default — this is a self-contained fix for one concrete instance of the underlying pattern.




### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection. `E()` uses `createTextNode()` for scalar string children per `dom.append()` in `luci.js`, confirmed against existing `ifacebadge` usage in the same file (line 204) and elsewhere in the codebase.


---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.

