### PR TITLE
luci-mod-network: Add WPA3-Personal Compatibility Mode

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -295,6 +295,30 @@ function add_dependency_permutations(o, deps) {
 	res.forEach(dep => o.depends(dep));
 }
 
+// Default gcmp256/sae_ext_key like the wifi-scripts backend: on only for
+// WPA3-Personal Compatibility Mode (sae-compat) on an EHT (Wi-Fi 7) radio, off
+// otherwise. htmode is a radio property, not a wifi-iface one, so it cannot be a
+// same-section o.defaults dependency. Read the currently selected htmode from the
+// radio's frequency/width widget so the default reacts to changes made in the
+// same modal, and only fall back to the saved config if that widget is not
+// available. On EHT the base updateDefaultValue picks the default from the
+// encryption mode (sae-compat -> on, sae/sae-mixed -> off); otherwise force off.
+// Both paths go through the base method so the checkbox is updated reactively.
+function eht_compat_default(section_id) {
+	const dev = uci.get('wireless', section_id, 'device');
+	let htmode = dev ? uci.get('wireless', dev, 'htmode') : null;
+
+	const freq = dev ? this.map.lookupOption('_freq', dev) : null;
+	if (freq)
+		htmode = freq[0].formvalue(dev)?.[0] ?? htmode;
+
+	this.defaults = (htmode && htmode.match(/^EHT/))
+		? { '1': [{ encryption: 'sae-compat' }], '0': [{ encryption: 'sae' }, { encryption: 'sae-mixed' }] }
+		: { '0': [] };
+
+	return form.Flag.prototype.updateDefaultValue.call(this, section_id);
+}
+
 // Define a class CBIWifiFrequencyValue that extends form.Value
 var CBIWifiFrequencyValue = form.Value.extend({
 	// Declare an RPC method to get the frequency list for a given device
@@ -2156,6 +2180,22 @@ return view.extend({
 
 						o = ss.taboption('encryption', form.Flag, 'wpa_disable_eapol_key_retries', _('Enable key reinstallation (KRACK) countermeasures'), _('Complicates key reinstallation attacks on the client side by disabling retransmission of EAPOL-Key frames that are used to install keys. This workaround might cause interoperability issues and reduced robustness of key negotiation especially in environments with heavy traffic load.'));
 						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed', 'sae-compat', 'wpa2', 'wpa3', 'wpa3-mixed'] });
+
+						o = ss.taboption('encryption', form.Flag, 'gcmp256', _('GCMP-256 pairwise cipher'), _('Advertise the GCMP-256 pairwise cipher. Mandatory for Wi-Fi 7 (EHT) and recommended otherwise, but some clients and chipsets fail to associate when it is offered. Enabled by default only in Compatibility Mode on a Wi-Fi 7 (EHT) radio, disabled otherwise.'));
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['sae', 'sae-mixed', 'sae-compat'] });
+						o.updateDefaultValue = eht_compat_default;
+
+						o = ss.taboption('encryption', form.Flag, 'sae_ext_key', _('SAE-EXT-KEY (SAE-GDH)'), _('Advertise the SAE-EXT-KEY AKM (SAE using a group-dependent hash). Mandatory for Wi-Fi 7 (EHT) and recommended otherwise, but some clients misbehave when it is offered, in particular together with 802.11r Fast Transition. Enabled by default only in Compatibility Mode on a Wi-Fi 7 (EHT) radio, disabled otherwise.'));
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['sae', 'sae-mixed', 'sae-compat'] });
+						o.updateDefaultValue = eht_compat_default;
+
+						o = ss.taboption('encryption', form.Flag, 'transition_disable', _('Transition Disable'), _('Signal Transition Disable (WPA3 Specification v3.5 section 13) so that a client which has connected once no longer downgrades to a weaker security mode for this SSID. The advertised bitmap is derived from the encryption mode.'));
+						o.enabled = 'on';
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['sae', 'wpa3', 'wpa3-192', 'owe'] });
+						o.cfgvalue = function(section_id) {
+							const v = L.toArray(uci.get('wireless', section_id, 'transition_disable'))[0];
+							return (v && v != 'off' && v != '0') ? 'on' : '0';
+						};
 
 						if (L.hasSystemFeature('hostapd', 'wps') && L.hasSystemFeature('wpasupplicant')) {
 							o = ss.taboption('encryption', form.Flag, 'wps_pushbutton', _('Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE'));

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1375,6 +1375,10 @@ return view.extend({
 						crypto_modes.push(['sae-mixed', 'WPA2-PSK/WPA3-SAE Mixed Mode', 30]);
 					}
 
+					// WPA3-Personal Compatibility Mode uses RSN overriding, which is an AP-only feature
+					if (has_ap_sae)
+						crypto_modes.push(['sae-compat', 'WPA2-PSK/WPA3-SAE Compatibility Mode', 30]);
+
 					if (has_ap_wep || has_sta_wep) {
 						crypto_modes.push(['wep-open',   _('WEP Open System'), 11]);
 						crypto_modes.push(['wep-shared', _('WEP Shared Key'),  10]);
@@ -1404,6 +1408,7 @@ return view.extend({
 							'psk-mixed': has_hostapd || _('Requires hostapd'),
 							'sae': has_ap_sae || _('Requires hostapd with SAE support'),
 							'sae-mixed': has_ap_sae || _('Requires hostapd with SAE support'),
+							'sae-compat': has_ap_sae || _('Requires hostapd with SAE support'),
 							'wpa': has_ap_eap || _('Requires hostapd with EAP support'),
 							'wpa2': has_ap_eap || _('Requires hostapd with EAP support'),
 							'wpa3': has_ap_eap192 || _('Requires hostapd with EAP Suite-B support'),
@@ -1813,6 +1818,7 @@ return view.extend({
 				add_dependency_permutations(o, { mode: ['sta', 'adhoc', 'mesh', 'sta-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'] });
 				o.depends('encryption', 'sae');
 				o.depends('encryption', 'sae-mixed');
+				o.depends('encryption', 'sae-compat');
 				o.datatype = 'wpakey';
 				o.rmempty = true;
 				o.password = true;
@@ -1871,7 +1877,7 @@ return view.extend({
 					o = ss.taboption('roaming', form.Flag, 'ieee80211r', _('802.11r Fast Transition'), _('Enables fast roaming among access points that belong to the same Mobility Domain'));
 					add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
 					if (has_80211r)
-						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed'] });
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed', 'sae-compat'] });
 					o.rmempty = true;
 
 					o = ss.taboption('roaming', form.Value, 'nasid', _('NAS ID'), _('Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not needed with normal WPA(2)-PSK.'));
@@ -2149,7 +2155,7 @@ return view.extend({
 						}
 
 						o = ss.taboption('encryption', form.Flag, 'wpa_disable_eapol_key_retries', _('Enable key reinstallation (KRACK) countermeasures'), _('Complicates key reinstallation attacks on the client side by disabling retransmission of EAPOL-Key frames that are used to install keys. This workaround might cause interoperability issues and reduced robustness of key negotiation especially in environments with heavy traffic load.'));
-						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed', 'wpa2', 'wpa3', 'wpa3-mixed'] });
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed', 'sae-compat', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 
 						if (L.hasSystemFeature('hostapd', 'wps') && L.hasSystemFeature('wpasupplicant')) {
 							o = ss.taboption('encryption', form.Flag, 'wps_pushbutton', _('Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE'));
@@ -2161,6 +2167,7 @@ return view.extend({
 							o.depends('encryption', 'psk-mixed');
 							o.depends('encryption', 'sae');
 							o.depends('encryption', 'sae-mixed');
+							o.depends('encryption', 'sae-compat');
 						}
 					}
 				}


### PR DESCRIPTION
## Pull request details

### Description

 * luci-mod-network: wireless: add WPA3-Personal Compatibility Mode
    
    Expose the sae-compat encryption mode (WPA3-Personal Compatibility Mode)
    in the wireless security settings. It advertises WPA2-PSK in the base
    RSNE while offering SAE through RSN Override elements, so that both
    legacy WPA2 and modern WPA3 clients can connect to a single SSID.
    
    The mode relies on RSN overriding, which is an access-point feature, so
    it is offered for AP mode only. It gets the passphrase field and, like
    the other WPA2/WPA3 modes, the 802.11r, KRACK-countermeasure and WPS
    options.
    
 * luci-mod-network: wireless: add gcmp256, sae_ext_key, transition_disable
    
    Expose three per-BSS WPA3 tuning options in the wireless security tab:
    
     - gcmp256: advertise the GCMP-256 pairwise cipher
     - sae_ext_key: advertise the SAE-EXT-KEY AKM (SAE using a group-dependent
       hash, aka SAE-GDH)
     - transition_disable: signal Transition Disable (WPA3 Specification v3.5
       section 13) so a client that connected once no longer downgrades
    
    GCMP-256 and SAE-EXT-KEY are mandatory for Wi-Fi 7 (EHT) but break
    interoperability with some clients. The wifi-scripts backend therefore
    defaults them on only for WPA3-Personal Compatibility Mode (sae-compat)
    on an EHT radio, and off everywhere else. The gcmp256/sae_ext_key
    checkboxes mirror that default, derived from both the encryption mode and
    the radio htmode, so the box shows the real default: leaving it untouched
    keeps the option unset (the backend decides), while toggling it writes an
    explicit override. As htmode is a radio property, not a wifi-iface one,
    it is read from the current selection of the radio's frequency widget
    (falling back to the saved config) instead of a same-section dependency.
    
    transition_disable is offered only for the WPA3-only modes where the
    signalled bitmap is non-empty.
    
This depends on https://github.com/openwrt/openwrt/pull/24041

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12-SNAPSHOT r33058+16-949e61ec65 
**LuCI version:** LuCI wifi-wpa3-compat-mode-25.12 branch 26.155.67407~06be235
**Web browser(s):** firefox

---
