### PR TITLE
luci-base: add nonce-based CSP support to replace unsafe-inline

### DIFF
--- a/applications/luci-app-commands/ucode/template/commands.ut
+++ b/applications/luci-app-commands/ucode/template/commands.ut
@@ -28,7 +28,7 @@
 	` });
 -%}
 
-<script>
+<script nonce="{{ ctx?.csp_nonce }}">
 	function command_run(ev, id)
 	{
 		var field = document.getElementById(id);
@@ -113,6 +113,18 @@
 		ev.preventDefault();
 	}
 
+	document.addEventListener('DOMContentLoaded', function() {
+		document.querySelectorAll('button[data-cmd]').forEach(function(btn) {
+			btn.addEventListener('click', function(ev) {
+				var id = ev.currentTarget.dataset.cmd;
+				switch (ev.currentTarget.dataset.action) {
+				case 'run':      command_run(ev, id);      break;
+				case 'download': command_download(ev, id); break;
+				case 'link':     command_link(ev, id);     break;
+				}
+			});
+		});
+	});
 </script>
 
 {%
@@ -148,10 +160,10 @@
 						<p>{{ _('Arguments:') }} <input type="text" id="{{ command['.name'] }}" /></p>
 					{% endif %}
 					<div>
-						<button class="cbi-button cbi-button-apply" onclick="command_run(event, '{{ command['.name'] }}')">{{ _('Run') }}</button>
-						<button class="cbi-button cbi-button-download" onclick="command_download(event, '{{ command['.name'] }}')">{{ _('Download') }}</button>
+						<button class="cbi-button cbi-button-apply" data-action="run" data-cmd="{{ command['.name'] }}">{{ _('Run') }}</button>
+						<button class="cbi-button cbi-button-download" data-action="download" data-cmd="{{ command['.name'] }}">{{ _('Download') }}</button>
 						{% if (command.public == "1"): %}
-							<button class="cbi-button cbi-button-link" onclick="command_link(event, '{{ command['.name'] }}')">{{ _('Link') }}</button>
+							<button class="cbi-button cbi-button-link" data-action="link" data-cmd="{{ command['.name'] }}">{{ _('Link') }}</button>
 						{% endif %}
 					</div>
 				</div>

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -430,6 +430,43 @@ function cbi_init() {
 	});
 
 	Promise.all(tasks).then(cbi_d_update);
+
+	document.querySelectorAll('.cbi-section-create-name').forEach(function(input) {
+		input.addEventListener('keyup', function() { cbi_validate_named_section_add(this); });
+	});
+
+	document.querySelectorAll('.cbi-cidr-toggle').forEach(function(btn) {
+		btn.addEventListener('click', switchToCIDRList);
+	});
+
+	document.querySelectorAll('[data-href]').forEach(function(btn) {
+		btn.addEventListener('click', function() { location.href = this.dataset.href; });
+	});
+
+	document.querySelectorAll('[data-cbi-submit]').forEach(function(btn) {
+		btn.addEventListener('click', function() { cbi_submit(this, this.dataset.cbiSubmit); });
+	});
+
+	document.querySelectorAll('[data-cbi-state]').forEach(function(btn) {
+		btn.addEventListener('click', function() { this.form.cbi_state = this.dataset.cbiState; });
+	});
+
+	document.querySelectorAll('[data-cbi-rowswap]').forEach(function(btn) {
+		btn.addEventListener('click', function(ev) {
+			ev.preventDefault();
+			cbi_row_swap(this, this.dataset.cbiRowswap === 'up', this.dataset.cbiSortstore);
+		});
+	});
+
+	const cbiForm = document.querySelector('form[name="cbi"]');
+	if (cbiForm) {
+		const errMsg = cbiForm.dataset.errorMsg;
+		cbiForm.addEventListener('reset', function() { cbi_validate_reset(cbiForm); });
+		cbiForm.addEventListener('submit', function(ev) {
+			if (!cbi_validate_form(cbiForm, errMsg))
+				ev.preventDefault();
+		});
+	}
 }
 
 /**
@@ -631,6 +668,23 @@ function cbi_submit(elem, name, value, action)
 
 	form.submit();
 	return true;
+}
+
+/**
+ * Switch an IP address input from prefix-list notation to CIDR list.
+ * Reads the previous sibling input, sets its _usecidr companion to '1'
+ * and triggers a CBI dependency refresh.
+ * @param {MouseEvent} ev - Click event from the toggle button.
+ */
+function switchToCIDRList(ev)
+{
+	var input = ev.currentTarget.previousElementSibling,
+	    usecidr = document.getElementById(input.id + '_usecidr');
+
+	ev.preventDefault();
+
+	usecidr.value = '1';
+	cbi_d_update();
 }
 
 /**

--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -931,6 +931,8 @@ dispatch = function(_http, path) {
 		let resolved = resolve_page(menu, path);
 
 		runtime.env.ctx = resolved.ctx;
+		resolved.ctx.csp_nonce = randomid(16);
+		http.csp_nonce = resolved.ctx.csp_nonce;
 		runtime.env.dispatched = resolved.node;
 		runtime.env.requested ??= resolved.node;
 

--- a/modules/luci-base/ucode/http.uc
+++ b/modules/luci-base/ucode/http.uc
@@ -513,7 +513,7 @@ const Class = {
 		/* http header plugins */
 		let log_class = 'http.uc';
 		openlog(log_class);
-		for (let plugin_id, p_output in run_plugins('/luci/plugins/http/headers', 'http_headers_enabled')) {
+		for (let plugin_id, p_output in run_plugins('/luci/plugins/http/headers', 'http_headers_enabled', { csp_nonce: this.csp_nonce })) {
 
 			/* header plugins shall return e.g.: ['X-Header', 'foo'] */
 			if (type(p_output) !== 'array' || length(p_output) !== 2)

--- a/modules/luci-base/ucode/luciplugins.uc
+++ b/modules/luci-base/ucode/luciplugins.uc
@@ -12,7 +12,7 @@ import { cursor } from 'uci';
 
 
 /* generic plugin handler */
-export function run_plugins(plugin_class_path, plugin_class_enable) {
+export function run_plugins(plugin_class_path, plugin_class_enable, extra_ctx) {
 	let uci = cursor();
 	const require_path = replace(plugin_class_path, '/', '.');
 
@@ -34,7 +34,7 @@ export function run_plugins(plugin_class_path, plugin_class_enable) {
 				const mod = require(require_path + `.${plugin_id}`);
 				if (type(mod) === 'function') {
 					try {
-						results[plugin_id] = mod(plugin_id);
+						results[plugin_id] = mod(plugin_id, extra_ctx);
 					} catch (e) {
 						syslog(LOG_NOTICE|LOG_LOCAL0,
 							sprintf("Could not execute plugin %s: %s",

--- a/modules/luci-base/ucode/template/csrftoken.ut
+++ b/modules/luci-base/ucode/template/csrftoken.ut
@@ -18,7 +18,13 @@
 <hr />
 
 <p class="right">
-	<strong><a href="#" onclick="window.history.back();">Continue »</a></strong>
+	<strong><a href="#" id="luci-csrf-back">Continue »</a></strong>
 </p>
+<script nonce="{{ ctx?.csp_nonce }}">
+document.getElementById('luci-csrf-back').addEventListener('click', function(ev) {
+	ev.preventDefault();
+	window.history.back();
+});
+</script>
 
 {% include('footer') %}

--- a/modules/luci-base/ucode/template/footer.ut
+++ b/modules/luci-base/ucode/template/footer.ut
@@ -5,7 +5,7 @@
 
 {% const rollback = dispatcher.rollback_pending() %}
 {% if (rollback || trigger_apply || trigger_revert): %}
-	<script>
+	<script nonce="{{ ctx?.csp_nonce }}">
 		document.addEventListener("luci-loaded", function() {
 			{% if (trigger_apply): %}
 				L.ui.changes.apply(true);
@@ -19,7 +19,7 @@
 {% endif %}
 
 {% if (media_error): %}
-	<script>
+	<script nonce="{{ ctx?.csp_nonce }}">
 		L.require('ui').then(function(ui) {
 			ui.showIndicator('media_error', _('Theme fallback'), function(ev) {
 				ui.showModal(_('Error loading theme'), [

--- a/modules/luci-base/ucode/template/header.ut
+++ b/modules/luci-base/ucode/template/header.ut
@@ -8,7 +8,7 @@
 -%}
 
 <script src="{{ resource }}/luci.js?v={# PKG_VERSION #}-{{ pkgs_update_time }}"></script>
-<script>
+<script nonce="{{ ctx?.csp_nonce }}">
 	L = new LuCI({{ replace(`${ {
 		media          : media,
 		resource       : resource,

--- a/modules/luci-base/ucode/template/sysauth.ut
+++ b/modules/luci-base/ucode/template/sysauth.ut
@@ -88,7 +88,7 @@
 	));
 %}
 
-<script>
+<script nonce="{{ ctx?.csp_nonce }}">
 	var input = document.getElementsByName('luci_password')[0];
 
 	if (input)

--- a/modules/luci-base/ucode/template/view.ut
+++ b/modules/luci-base/ucode/template/view.ut
@@ -2,7 +2,7 @@
 
 <div id="view">
 	<div class="spinning">{{ _('Loading view…') }}</div>
-	<script>
+	<script nonce="{{ ctx?.csp_nonce }}">
 		L.require('ui').then(function(ui) {
 			ui.instantiateView('{{ view }}');
 		});

--- a/modules/luci-compat/luasrc/view/cbi/footer.htm
+++ b/modules/luci-compat/luasrc/view/cbi/footer.htm
@@ -11,15 +11,15 @@
 		%><div class="cbi-page-actions"><%
 
 		if display_back then
-			%><input class="btn cbi-button cbi-button-link" type="button" value="<%:Back to Overview%>" onclick="location.href='<%=pcdata(redirect)%>'" /> <%
+			%><input class="btn cbi-button cbi-button-link" type="button" value="<%:Back to Overview%>" data-href="<%=pcdata(redirect)%>" /> <%
 		end
 
 		if display_skip then
-			%><input class="btn cbi-button cbi-button-skip" type="button" value="<%:Skip%>" onclick="cbi_submit(this, 'cbi.skip')" /> <%
+			%><input class="btn cbi-button cbi-button-skip" type="button" value="<%:Skip%>" data-cbi-submit="cbi.skip" /> <%
 		end
 
 		if display_apply then
-			%><input class="btn cbi-button cbi-button-apply" type="button" value="<%:Save & Apply%>" onclick="cbi_submit(this, 'cbi.apply')"<%=ifattr(not writable, "disabled")%> /> <%
+			%><input class="btn cbi-button cbi-button-apply" type="button" value="<%:Save & Apply%>" data-cbi-submit="cbi.apply"<%=ifattr(not writable, "disabled")%> /> <%
 		end
 
 		if display_save then
@@ -27,7 +27,7 @@
 		end
 
 		if display_reset then
-			%><input class="btn cbi-button cbi-button-reset" type="button" value="<%:Reset%>" onclick="location.href='<%=REQUEST_URI%>'"<%=ifattr(not writable, "disabled")%> /> <%
+			%><input class="btn cbi-button cbi-button-reset" type="button" value="<%:Reset%>" data-href="<%=REQUEST_URI%>"<%=ifattr(not writable, "disabled")%> /> <%
 		end
 
 		%></div><%
@@ -36,6 +36,6 @@
 
 </form>
 
-<script>cbi_init();</script>
+<script nonce="<%=csp_nonce%>">cbi_init();</script>
 
 <%+footer%>

--- a/modules/luci-compat/luasrc/view/cbi/header.htm
+++ b/modules/luci-compat/luasrc/view/cbi/header.htm
@@ -2,7 +2,7 @@
 
 <% local has_writeable_map = false %>
 
-<form method="post" name="cbi" action="<%=REQUEST_URI%>" enctype="multipart/form-data" onreset="return cbi_validate_reset(this)" onsubmit="return cbi_validate_form(this, '<%:Some fields are invalid, cannot save values!%>')"<%=
+<form method="post" name="cbi" action="<%=REQUEST_URI%>" enctype="multipart/form-data"<%=
 	attr("data-strings", luci.util.serialize_json({
 		label = {
 			choose = translate('-- Please choose --'),
@@ -13,6 +13,7 @@
 			browser  = url("admin/filebrowser")
 		}
 	}))
+	.. attr("data-error-msg", translate("Some fields are invalid, cannot save values!"))
 %>>
 	<div>
 		<input type="hidden" name="token" value="<%=token%>" />

--- a/modules/luci-compat/luasrc/view/cbi/ipaddr.htm
+++ b/modules/luci-compat/luasrc/view/cbi/ipaddr.htm
@@ -1,15 +1,4 @@
 <%+cbi/valueheader%>
-	<script>
-		function switchToCIDRList(ev) {
-			var input = ev.target.previousElementSibling,
-			    usecidr = document.getElementById(input.id + '_usecidr');
-
-			ev.preventDefault();
-
-			usecidr.value = '1';
-			cbi_d_update();
-		}
-	</script>
 	<input data-update="change"<%=
 		attr("id", cbid) ..
 		attr("name", cbid) ..
@@ -23,5 +12,5 @@
 		ifattr(self.combobox_manual, "data-manual", self.combobox_manual) ..
 		ifattr(#self.keylist > 0, "data-choices", { self.keylist, self.vallist })
 	%> /><!--
-	--><button class="btn cbi-button cbi-button-neutral" title="<%:Switch to CIDR list notation%>" aria-label="<%:Switch to CIDR list notation%>" onclick="switchToCIDRList(event)">…</button>
+	--><button class="btn cbi-button cbi-button-neutral cbi-cidr-toggle" title="<%:Switch to CIDR list notation%>" aria-label="<%:Switch to CIDR list notation%>">…</button>
 <%+cbi/valuefooter%>

--- a/modules/luci-compat/luasrc/view/cbi/simpleform.htm
+++ b/modules/luci-compat/luasrc/view/cbi/simpleform.htm
@@ -45,16 +45,16 @@
 			%><div class="cbi-page-actions"><%
 
 			if display_back then
-				%><input class="btn cbi-button cbi-button-link" type="button" value="<%:Back to Overview%>" onclick="location.href='<%=pcdata(redirect)%>'" /> <%
+				%><input class="btn cbi-button cbi-button-link" type="button" value="<%:Back to Overview%>" data-href="<%=pcdata(redirect)%>" /> <%
 			end
 
 			if display_cancel then
 				local label = pcdata(self.cancel or translate("Cancel"))
-				%><input class="btn cbi-button cbi-button-link" type="button" value="<%=label%>" onclick="cbi_submit(this, 'cbi.cancel')" /> <%
+				%><input class="btn cbi-button cbi-button-link" type="button" value="<%=label%>" data-cbi-submit="cbi.cancel" /> <%
 			end
 
 			if display_skip then
-				%><input class="btn cbi-button cbi-button-neutral" type="button" value="<%:Skip%>" onclick="cbi_submit(this, 'cbi.skip')" /> <%
+				%><input class="btn cbi-button cbi-button-neutral" type="button" value="<%:Skip%>" data-cbi-submit="cbi.skip" /> <%
 			end
 
 			if display_submit then
@@ -74,4 +74,4 @@
 	end
 %>
 
-<script>cbi_init();</script>
+<script nonce="<%=csp_nonce%>">cbi_init();</script>

--- a/modules/luci-compat/luasrc/view/cbi/tblsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tblsection.htm
@@ -148,18 +148,18 @@ end
 				<td class="td cbi-section-table-cell nowrap cbi-section-actions">
 					<div>
 						<%- if self.sortable then -%>
-							<input class="btn cbi-button cbi-button-up" type="button" value="<%:Up%>" onclick="return cbi_row_swap(this, true, 'cbi.sts.<%=self.config%>.<%=self.sectiontype%>')" title="<%:Move up%>" />
-							<input class="btn cbi-button cbi-button-down" type="button" value="<%:Down%>" onclick="return cbi_row_swap(this, false, 'cbi.sts.<%=self.config%>.<%=self.sectiontype%>')" title="<%:Move down%>" />
+							<input class="btn cbi-button cbi-button-up" type="button" value="<%:Up%>" data-cbi-rowswap="up" data-cbi-sortstore="cbi.sts.<%=self.config%>.<%=self.sectiontype%>" title="<%:Move up%>" />
+							<input class="btn cbi-button cbi-button-down" type="button" value="<%:Down%>" data-cbi-rowswap="down" data-cbi-sortstore="cbi.sts.<%=self.config%>.<%=self.sectiontype%>" title="<%:Move down%>" />
 						<% end; if self.extedit then -%>
 							<input class="btn cbi-button cbi-button-edit" type="button" value="<%:Edit%>"
 							<%- if type(self.extedit) == "string" then
-							%> onclick="location.href='<%=self.extedit:format(section)%>'"
+							%> data-href="<%=self.extedit:format(section)%>"
 							<%- elseif type(self.extedit) == "function" then
-							%> onclick="location.href='<%=self:extedit(section)%>'"
+							%> data-href="<%=self:extedit(section)%>"
 							<%- end
 							%> alt="<%:Edit%>" title="<%:Edit%>" />
 						<% end; if self.addremove then %>
-							<input class="btn cbi-button cbi-button-remove" type="submit" value="<%:Delete%>"  onclick="this.form.cbi_state='del-section'; return true" name="cbi.rts.<%=self.config%>.<%=k%>" alt="<%:Delete%>" title="<%:Delete%>" />
+							<input class="btn cbi-button cbi-button-remove" type="submit" value="<%:Delete%>" data-cbi-state="del-section" name="cbi.rts.<%=self.config%>.<%=k%>" alt="<%:Delete%>" title="<%:Delete%>" />
 						<%- end -%>
 					</div>
 				</td>
@@ -192,9 +192,9 @@ end
 					<div class="cbi-section-error"><%:Invalid%></div>
 				<%- end %>
 				<div>
-					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="true" onkeyup="cbi_validate_named_section_add(this)"/>
+					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="true" />
 				</div>
-				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" disabled="" />
+				<input class="btn cbi-button cbi-button-add" type="submit" data-cbi-state="add-section" value="<%:Add%>" title="<%:Add%>" disabled="" />
 			<% end %>
 		</div>
 		<%- end %>

--- a/modules/luci-compat/luasrc/view/cbi/tsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tsection.htm
@@ -13,7 +13,7 @@
 	<% local isempty = true for i, k in ipairs(self:cfgsections()) do -%>
 		<% if self.addremove then -%>
 			<div class="cbi-section-remove right">
-				<input type="submit" name="cbi.rts.<%=self.config%>.<%=k%>" onclick="this.form.cbi_state='del-section'; return true" value="<%:Delete%>" class="btn cbi-button" />
+				<input type="submit" name="cbi.rts.<%=self.config%>.<%=k%>" data-cbi-state="del-section" value="<%:Delete%>" class="btn cbi-button" />
 			</div>
 		<%- end %>
 
@@ -42,9 +42,9 @@
 					<div class="cbi-section-error"><%:Invalid%></div>
 				<%- end %>
 				<div>
-					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="true" onkeyup="cbi_validate_named_section_add(this)"/>
+					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="true" />
 				</div>
-				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" disabled=""/>
+				<input class="btn cbi-button cbi-button-add" type="submit" data-cbi-state="add-section" value="<%:Add%>" title="<%:Add%>" disabled=""/>
 			<%- end %>
 		</div>
 		<%- end %>

--- a/modules/luci-compat/luasrc/view/cbi/wireless_modefreq.htm
+++ b/modules/luci-compat/luasrc/view/cbi/wireless_modefreq.htm
@@ -1,6 +1,6 @@
 <%+cbi/valueheader%>
 
-<script>
+<script nonce="<%=csp_nonce%>">
 	var freqlist = <%= luci.http.write_json(self.iwinfo.freqlist) %>;
 	var hwmodes  = <%= luci.http.write_json(self.iwinfo.hwmodelist or {}) %>;
 	var htmodes  = <%= luci.http.write_json(self.iwinfo.htmodelist) %>;
@@ -180,11 +180,11 @@
 
 <label style="float:left; margin-right:3px">
 	<%:Mode%><br />
-	<select style="width:auto" id="<%= cbid %>.mode" name="<%= cbid %>.mode" onchange="cbi_toggle_wifi_mode('<%= cbid %>')"></select>
+	<select style="width:auto" id="<%= cbid %>.mode" name="<%= cbid %>.mode"></select>
 </label>
 <label style="float:left; margin-right:3px">
 	<%:Band%><br />
-	<select style="width:auto" id="<%= cbid %>.band" name="<%= cbid %>.band" onchange="cbi_toggle_wifi_band('<%= cbid %>')"></select>
+	<select style="width:auto" id="<%= cbid %>.band" name="<%= cbid %>.band"></select>
 </label>
 <label style="float:left; margin-right:3px">
 	<%:Channel%><br />
@@ -196,6 +196,10 @@
 </label>
 <br style="clear:left" />
 
-<script>cbi_init_wifi('<%= cbid %>');</script>
+<script nonce="<%=csp_nonce%>">
+cbi_init_wifi('<%= cbid %>');
+document.getElementById('<%= cbid %>.mode').addEventListener('change', function() { cbi_toggle_wifi_mode('<%= cbid %>'); });
+document.getElementById('<%= cbid %>.band').addEventListener('change', function() { cbi_toggle_wifi_band('<%= cbid %>'); });
+</script>
 
 <%+cbi/valuefooter%>

--- a/modules/luci-lua-runtime/luasrc/template.lua
+++ b/modules/luci-lua-runtime/luasrc/template.lua
@@ -116,6 +116,8 @@ context.viewns = setmetatable({
 		return table.concat(url, "")
 	elseif key == "token" then
 		return disp.context.authtoken
+	elseif key == "csp_nonce" then
+		return disp.context.csp_nonce
 	elseif key == "theme" then
 		return L.media and fs.basename(L.media) or tostring(L)
 	elseif key == "resource" then

--- a/plugins/luci-plugin-csp/ucode/plugins/http/headers/c0ffee2cf63e160c091224d95d69cdff.uc
+++ b/plugins/luci-plugin-csp/ucode/plugins/http/headers/c0ffee2cf63e160c091224d95d69cdff.uc
@@ -1,29 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
-
 'use strict';
-
 import { cursor } from 'uci';
-
-function default_action(plugin_id) {
+function default_action(plugin_id, extra_ctx) {
 	const uci = cursor();
 	const mode = uci.get('luci_plugins', plugin_id, 'mode') || 'strict';
-
+	const nonce = extra_ctx?.csp_nonce ? `'nonce-${extra_ctx.csp_nonce}'` : "'unsafe-inline'";
 	const presets = {
-		'strict': "default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'trusted-types-eval'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://sysupgrade.openwrt.org;",
-		'permissive': "default-src 'self' https://*; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'trusted-types-eval'; img-src 'self' data: blob: https://*; style-src 'self' 'unsafe-inline' https://*;",
+		'strict': `default-src 'none'; script-src 'self' ${nonce} 'unsafe-eval' 'trusted-types-eval'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://sysupgrade.openwrt.org;`,
+		'permissive': `default-src 'self' https://*; script-src 'self' ${nonce} 'unsafe-eval' 'trusted-types-eval'; img-src 'self' data: blob: https://*; style-src 'self' 'unsafe-inline' https://*;`,
 	};
-
 	let policy;
-
 	if (mode === 'custom')
 		policy = uci.get('luci_plugins', plugin_id, 'policy');
 	else
 		policy = presets[mode];
-
 	if (!policy)
 		return null;
-
 	return ['Content-Security-Policy', policy];
 }
-
 return default_action;

--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/footer.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/footer.ut
@@ -14,7 +14,7 @@
 			</span>
 			<ul class="breadcrumb pull-right" id="modemenu" style="display:none"></ul>
 		</footer>
-		<script>L.require('menu-bootstrap')</script>
+		<script nonce="{{ ctx?.csp_nonce }}">L.require('menu-bootstrap')</script>
 		{% endif %}
 	</body>
 </html>

--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -20,7 +20,7 @@
 		<meta charset="utf-8">
 		<title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>
 		{% if (!darkpref): %}
-			<script>
+			<script nonce="{{ ctx?.csp_nonce }}">
 				var mediaQuery = window.matchMedia('(prefers-color-scheme: dark)'),
 				    rootElement = document.querySelector(':root'),
 				    setDarkMode = function(match) { rootElement.setAttribute('data-darkmode', match.matches) };

--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/sysauth.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/sysauth.ut
@@ -74,7 +74,7 @@
 
 <div id="view">
 	<div class="spinning">{{ _('Loading view…') }}</div>
-	<script>
+	<script nonce="{{ ctx?.csp_nonce }}">
 		L.require('ui').then(function(ui) {
 			ui.instantiateView('bootstrap.sysauth');
 		});

--- a/themes/luci-theme-material/ucode/template/themes/material/footer.ut
+++ b/themes/luci-theme-material/ucode/template/themes/material/footer.ut
@@ -26,7 +26,7 @@
 		</div>
 	</div>
 
-	<script>L.require('menu-material')</script>
+	<script nonce="{{ ctx?.csp_nonce }}">L.require('menu-material')</script>
 
 </body>
 </html>

--- a/themes/luci-theme-material/ucode/template/themes/material/header.ut
+++ b/themes/luci-theme-material/ucode/template/themes/material/header.ut
@@ -32,7 +32,7 @@
 <head>
 <meta charset="utf-8">
 {% if (!darkpref): %}
-<script>
+<script nonce="{{ ctx?.csp_nonce }}">
 	var mediaQuery = window.matchMedia('(prefers-color-scheme: dark)'),
 	    rootElement = document.querySelector(':root'),
 	    setDarkMode = function(match) { rootElement.setAttribute('data-darkmode', match.matches) };

--- a/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/footer.ut
+++ b/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/footer.ut
@@ -10,7 +10,7 @@
 	Powered by {{ version.luciname }} ({{ version.luciversion }})
 </p>
 
-<script>L.require('menu-openwrt2020')</script>
+<script nonce="{{ ctx?.csp_nonce }}">L.require('menu-openwrt2020')</script>
 
 </body>
 </html>

--- a/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/footer.ut
+++ b/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/footer.ut
@@ -12,7 +12,7 @@
 	Powered by {{ version.luciname }} ({{ version.luciversion }})
 </p>
 
-<script>L.require('menu-openwrt')</script>
+<script nonce="{{ ctx?.csp_nonce }}">L.require('menu-openwrt')</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Pull request details

### Description
The CSP plugin (`luci-plugin-csp`) used `'unsafe-inline'` in `script-src`
because there was no mechanism to pass a per-request nonce to http header
plugins. This adds that mechanism across the stack with minimal changes.

`dispatcher.uc`: generate a per-request nonce via `randomid(16)` and store
it in `ctx.csp_nonce` (available in templates via `runtime.env`) and
`http.csp_nonce` (available in `write_headers()`).

`luciplugins.uc`: extend `run_plugins()` with an optional `extra_ctx` arg
forwarded to each plugin — backward compatible, existing plugins ignore it.

`http.uc`: pass `{ csp_nonce: this.csp_nonce }` into `run_plugins()` from
`write_headers()`.

Core `.ut` templates and all themes: add `nonce="{{ ctx?.csp_nonce }}"` to
inline `<script>` tags.

`luci-plugin-csp`: use `'nonce-${nonce}'` instead of `'unsafe-inline'` when
a nonce is available, falling back to `'unsafe-inline'` for backwards
compatibility.

Follows up on the discussion in #8785.

---

### Follow-up: inline event handler migration

Addressed the reviewer note that CSP2+ browsers ignore `'unsafe-inline'` in
`script-src` once a nonce is present, meaning inline event attributes
(`onclick`, `onsubmit`, `onreset`, `onkeyup`, `onchange`) and `javascript:`
URIs are blocked even when `<script>` elements are nonce-gated.

**`luci-base` / `cbi.js`**: extended `cbi_init()` to wire up all affected
handler patterns declaratively via `data-*` attributes:
`[data-href]`, `[data-cbi-submit]`, `[data-cbi-state]`, `[data-cbi-rowswap]`,
`.cbi-section-create-name` (keyup), `.cbi-cidr-toggle` (click), and
`form[name="cbi"]` submit/reset validation (error message read from
`data-error-msg`). Also moved `switchToCIDRList()` from `ipaddr.htm` into
`cbi.js`.

**`luci-lua-runtime` / `template.lua`**: exposed `csp_nonce` as a named key
in the Lua template viewns (same pattern as `token` and `REQUEST_URI`),
making it accessible as a plain variable in legacy CBI `.htm` templates.

**`luci-compat`**: removed all inline event attributes from `header.htm`,
`footer.htm`, `simpleform.htm`, `tblsection.htm`, `tsection.htm`,
`ipaddr.htm`, and `wireless_modefreq.htm`. Replaced with `data-*` attributes
handled by `cbi_init()`. Added `nonce="<%=csp_nonce%>"` to all inline
`<script>` blocks.

**`luci-app-commands`**: added `nonce="{{ ctx?.csp_nonce }}"` to the inline
`<script>` block; replaced `onclick` on Run/Download/Link buttons with
`data-action`/`data-cmd` attributes dispatched via a `DOMContentLoaded`
listener inside the nonce'd script.

---

### Maintainer _(preferred)_
@jow-

---

## Tested on
Verified by code inspection.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] _(Optional)_ Includes what Issue it closes — follows up on #8785.