### PR TITLE
luci-base: protocol/dhcp: add option to disable the DHCPv4 client ID

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
+++ b/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
@@ -34,8 +34,12 @@ return network.registerProtocol('dhcp', {
 		o = s.taboption('advanced', form.Flag, 'broadcast', _('Use broadcast flag'), _('Required for certain ISPs, e.g. Charter with DOCSIS 3'));
 		o.default = o.disabled;
 
+		o = s.taboption('advanced', form.Flag, 'sendclientid', _('Send Client ID'), _('Send the DHCP client identifier (option 61). Disable for ISPs that reject requests containing it'));
+		o.default = o.enabled;
+
 		o = s.taboption('advanced', form.Value, 'clientid', _('Client ID to send when requesting DHCP'));
 		o.datatype  = 'hexstring';
+		o.depends('sendclientid', '1');
 
 		s.taboption('advanced', form.Value, 'vendorid', _('Vendor Class to send when requesting DHCP'));
 	}


### PR DESCRIPTION
## Pull request details

### Description
netifd gained a per-interface "sendclientid" boolean to suppress DHCP option 61 (client identifier), for ISPs that reject requests carrying it (e.g. Turksat KabloNet).

Expose it in the DHCP protocol form as a "Send Client ID" flag, enabled by default. Disabling it writes sendclientid '0', which makes netifd start udhcpc with -C so no client identifier is sent. The explicit "Client ID" field is hidden while sending is disabled.

Reported-at: https://github.com/openwrt/openwrt/issues/24065

This depends on https://github.com/openwrt/openwrt/pull/24087


### Maintainer _(preferred)_
@jow- 

---

## Tested on

**OpenWrt version:** OpenWrt SNAPSHOT r35210+1-8614a2ba68
**LuCI version:** LuCI luci-dhcp-sendclientid branch 26.186.53400~11788e4
**Web browser(s):** Firefox
