### PR TITLE
luci-app-ddns: replace dynamic_dns_lucihelper call on handleStopDDnsRule

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -220,8 +220,8 @@ return view.extend({
 			const stop = rows[i].querySelector('.cbi-section-actions .stop');
 			const cfg_enabled = uci.get('ddns', section_id, 'enabled');
 
-			reload.disabled = (status['_enabled'] == 0 || cfg_enabled == 0);
-			stop.disabled = (!service[section_id].pid);
+			reload.disabled = (cfg_enabled == 0)
+			stop.disabled = !(service[section_id] && service[section_id].pid);
 
 			const host = uci.get('ddns', section_id, 'lookup_host') || _('Configuration Error');
 			const ip = service[section_id]?.ip || _('No Data');
@@ -555,11 +555,9 @@ return view.extend({
 					'title': _('Stop this service'),
 				};
 
-			if (status['_enabled'] == 0 || cfg_enabled == 0)
+			if (cfg_enabled == 0)
 				reload_opt['disabled'] = 'disabled';
-
-			if (!resolved[section_id] || !resolved[section_id].pid ||
-					(resolved[section_id].pid && cfg_enabled == '1'))
+			if (!(resolved[section_id] && resolved[section_id].pid))
 				stop_opt['disabled'] = 'disabled';
 
 			dom.content(tdEl.lastChild, [

--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -164,8 +164,7 @@ return view.extend({
 	},
 
 	handleReloadDDnsRule(m, section_id, ev) {
-		return fs.exec('/etc/init.d/ddns',
-							[ 'restart', section_id ])
+		return fs.exec('/etc/init.d/ddns', [ 'restart', section_id ])
 			.then(L.bind(m.load, m))
 			.then(L.bind(m.render, m))
 			.catch(function(e) { ui.addNotification(null, E('p', e.message)) });
@@ -179,7 +178,7 @@ return view.extend({
 	},
 
 	handleToggleDDns(m, ev) {
-        let action = this.status['_enabled'];
+		let action = this.status['_enabled'];
 		return this.callInitAction('ddns', action ? 'disable' : 'enable')
 			.then(L.bind(function () { return this.callInitAction('ddns', action ? 'stop' : 'start')}, this))
 			.then(L.bind(m.render, m))

--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -172,8 +172,8 @@ return view.extend({
 	},
 
 	handleStopDDnsRule(m, section_id, ev) {
-		return fs.exec('/usr/lib/ddns/dynamic_dns_lucihelper.sh',
-							[ '-S', section_id, '--', 'stop' ])
+		return fs.exec('/etc/init.d/ddns', [ 'stop', section_id ])
+			.then(L.bind(m.load, m))
 			.then(L.bind(m.render, m))
 			.catch(function(e) { ui.addNotification(null, E('p', e.message)) });
 	},

--- a/applications/luci-app-ddns/root/usr/share/rpcd/acl.d/luci-app-ddns.json
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/acl.d/luci-app-ddns.json
@@ -13,7 +13,7 @@
 				"/usr/share/ddns/custom/*": [ "read" ],
 				"/usr/share/ddns/list": [ "read" ],
 				"/usr/bin/ddns": [ "exec" ],
-				"/usr/lib/ddns/dynamic_dns_lucihelper.sh": [ "exec" ]
+				"/etc/init.d/ddns": [ "exec" ]
 			},
 			"uci": [ "ddns" ]
 		},


### PR DESCRIPTION
### Description
@champtar This should fix https://github.com/openwrt/packages/security/advisories/GHSA-hfpc-hw28-69pj

However, this change only works if the procd change is used to start the service. 
This change is included in [master](https://github.com/openwrt/packages/commit/b1502c453e50aac26ada49dd87300eb6c4449e36) and [openwrt-25.12](https://github.com/openwrt/packages/commit/04f0c5bccdeec03c1a2aabdb783648f842087dc4)

Also, I'm no longer satisfied with the app. The app needs a little love. Please try it again with a different setup.

## Checklist
- [ x ] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [ x ] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [ x ] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.

