### PR TITLE
luci-proto-openvpn: fix auth_user_pass option, clarify label

### DIFF
--- a/protocols/luci-proto-openvpn/htdocs/luci-static/resources/protocol/openvpn.js
+++ b/protocols/luci-proto-openvpn/htdocs/luci-static/resources/protocol/openvpn.js
@@ -73,6 +73,14 @@ const openvpnOptions = [
 	},
 	{
 		tab: 'general',
+		type: form.FileUpload,
+		root_directory: '/etc/openvpn',
+		name: 'auth_user_pass',
+		label: _('Username and password file (one per line)'),
+		placeholder: '/etc/openvpn/some-client-auth-user-pass'
+	},
+	{
+		tab: 'general',
 		type: form.Value,
 		name: 'ifconfig',
 		datatype: 'tuple(ipaddr,ipaddr)',
@@ -1471,13 +1479,6 @@ const openvpnOptions = [
 		name: 'pull',
 		label: _('Accept options pushed from server'),
 		default: 0
-	},
-	{
-		tab: 'push_opt',
-		depends: { server: "", "!reverse": true },
-		type: form.Value,
-		name: 'auth_user_pass',
-		label: _('Authenticate using username/password')
 	},
 	{
 		tab: 'push_opt',


### PR DESCRIPTION
Maintainer: @systemcrash

CC: @feckert

Version: Main
Compile tested: X86-64
Run tested: X86-64

Description:
The push_opt tab incorrectly registered a server-side 'auth_user_pass' Value option. So move it to the client-side FileUpload option on the general tab.

auth_user_pass is a client-only option; the corresponding server-side directive is auth-user-pass-verify, which is already correctly defined under the scripts tab as auth_user_pass_verify. Comment out the erroneous push_opt duplicate accordingly.

Also updated the general-tab auth_user_pass label to a clearer description of the expected file format (username and password on separate lines).

Signed-off-by: Erik Conijn <egc112@msn.com>

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->


---


---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
