### PR TITLE
luci-app-pbr: update to 1.2.2-18

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=14
+PKG_RELEASE:=18
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
@@ -11,7 +11,7 @@ var pkg = {
 		return "pbr";
 	},
 	get LuciCompat() {
-		return 25;
+		return 26;
 	},
 	get ReadmeCompat() {
 		return "1.2.2";
@@ -329,6 +329,9 @@ var status = baseclass.extend({
 					),
 					warningTorUnsetChainNft: _(
 						"Please unset 'chain' or set 'chain' to 'prerouting' for policy '%s'",
+					),
+					warningInterfaceRoutingUnknownGateway: _(
+						"Unknown Gateway for device '%s'",
 					),
 					warningInvalidOVPNConfig: _(
 						"Invalid OpenVPN config for %s interface",

--- a/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
+++ b/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
@@ -10,7 +10,7 @@
 # ubus -S call luci.pbr getPlatformSupport '{"name": "pbr" }'
 # ubus -S call luci.pbr getInterfaces '{"name": "pbr" }'
 
-readonly rpcdCompat='25'
+readonly rpcdCompat='26'
 readonly pbrFunctionsFile="${IPKG_INSTROOT}/etc/init.d/pbr"
 if [ -s "$pbrFunctionsFile" ]; then
 # shellcheck source=../../../../../pbr/files/etc/init.d/pbr


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
update to release 18

Makefile:
  - Bump PKG_RELEASE to 18.

htdocs/luci-static/resources/pbr/status.js:
  - Update LuciCompat to 26.
  - Add warning for unknown gateway on interface routing.

root/usr/libexec/rpcd/luci.pbr:
  - Update rpcdCompat to 26