### PR TITLE
luci-app-nut: USB HID UPS update and remove unneeded param

### DIFF
--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -111,10 +111,6 @@ return view.extend({
 		o = s.option(form.Value, 'chroot', _('chroot'), _('Run drivers in a chroot(2) environment'));
 		o.optional = true;
 
-		o = s.option(form.Value, 'driverpath', _('Driver Path'), _('Path to drivers (instead of default)'));
-		o.optional = true;
-		o.placeholder = '/lib/lnut';
-
 		o = s.option(form.Value, 'maxstartdelay', _('Maximum Start Delay'), _('Default for UPSes without this field.'));
 		o.optional = true;
 		o.datatype = 'uinteger';

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -140,6 +140,27 @@ return view.extend({
 		s.addremove = true;
 		s.anonymous = false;
 
+		o = s.option(form.ListValue, 'driver', _('Driver'),
+			_('If this list is empty you need to %s'.format('<a href="/cgi-bin/luci/admin/system/package-manager?query=nut-driver-">%s</a>'.format(_('install drivers')))));
+		driver_list.forEach(driver => {
+			o.value(driver);
+		});
+		o.optional = false;
+
+		o = s.option(form.Value, 'productid', _('USB Product Id'), _('For USB HID based UPSes, USB Product Id is required for NUT to set permissions so the driver can access the UPS'));
+		o.optional = true;
+
+		o = s.option(form.Value, 'vendorid', _('USB Vendor Id'), _('For USB HID based UPSes, USB Vendor Id is required for NUT to set permissions so the driver can access the UPS'));
+		o.optional = true;
+
+		o = s.option(form.Value, 'serial', _('Serial Number'), _('For USB HID based UPSes, allows use of multiple USB devices of the same type (USB product and USB vendor are identical). Other UPSes may also use this value.'));
+		o.optional = true;
+
+		o = s.option(form.Flag, 'enable_usb_serial', _('Set USB serial port permissions'),
+			_('Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) group read-write as user %s'.format('<code>nut</code>')));
+		o.optional = true;
+		o.default = false;
+
 		o = s.option(form.Value, 'bus', _('USB Bus(es) (regex)'));
 		o.optional = true;
 		o.datatype = 'uinteger';
@@ -150,18 +171,6 @@ return view.extend({
 
 		o = s.option(form.Value, 'desc', _('Description (Display)'), _('This is passed through to the driver, so make sure your driver supports this option'));
 		o.optional = true;
-
-		o = s.option(form.ListValue, 'driver', _('Driver'),
-			_('If this list is empty you need to %s'.format('<a href="/cgi-bin/luci/admin/system/package-manager?query=nut-driver-">%s</a>'.format(_('install drivers')))));
-		driver_list.forEach(driver => {
-			o.value(driver);
-		});
-		o.optional = false;
-
-		o = s.option(form.Flag, 'enable_usb_serial', _('Set USB serial port permissions'),
-			_('Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) group read-write as user %s'.format('<code>nut</code>')));
-		o.optional = true;
-		o.default = false;
 
 		o = s.option(form.Flag, 'ignorelb', _('Ignore Low Battery'));
 		o.optional = true;
@@ -228,17 +237,11 @@ return view.extend({
 		o = s.option(form.Value, 'product', _('Product (regex)'));
 		o.optional = true;
 
-		o = s.option(form.Value, 'productid', _('USB Product Id'));
-		o.optional = true;
-
 		o = s.option(form.Value, 'sdorder', _('Driver Shutdown Order'));
 		o.optional = true;
 		o.datatype = 'uinteger';
 
 		o = s.option(form.Value, 'sdtime', _('Additional Shutdown Time(s)'));
-		o.optional = true;
-
-		o = s.option(form.Value, 'serial', _('Serial Number'),  _('This is passed through to the driver, so make sure your driver supports this option'));
 		o.optional = true;
 
 		o = s.option(form.Value, 'snmp_retries', _('SNMP retries'));
@@ -258,9 +261,6 @@ return view.extend({
 		o.placeholder = ''
 
 		o = s.option(form.Value, 'vendor', _('Vendor (regex)'));
-		o.optional = true;
-
-		o = s.option(form.Value, 'vendorid', _('USB Vendor Id'));
 		o.optional = true;
 
 		o = s.option(form.Flag, 'synchronous', _('Synchronous Communication'), _('Driver waits for data to be consumed by upsd before publishing more.'));


### PR DESCRIPTION
## Pull request details

### Description

* update nut_server page for better USB HID UPS experience
  * With https://github.com/openwrt/packages/pull/29607 the NUT package in 
    OpenWrt requires that USB HID UPSes define USB productId and vendorId so the 
    initscript can give the driver(s) permissions to access the UPS. We make 
    this clear on the nut_server configuration page.

* remove spurious driverpath config
  * Making this configurable was never fully implemented in the NUT package,
    and it doesn't make sense for OpenWrt. It is being removed in
    https://github.com/openwrt/packages/pull/29896. Therefore remove it as an
    configurable option, and remove related ACL.

I have separated these commits from the SSL updates as the SSL updates are incomplete and depend on a work in progress PR in openwrt/packages.

### Maintainer
@danielfdickinson @systemcrash 

---

## Tested on
**OpenWrt version:** OpenWrt SNAPSHOT (r35205-97d6719ca7)
**LuCI version:** LuCI Master (26.184.55701~45b3640)
**Web browser(s):** Firefox ESR 140.12.0esr (64-bit)

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
      * Works without, but works better with https://github.com/openwrt/packages/pull/29896

