### PR TITLE
luci-base: fix undefined View reference in instantiateView()

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3362,7 +3362,7 @@ const UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */
 	 * @returns {Promise}
 	 */
 	handleDelete(path, fileStat, ev) {
-		const parent = path.replace(/\/[^\/]+$/, '') ?? '/';
+		const parent = path.replace(/\/[^/]+$/, '') ?? '/';
 		const name = path.replace(/^.+\//, '');
 		let msg;
 
@@ -5102,7 +5102,7 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 				for (let i = 0; i < 2; i++)
 					for (let j = 0; j < ipaddrs.length; j++)
 						tasks.push(this.pingDevice(i ? 'https' : 'http', ipaddrs[j])
-							.then(ev => { reachable = ev.target.src.replace(/^(https?:\/\/[^\/]+).*$/, '$1/') }, () => {}));
+							.then(ev => { reachable = ev.target.src.replace(/^(https?:\/\/[^/]+).*$/, '$1/') }, () => {}));
 
 				return Promise.all(tasks).then(() => {
 					if (reachable) {
@@ -5715,7 +5715,7 @@ const UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 		const className = 'view.%s'.format(path.replace(/\//g, '.'));
 
 		return L.require(className).then(view => {
-			if (!(view instanceof View))
+			if (typeof view?.render !== 'function')
 				throw new TypeError('Loaded class %s is not a descendant of View'.format(className));
 
 			return view;


### PR DESCRIPTION
## Pull request details

### Description
`instantiateView()` in `ui.js` guarded against invalid view modules with:

```js
if (!(view instanceof View))
```

`View` (capital V) is never declared or imported in `ui.js`, so this
line throws a `ReferenceError` whenever the guard is reached. Adding
`'require view as View'` would introduce a circular dependency since
view modules themselves require `ui`. Additionally, `L.require()`
returns a class instance rather than a constructor, making `instanceof`
conceptually incorrect here regardless.

Replace with a duck-type check on `render()`, which all valid LuCI view
modules are required to implement. Preserves fail-fast behavior for
invalid modules without relying on an undefined identifier.

The bug has been present since the function was introduced in
4e9cf92 (2020).

Also fixes two pre-existing `no-useless-escape` lint errors in the same
file (lines 3365 and 5105) that were surfaced by ESLint when the file
was touched.

### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection. `L.require()` returns `instance` per
`luci.js:2562`, not the constructor, confirming `instanceof` was
never applicable here.
---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
---

Per the contributing guidelines, I'd like to request commit access.
Happy to take on more responsibility if you think the time is right.
