### PR TITLE
luci-app-strongswan-swanctl: move connection mapping to ucode

### DIFF
--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js
@@ -3,7 +3,14 @@
 'require dom';
 'require poll';
 'require fs';
+'require rpc';
 'require ui';
+
+const callMapConns = rpc.declare({
+	object: 'luci.swanctl',
+	method: 'map-conns',
+	expect: { }
+});
 
 function formatTime(seconds, selectCount) {
 	const days = Math.floor(seconds / (60 * 60 * 24));
@@ -48,36 +55,6 @@ function buildKeyValueTable(kvPairs) {
 	return buildTable(rows);
 }
 
-function mapConnectionSas(conns, sas) {
-	/* map connections to SAs and connection children to SA children */
-	const connMap = new Map();
-	const childConnMap = new Map();
-	conns.forEach(function (connObject) {
-		const [connName, conn] = Object.entries(connObject)[0];
-		connMap.set(connName, conn);
-		Object.entries(conn.children).forEach(function ([childName, child]) {
-			childConnMap.set(childName, child);
-		});
-	});
-
-	sas.forEach(function (saObject) {
-		const [saName, sa] = Object.entries(saObject)[0];
-		const connection = connMap.get(saName);
-		if (connection) {
-			connection.childSa = sa;
-		}
-
-		Object.entries(sa['child-sas']).forEach(function ([childSaName, childSa]) {
-			const childConnection = childConnMap.get(childSaName);
-			if (childConnection) {
-				childConnection.childSa = childSa;
-			}
-		});
-	});
-
-	return conns;
-}
-
 function swanctlCommand(parameters) {
 	return fs.exec('/usr/sbin/swanctl', parameters)
 		.catch(e => ui.addNotification(null, E('p', e.message)));
@@ -99,11 +76,11 @@ function handleChildDown(childName) {
 	return swanctlCommand(['--terminate', '--child', childName]);
 }
 
-function renderDetailsSection(connection, connectionName) {
+function renderDetailsSection(connection) {
 	const sa = connection.sa;
 
 	return buildSection(_('Details'), buildKeyValueTable([
-		[_('Name'), connectionName],
+		[_('Name'), connection.name],
 		[_('Unique ID'), sa ? sa.uniqueid : ''],
 		[_('Local Addresses'), connection.local_addrs.join(', ')],
 		[_('Remote Addresses'), connection.remote_addrs.join(', ')],
@@ -161,7 +138,7 @@ function renderChildTable(children) {
 	];
 
 	Object.entries(children).forEach(([childName, child]) => {
-		const childSa = child.ChildSa;
+		const childSa = child.childSa;
 		const state = childSa ? childSa.state : _('Inactive');
 		const isDown = !childSa;
 
@@ -227,8 +204,8 @@ function filterConnectionAuths(connection, prefix) {
 	return auths.map(([key, value]) => value);
 }
 
-function handleConnectionDetails(connection, connectionName) {
-	const detailSection = renderDetailsSection(connection, connectionName);
+function handleConnectionDetails(connection) {
+	const detailSection = renderDetailsSection(connection);
 	const childTable = renderChildTable(connection.children);
 	const localAuths = filterConnectionAuths(connection, 'local-');
 	const remoteAuths = filterConnectionAuths(connection, 'remote-');
@@ -255,7 +232,7 @@ function handleConnectionDetails(connection, connectionName) {
 	])], 'cbi-modal');
 }
 
-function collectErrorMessages(results) {
+function collectSwanmonErrorMessages(results) {
 	const errorMessages = results.reduce(function (messages, result) {
 		return messages.concat(result.errors.map(function (error) {
 			return error.message;
@@ -271,8 +248,7 @@ return view.extend({
 		return Promise.all([
 			fs.exec_direct('/usr/sbin/swanmon', ['version'], 'json'),
 			fs.exec_direct('/usr/sbin/swanmon', ['stats'], 'json'),
-			fs.exec_direct('/usr/sbin/swanmon', ['list-conns'], 'json'),
-			fs.exec_direct('/usr/sbin/swanmon', ['list-sas'], 'json')
+			callMapConns()
 		]);
 	},
 
@@ -285,10 +261,14 @@ return view.extend({
 	},
 
 	renderContent(results) {
+		const [versionResult, statsResult, connectionResult] = results;
 		const node = E('div', [E('div')]);
 		const firstNode = node.firstElementChild;
 
-		const errorMessages = collectErrorMessages(results);
+		const errorMessages = collectSwanmonErrorMessages([versionResult, statsResult]);
+		if (connectionResult.error)
+			errorMessages.push(connectionResult.error);
+
 		if (errorMessages.length > 0) {
 			const messageEls = errorMessages.map(function (message) {
 				return E('li', message);
@@ -300,7 +280,7 @@ return view.extend({
 			return node;
 		}
 
-		const [version, stats, conns, sas] = results.map(function (r) {
+		const [version, stats, connections] = results.map(function (r) {
 			return r.data;
 		});
 
@@ -314,7 +294,6 @@ return view.extend({
 		]));
 		firstNode.appendChild(overviewSection);
 
-		const connections = mapConnectionSas(conns, sas);
 		const connectionTableRows = [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, _('Name')),
@@ -323,31 +302,30 @@ return view.extend({
 				E('th', { 'class': 'th' }) /* up/down button */
 			])
 		];
-		connections.forEach(function (connectionObject) {
-			const [connectionName, connection] = Object.entries(connectionObject)[0];
+		connections.forEach(function (connection) {
 			const state = connection.sa ? connection.sa.state : _('Inactive');
 			const isDown = !connection.sa;
 
 			connectionTableRows.push(E('tr', { 'class': 'tr' }, [
-				E('td', { 'class': 'td' }, [connectionName]),
+				E('td', { 'class': 'td' }, [connection.name]),
 				E('td', { 'class': 'td' }, [state]),
 				E('td', { 'class': 'td', 'width': '20%' }, [E('button', {
 					'title': _('Details'),
 					'class': 'btn cbi-button cbi-button-primary',
-					'click': ui.createHandlerFn(null, handleConnectionDetails, connection, connectionName)
+					'click': ui.createHandlerFn(null, handleConnectionDetails, connection)
 				}, [_('Details')])]),
 				E('td', { 'class': 'td', 'width': '25%' }, [
 					E('button', {
 						'title': _('Start'),
 						'class': 'btn cbi-button cbi-button-positive',
 						...(isDown ? {} : { 'disabled': 'disabled' }),
-						'click': ui.createHandlerFn(null, handleConnectionUp, connectionName)
+						'click': ui.createHandlerFn(null, handleConnectionUp, connection.name)
 					}, [_('Start')]),
 					E('button', {
 						'title': _('Stop'),
 						'class': 'btn cbi-button cbi-button-negative',
 						...(isDown ? { 'disabled': 'disabled' } : {}),
-						'click': ui.createHandlerFn(null, handleConnectionDown, connectionName)
+						'click': ui.createHandlerFn(null, handleConnectionDown, connection.name)
 					}, [_('Stop')])
 				])
 			]));

--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js
@@ -93,7 +93,7 @@ function renderDetailsSection(connection) {
 	]));
 }
 
-function handleChildDetails(childName, child, childSa) {
+function handleChildDetails(connection, childName, child, childSa) {
 	const modal = buildSection(_('Details'), buildKeyValueTable([
 		[_('Name'), childName],
 		[_('Mode'), child.mode],
@@ -114,12 +114,12 @@ function handleChildDetails(childName, child, childSa) {
 	ui.showModal(_('Child Details'), [modal, E('div', { 'class': 'right' }, [
 		E('button', {
 			'class': 'btn cbi-button',
-			'click': ui.hideModal
+			'click': ui.createHandlerFn(null, handleConnectionDetails, connection)
 		}, [_('Dismiss')])
 	])], 'cbi-modal');
 }
 
-function renderChildTable(children) {
+function renderChildTable(connection) {
 	const tableHeaders = [
 		[_('Name')],
 		[_('State')],
@@ -137,7 +137,7 @@ function renderChildTable(children) {
 		))
 	];
 
-	Object.entries(children).forEach(([childName, child]) => {
+	Object.entries(connection.children).forEach(([childName, child]) => {
 		const childSa = child.childSa;
 		const state = childSa ? childSa.state : _('Inactive');
 		const isDown = !childSa;
@@ -154,7 +154,7 @@ function renderChildTable(children) {
 				E('button', {
 					'title': _('Details'),
 					'class': 'btn cbi-button cbi-button-primary',
-					'click': ui.createHandlerFn(null, handleChildDetails, childName, child, childSa)
+					'click': ui.createHandlerFn(null, handleChildDetails, connection, childName, child, childSa)
 				}, [_('Details')])
 			],
 			[
@@ -206,7 +206,7 @@ function filterConnectionAuths(connection, prefix) {
 
 function handleConnectionDetails(connection) {
 	const detailSection = renderDetailsSection(connection);
-	const childTable = renderChildTable(connection.children);
+	const childTable = renderChildTable(connection);
 	const localAuths = filterConnectionAuths(connection, 'local-');
 	const remoteAuths = filterConnectionAuths(connection, 'remote-');
 	const localAuthTable = renderAuthTable(localAuths);

--- a/applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json
+++ b/applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json
@@ -4,12 +4,10 @@
 		"read": {
 			"file": {
 				"/usr/sbin/swanmon version": [ "exec" ],
-				"/usr/sbin/swanmon stats": [ "exec" ],
-				"/usr/sbin/swanmon list-conns": [ "exec" ],
-				"/usr/sbin/swanmon list-sas": [ "exec" ]
+				"/usr/sbin/swanmon stats": [ "exec" ]
 			},
 			"ubus": {
-				"luci.swanctl": [ "list-algs" ]
+				"luci.swanctl": [ "list-algs", "map-conns" ]
 			},
 			"uci": [ "ipsec" ]
 		},

--- a/applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/ucode/luci.swanctl
+++ b/applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/ucode/luci.swanctl
@@ -371,6 +371,102 @@ const methods = {
 
 			return result;
 		}
+	},
+	'map-conns': {
+		call: function() {
+			const result = {
+				error: null,
+				data: null
+			};
+			const conns_cmd = '/usr/sbin/swanmon list-conns';
+			const sas_cmd = '/usr/sbin/swanmon list-sas';
+			let conns_output;
+			let sas_output;
+
+			try {
+				conns_output = json(popen(conns_cmd)?.read?.('all'));
+			}
+			catch (e) {
+				result.error = e.message;
+				return result;
+			}
+			if (length(conns_output.errors) > 0)
+				result.error = conns_output.errors[0].message;
+
+			try {
+				sas_output = json(popen(sas_cmd)?.read?.('all'));
+			}
+			catch (e) {
+				result.error = e.message;
+				return result;
+			}
+			if (length(sas_output.errors) > 0)
+				result.error = sas_output.errors[0].message;
+
+			if (conns_output.data && sas_output.data) {
+				const saMap = {};
+
+				for (let saObject in sas_output.data) {
+					const saName = keys(saObject)[0];
+					saMap[saName] = saObject[saName];
+				}
+
+				result.data = map(conns_output.data, connObj => {
+					const connName = keys(connObj)[0];
+					const conn = connObj[connName];
+
+					/* set name as property of connection */
+					conn.name = connName;
+
+					/* connection name and SA name are equal -> match using name */
+					if (exists(saMap, connName)) {
+						const sa = saMap[connName];
+						const childSas = sa["child-sas"];
+						const childSaMap = {};
+
+						/* set SA as property of connection */
+						conn.sa = sa;
+
+						for (let _, childSa in childSas)
+							childSaMap[childSa.name] = childSa;
+
+						for (let connChildName, child in conn.children) {
+							/* connection child name and SA child name are equal -> match using name */
+							if (exists(childSaMap, connChildName)) {
+								/* set SA child as property of connection child */
+								child.childSa = childSaMap[connChildName];
+							}
+						}
+					}
+
+					return conn;
+				});
+			}
+
+			/*
+			 * Successful response format:
+			 *	{
+			 *		"error": null,
+			 *		"data": [{
+			 *			"name": "remote_1",
+			 *			... // data from swanctl --list-conns
+			 *			"sa": {
+			 *				... // data from swanctl --list-sas
+			 *			},
+			 *			"children": {
+			 *				"remote_child_1": {
+			 *					... // child data from swanctl --list-conns
+			 *					"childSa": {
+			 *						"name": "remote_child_1",
+			 *						... // child data from swanctl --list-sas
+			 *					}
+			 *				}
+			 *			}
+			 *		}]
+			 *	}
+			 */
+			return result;
+		}
 	}
 };
 


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
Moves mapping strongSwan connections and SAs into a ucode function. While moving it there, also fixes an error where `.sa` property was falsely named `.childSa` and `.childSa` was referenced as `.ChildSa`.

When opening the inner 'child' modal, the dismiss button now takes the user back to the outer modal instead of closing the modal completely.

### Maintainer
<!-- You can find this by checking the history of the package Makefile. -->
@lvoegl, Nicholas Smith

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** master <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** master<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** 152.0.4

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.