### PR TITLE
luci-app-lxc: fix stale sibling check in action_more_handler

### DIFF
--- a/applications/luci-app-lxc/htdocs/luci-static/resources/view/lxc/overview.js
+++ b/applications/luci-app-lxc/htdocs/luci-static/resources/view/lxc/overview.js
@@ -218,7 +218,7 @@ return L.view.extend({
 
 			switch(option) {
 				case 'configure':
-					if (next_div && next_div.dataset['action'] !== null) {
+					if (next_div && next_div.dataset['action'] !== undefined) {
 						div1.parentNode.removeChild(next_div);
 					}
 


### PR DESCRIPTION
## Pull request details

### Description
`element.dataset` never returns `null` — per the `HTMLElement.dataset` spec it reads a `data-*` attribute as a string when present, or `undefined` when absent. So `next_div.dataset['action'] !== null` in `action_more_handler()` was always true, regardless of whether the sibling actually had the marker.

The check was meant to detect the previously-opened configuration panel (marked a few lines below via `div0.setAttribute('data-action', '')`) before removing it and inserting a fresh one. Because the comparison was a tautology, selecting "configure" removed *any* next sibling row unconditionally — including an unrelated container's row, not just a stale config panel.

Fix: compare against `undefined` instead, so the removal only fires when the next sibling is actually the marked panel.

Found while auditing this file for inline-handler removal ahead of enabling nonce-based CSP (`luci-plugin-csp`); unrelated to that change, so filed as a standalone fix.

### Maintainer _(preferred)_
@systemcrash

---

## Tested on
Verified by code inspection: confirmed `HTMLElement.dataset` returns `undefined` (never `null`) for a missing attribute per MDN/spec, so the old `!== null` check could never be false.

Manual repro for anyone testing on a device:
1. Create at least two containers so two rows exist in the container list.
2. On the first row, open the "more" dropdown and select "configure" — a config editor panel is inserted right below that row.
3. Before this fix: the second container's row (the one now pushed below the new panel) gets removed from the DOM. After this fix: it stays untouched.
4. Click "configure" again on the same container — the old editor panel is still correctly replaced by a new one, confirming the intended replace-panel path still works.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
