### PR TITLE
luci-app-mwan3: fix ACL status diag page

### DIFF
--- a/applications/luci-app-mwan3/root/usr/share/rpcd/acl.d/luci-app-mwan3.json
+++ b/applications/luci-app-mwan3/root/usr/share/rpcd/acl.d/luci-app-mwan3.json
@@ -8,16 +8,7 @@
 			"file": {
 				"/usr/sbin/mwan3 status": [
 					"exec"
-				]
-			},
-			"ubus": {
-				"mwan3": [
-					"status"
-				]
-			}
-		},
-		"write": {
-			"file": {
+				],
 				"/usr/libexec/luci-mwan3 diag gateway *": [
 					"exec"
 				],
@@ -30,16 +21,27 @@
 				"/usr/libexec/luci-mwan3 diag routes *": [
 					"exec"
 				],
-				"/usr/sbin/mwan3 internal ipv4": [
-					"exec"
-				],
 				"/usr/sbin/mwan3 ifup *": [
 					"exec"
 				],
 				"/usr/sbin/mwan3 ifdown *": [
 					"exec"
+				],
+				"/usr/sbin/mwan3 internal ipv4": [
+					"exec"
 				]
 			},
+			"ubus": {
+				"mwan3": [
+					"status"
+				]
+			},
+			"uci": [
+				"mwan3",
+				"network"
+			]
+		},
+		"write": {
 			"ubus": {
 				"file": [
 					"exec"
@@ -53,23 +55,6 @@
 			"cgi-io": [
 				"exec"
 			],
-			"file": {
-				"/etc/mwan3.user": [
-					"read"
-				],
-				"/usr/bin/httping": [
-					"list"
-				],
-				"/usr/bin/nping": [
-					"list"
-				],
-				"/usr/bin/arping": [
-					"list"
-				],
-				"/usr/libexec/luci-mwan3 ipset dump": [
-					"exec"
-				]
-			},
 			"ubus": {
 				"mwan3": [
 					"status"


### PR DESCRIPTION
### Description
The "'Diagnostic' tab does not work if only the permission 'luci-app-mwan3-status' is set. Some  permissions required for the page to function are missing. This commit adds them.

Fixes: 110eecb9e1a1 ("luci-app-mwan3: split ACL into status and config")

### Maintainer _(preferred)_

@feckert

---

## Tested on
**OpenWrt version:**

master

**LuCI version:**

master

**Web browser(s):**

firefox

---

## Checklist

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.


