### PR TITLE
luci-app-attendedsysupgrade: handle device specific image types

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -160,14 +160,27 @@ return view.extend({
 				return (e.type == 'sysupgrade' || e.type == 'combined');
 			}
 		}
-		return images.filter(filesystemFilter).filter(typeFilter)[0];
+		let candidates = images.filter(filesystemFilter);
+		let image = candidates.filter(typeFilter)[0];
+
+		if (!image) {
+			/* Some devices ship a single image used for both factory
+			 * install and sysupgrade under a device specific type, e.g.
+			 * 'trx' on bcm53xx. Like owut, fall back to the remaining
+			 * non-factory type if it is unambiguous. */
+			let remaining = candidates.filter((e) => !e.type.includes('factory'));
+			if (remaining.length && remaining.every((e) => e.type == remaining[0].type))
+				image = remaining[0];
+		}
+
+		return image;
 	},
 
 	handle200: function (response, content, data, firmware) {
 		response = response.json();
 		let image = this.selectImage(response.images, data, firmware);
 
-		if (image.name != undefined) {
+		if (image) {
 			this.sha256_unsigned = image.sha256_unsigned;
 			let sysupgrade_url = `${data.url}/store/${response.bin_dir}/${image.name}`;
 
@@ -246,6 +259,18 @@ return view.extend({
 			if (data.rebuilder) {
 				this.handleRebuilder(content, data, firmware);
 			}
+		} else {
+			ui.showModal(_('No sysupgrade image found'), [
+				E('p', _('The image builder did not return a usable sysupgrade image for this device (image types: %s).').format(
+					response.images.map((i) => i.type).join(', '))),
+				E('p', [
+					_('Please report this in'), ' ',
+					support_link, '.',
+				]),
+				E('div', { class: 'right' }, [
+					E('div', { class: 'btn', click: ui.hideModal }, _('Close')),
+				]),
+			]);
 		}
 	},
 
@@ -395,7 +420,9 @@ return view.extend({
 							response = response.json();
 							let view = document.getElementById(server);
 							let image = this.selectImage(response.images, data, firmware);
-							if (image.sha256_unsigned == this.sha256_unsigned) {
+							if (!image) {
+								view.innerText = '⚠️ %s'.format(server);
+							} else if (image.sha256_unsigned == this.sha256_unsigned) {
 								view.innerText = '✅ %s'.format(server);
 							} else {
 								view.innerHTML = `⚠️ ${server} (<a href="${server}/store/${


### PR DESCRIPTION
## Pull request details

### Description

Fixes openwrt/luci#8795.

bcm53xx devices publish their single image under a device specific type such as `trx` or `chk` instead of `sysupgrade`, so `selectImage()` came up empty and `handle200()` threw an unhandled TypeError on `image.name`, leaving the "Request firmware image" button silently broken. The same applies to `sdcard` images on tegra.

This mirrors the fallback owut uses in `complete_build_info()`: when no image matches the expected types, drop factory images and accept the remaining type if it is unambiguous. When no usable image is left (some devices only publish factory or kernel images), an error dialog pointing to the support thread is shown instead of failing silently.

### Maintainer _(preferred)_
@efahl

---

## Tested on

Not tested on a device. The new selection logic was run in isolation (node) against the real 25.12.5 `profiles.json` of bcm53xx/generic, x86/64, ath79/generic and tegra/generic, all profiles with and without the EFI flag:

- 762 device/EFI combinations pick the same image as before (no behavior change)
- 62 previously broken combinations now resolve (types `trx`, `chk`, `lxl`, `bin` on bcm53xx, `sdcard` on tegra)
- 6 devices without any usable sysupgrade image now get the error dialog instead of the silent failure

eslint passes on the changed file.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.
- [x] Incremented :up: any `PKG_VERSION` in the Makefile. (no PKG_VERSION in this Makefile, the version comes from luci.mk)
- [x] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).