### PR TITLE
treewide: backport translations to 25.12

### DIFF
--- a/applications/luci-app-apinger/po/cs/apinger.po
+++ b/applications/luci-app-apinger/po/cs/apinger.po
@@ -1,0 +1,273 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-08 17:33+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Aktivní alarmy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Přidat alarm na zpoždění/prodlevu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Přidat alarm na nedostupnost"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Přidat instanci zařízení"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Přidat alarm na ztrátu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Přidat cíl"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Adresa"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Adresa: cílová adresa pro sledování"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Prodleva alarmu"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Alarm dole"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Alarm ztráta"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger – odložit alarmy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - alarm na nedostupnost"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger – rozhraní"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger – alarmy ztráty"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger – cíle"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Cíle apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "RRD graf cílů apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Průměrná prodleva"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Průměrná prodleva a ztráta: prodleva (ve vzorcích) po které je spočítána "
+"ztráta. Bez této prodlevy delší než interval by bylo nakládáno jako se "
+"ztrátou"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Průměrná prodleva: kolik odpovědí má být použito pro spočítání průměrné "
+"prodlevy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Průměrná ztráta"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Průměrná ztráta/prodleva"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+"Průměrná ztráta: kolik sond má být použito pro spočítání průměrné ztráty"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Ladění"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Odložit alarm"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Horní práh prodlevy (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Spodní práh prodlevy (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Alarm na nedostupnost"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Nechat vytvořit RRD grafy"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Udělit přístup k LuCI aplikaci Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Grafy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Rozhraní"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "Rozhraní: které použít pro sledování cíle"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Rozhraní"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Zpoždění"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Ztráta"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Alarm na ztrátu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Horní práh ztráty (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Spodní práh ztráty (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+"Je třeba, aby se názvy shodovali s názvem rozhraní jak uveden v /etc/config/"
+"network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Není přístup k souboru serveru"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Nejsou k dispozici žádná data"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Přehled"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Interval ping"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Interval ping: jak často má být posílána sonda"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "Interval sběru RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Obdrženo"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Odesláno"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Služba není spuštěná"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "Zdrojová IP adresa"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Interval aktualizace stavu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Cíl"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Cíle"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "Nejsou zde žádné aktivní cíle"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Tento alarm bude zrušen, když zpoždění poklesne pod „Spodní hranice zpoždění“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+"Tento alarm bude zrušen, pokud ztráta poklesne pod „Spodní práh ztráty“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr "Tento alarm bude vypuštěn, pokud ztráta přesáhne „Horní práh ztráty“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "Tento alarm bude vypuštěn, pokud cíl neodpoví v rámci „Čas“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Čas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Čas (s)"

--- a/applications/luci-app-apinger/po/de/apinger.po
+++ b/applications/luci-app-apinger/po/de/apinger.po
@@ -1,0 +1,263 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-22 19:35+0000\n"
+"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/de/>\n"
+"Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Aktive Alarme"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr ""

--- a/applications/luci-app-apinger/po/es/apinger.po
+++ b/applications/luci-app-apinger/po/es/apinger.po
@@ -1,0 +1,281 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Alarmas activas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Agregar alarma de retardo/latencia"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Agregar Alarma Baja"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Agregar Instancia de Interfaz"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Agregar Alarma de Pérdida"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Agregar Destino"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Dirección"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Dirección: dirección destino a ser seguida"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Retardo de Alarma"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Alarma Apagada"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Pérdida de alarma"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger - Alarmas de demora"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - Bajar Alarma"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - Interfaces"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger - Pérdida de Alarmas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - Objetivos"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Objetivos de Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Objetivos de Apinger con Gráficas RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Retardo Promedio"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Retraso y pérdida promedio: el retraso (en muestras) después del cual se "
+"calcula la pérdida; sin este retraso, los retrasos mayores que el intervalo "
+"se tratarían como pérdida"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Retraso promedio: cuántas respuestas se deben utilizar para calcular el "
+"retraso promedio"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Pérdida Promedio"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Pérdida/Retraso Promedio"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+"Pérdida promedio: Cuantas sondas se deben utilizar para calcular la pérdida "
+"promedio"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Depuración"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Alarma de Retardo"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Retardo Alto (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Retardo bajo (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Bajar Alarma"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Genera Gráficos RRD"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Conceder acceso a LuCI app Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Gráficos"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Interfaz"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "Interfaz: Interfaz para utilizar al destino de pista"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Interfaces"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Latencia"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Pérdida"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Pérdida de Alarma"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Pérdida Alta (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Pérdida Baja (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+"Los nombres deben coincidir con el nombre de la interfaz que se encuentra "
+"en /etc/config/network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Sin acceso al archivo del servidor"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Sin datos disponibles"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Vista general"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Intervalo de Ping"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Intervalo de ping: Cuanto de a menudo debería enviarse la prueba"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "Intervalo de Colección RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Recibido"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Enviado"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Servicio no está en ejecución"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "IP de origen"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Estado de Intervalo de Actualización"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Objetivo"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Objetivos"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "No hay destinos activos"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Esta alarma será cancelada, cuando el retraso caiga por debajo del «Retraso "
+"bajo»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+"Esta alarma se cancelará cuando la pérdida caiga por debajo de «Pérdida baja»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+"Esta alarma se activará cuando la pérdida de paquetes supere el nivel "
+"«Pérdida Alta»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+"Esta alarma se activará cuando el objetivo no responda durante el «Tiempo»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Tiempo"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Tiempo (s)"

--- a/applications/luci-app-apinger/po/ga/apinger.po
+++ b/applications/luci-app-apinger/po/ga/apinger.po
@@ -1,0 +1,280 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Aláraim Ghníomhacha"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Cuir Aláram Moille/Aga folaigh leis"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Cuir Aláram Síos leis"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Cuir Cás Comhéadain leis"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Cuir Aláram Caillteanais leis"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Cuir Sprioc leis"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Seoladh"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Seoladh: Seoladh sprice le rianú"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Moill Aláraim"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Aláram Síos"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Caillteanas aláraim"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger - Aláraim Moillithe"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - Aláram Síos"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - Comhéadain"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger - Aláraim Caillteanais"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - Spriocanna"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Spriocanna Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Spriocanna Apinger Graf RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Meánmhoill"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Moill agus Caillteanas Meánach: An mhoill (i samplaí) a ríomhtar an "
+"caillteanas ina diaidh, gan é seo, dhéileálfaí le moilleanna níos mó ná an t-"
+"eatramh mar chaillteanas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Meánmhoill: Cé mhéad freagra ba chóir a úsáid chun an meánmhoill a ríomh"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Meánchaillteanas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Meánchaillteanas/Moill"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+"Meánchaillteanas: Cé mhéad tóireadóir ba chóir a úsáid chun meánchaillteanas "
+"a ríomh"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Dífhabhtú"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Aláram Moill"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Moill Ard (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Moill Íseal (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Síos Aláram"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Gin Graif RRD"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Deonaigh rochtain ar aip LuCI Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Graif"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Comhéadan"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "Comhéadan: Comhéadan le húsáid chun sprioc a rianú"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Comhéadain"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Aga folaigh"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Caillteanas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Aláram Caillteanais"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Caillteanas Ard (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Caillteanas Íseal (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+"Caithfidh na hainmneacha a bheith mar an gcéanna leis an ainm comhéadain atá "
+"le fáil i /etc/config/network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Gan rochtain ar chomhad an fhreastalaí"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Níl aon sonraí ar fáil"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Forbhreathnú"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Eatramh Ping"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Eatramh Ping: Cé chomh minic ba chóir an tóireadóir a sheoladh"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "Eatramh Bailithe RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Faighte"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Seolta"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Níl an tseirbhís ag rith"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "IP Foinse"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Eatramh Nuashonraithe Stádas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Sprioc"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Spriocanna"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "Níl aon spriocanna gníomhacha ann"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Cuirfear an t-aláram seo ar ceal nuair a thiteann an mhoill faoi bhun "
+"\"Moill Íseal\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+"Cuirfear an t-aláram seo ar ceal nuair a thiteann an caillteanas faoi bhun "
+"\"Caillteanas Íseal\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+"Cuirfear an t-aláram seo ar siúl nuair a théann an caillteanas paicéid thar "
+"\"Caillteanas Ard\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+"Cuirfear an t-aláram seo ar siúl nuair nach bhfreagraíonn an sprioc don "
+"\"Am\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Am"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Am (s)"

--- a/applications/luci-app-apinger/po/ko/apinger.po
+++ b/applications/luci-app-apinger/po/ko/apinger.po
@@ -1,0 +1,265 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-28 19:40+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "활성 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "지연 알람 추가"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "장애 알람 추가"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "인터페이스 인스턴스 추가"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "손실 알람 추가"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "대상 추가"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "주소"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "주소: 추적할 대상의 주소"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "지연 알람"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "장애 알람"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "손실 알람"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger - 지연 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - 장애 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - 인터페이스"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger - 손실 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - 대상"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Apinger 대상"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Apinger 대상 RRD 그래프"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "평균 지연"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"평균 손실 및 지연: 손실을 계산하기 전 대기할 지연 시간(샘플 수). 이 설정이 없"
+"으면 Ping 전송 주기보다 긴 지연은 모두 손실로 처리됩니다"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr "평균 지연: 평균 지연 시간을 계산할 때 사용할 응답 개수"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "평균 손실"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "평균 손실 및 지연"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr "평균 손실: 평균 손실률을 계산할 때 사용할 Ping 전송 횟수"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "디버그"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "지연 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "지연 상한 (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "지연 하한 (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "장애 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "RRD 그래프 생성"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "LuCI 앱 Apinger에 접근 권한 부여"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "그래프"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "인터페이스"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "인터페이스: 대상을 추적하는 데 사용할 인터페이스"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "인터페이스"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "지연 시간"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "손실"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "손실 알람"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "손실 상한 (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "손실 하한 (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr "이름은 /etc/config/network에 있는 인터페이스 이름과 일치해야 합니다."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "서버 파일에 접근할 수 없음"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "사용 가능한 데이터 없음"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "개요"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Ping 전송 주기"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Ping 전송 주기: 프로브(Probe) 전송 주기"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "RRD 수집 주기"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "받음"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "보냄"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "서비스가 실행 중 아님"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "출발지 IP"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "상태 갱신 주기"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "대상"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "대상"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "활성 대상 없음"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr "지연 시간이 \"지연 하한\" 아래로 떨어지면 알람이 해제됩니다"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr "손실률이 \"손실 하한\" 미만으로 떨어지면 알람이 해제됩니다"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr "패킷 손실률이 \"손실 상한\"을 초과하면 알람이 발생합니다"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "설정한 \"시간\" 동안 대상이 응답하지 않으면 이 알람이 발생합니다"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "시간"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "시간 (초)"

--- a/applications/luci-app-apinger/po/lo/apinger.po
+++ b/applications/luci-app-apinger/po/lo/apinger.po
@@ -1,0 +1,265 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "ການແຈ້ງເຕືອນທີ່ເຮັດວຽກຢູ່"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "ເພີ່ມການແຈ້ງເຕືອນຄວາມໜ່ວງ/ຄວາມຊ້າ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "ເພີ່ມການແຈ້ງເຕືອນເມື່ອລະບົບຫຼົ້ມ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "ເພີ່ມອິນເຕີເຟດ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "ເພີ່ມການແຈ້ງເຕືອນຂໍ້ມູນສູນຫາຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "ເພີ່ມປາຍທາງ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "ທີ່ຢູ່"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "ທີ່ຢູ່: ທີ່ຢູ່ປາຍທາງທີ່ຕ້ອງການຕິດຕາມ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "ການແຈ້ງເຕືອນຄວາມໜ່ວງ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "ການແຈ້ງເຕືອນເມື່ອລະບົບຫຼົ້ມ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "ການແຈ້ງເຕືອນຂໍ້ມູນສູນຫາຍ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger - ການແຈ້ງເຕືອນຄວາມໜ່ວງ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - ການແຈ້ງເຕືອນເມື່ອລະບົບຫຼົ້ມ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - ອິນເຕີເຟດ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger - ການແຈ້ງເຕືອນຂໍ້ມູນສູນຫາຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - ປາຍທາງ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "ປາຍທາງຂອງ Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "ກຣາຟ RRD ຂອງປາຍທາງ Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "ຄວາມໜ່ວງສະເລ່ຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"ຄວາມໜ່ວງ ແລະ ການສູນຫາຍສະເລ່ຍ: ຄວາມໜ່ວງ (ເປັນແຊມເປິ້ນ) ທີ່ໃຊ້ຄຳນວນການສູນຫາຍ, ຖ້າບໍ່ມີອັນນີ້ "
+"ຄວາມໜ່ວງທີ່ຫຼາຍກວ່າໄລຍະຫ່າງຈະຖືກນັບວ່າເປັນການສູນຫາຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr "ຄວາມໜ່ວງສະເລ່ຍ: ຕ້ອງໃຊ້ຈຳນວນການຕອບກັບເທົ່າໃດເພື່ອຄຳນວນຄວາມໜ່ວງສະເລ່ຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "ການສູນຫາຍສະເລ່ຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "ການສູນຫາຍ/ຄວາມໜ່ວງສະເລ່ຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr "ການສູນຫາຍສະເລ່ຍ: ຕ້ອງໃຊ້ຈຳນວນການກວດສອບເທົ່າໃດເພື່ອຄຳນວນການສູນຫາຍສະເລ່ຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "ດີບັກ (Debug)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "ການແຈ້ງເຕືອນຄວາມໜ່ວງ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "ຄວາມໜ່ວງສູງ (ມິນລີວິນາທີ)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "ຄວາມໜ່ວງຕ່ຳ (ມິນລີວິນາທີ)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "ການແຈ້ງເຕືອນເມື່ອລະບົບຫຼົ້ມ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "ສ້າງກຣາຟ RRD"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "ອະນຸຍາດໃຫ້ເຂົ້າເຖິງແອັບ LuCI Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "ກຣາຟ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "ອິນເຕີເຟດ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "ອິນເຕີເຟດ: ອິນເຕີເຟດທີ່ໃຊ້ຕິດຕາມປາຍທາງ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "ອິນເຕີເຟດ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "ຄວາມຊ້າ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "ການສູນຫາຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "ການແຈ້ງເຕືອນຂໍ້ມູນສູນຫາຍ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "ການສູນຫາຍສູງ (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "ການສູນຫາຍຕ່ຳ (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr "ຊື່ຕ້ອງກົງກັບຊື່ອິນເຕີເຟດທີ່ພົບໃນ /etc/config/network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "ບໍ່ສາມາດເຂົ້າເຖິງໄຟລ໌ເຊີບເວີ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "ບໍ່ມີຂໍ້ມູນ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "ພາບລວມ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "ໄລຍະຫ່າງການ Ping"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "ໄລຍະຫ່າງການ Ping: ຄວາມຖີ່ໃນການສົ່ງການກວດສອບ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "ໄລຍະຫ່າງການເກັບຂໍ້ມູນ RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "ໄດ້ຮັບ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "ສົ່ງແລ້ວ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "ບໍລິການບໍ່ໄດ້ເຮັດວຽກຢູ່"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "IP ຕົ້ນທາງ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "ໄລຍະຫ່າງການອັບເດດສະຖານະ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "ປາຍທາງ"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "ປາຍທາງ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "ບໍ່ມີປາຍທາງທີ່ເຮັດວຽກຢູ່"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr "ການແຈ້ງເຕືອນນີ້ຈະຖືກຍົກເລີກ ເມື່ອຄວາມໜ່ວງຫຼຸດລົງຕ່ຳກວ່າ \"ຄວາມໜ່ວງຕ່ຳ\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr "ການແຈ້ງເຕືອນນີ້ຈະຖືກຍົກເລີກ ເມື່ອການສູນຫາຍຫຼຸດລົງຕ່ຳກວ່າ \"ການສູນຫາຍຕ່ຳ\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr "ການແຈ້ງເຕືອນນີ້ຈະເຮັດວຽກ ເມື່ອການສູນຫາຍຂອງແພັກເກັດເກີນ \"ການສູນຫາຍສູງ\""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "ການແຈ້ງເຕືອນນີ້ຈະເຮັດວຽກ ເມື່ອປາຍທາງບໍ່ຕອບກັບຕາມ \"ເວລາ\" ທີ່ກຳນົດ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "ເວລາ"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "ເວລາ (ວິນາທີ)"

--- a/applications/luci-app-apinger/po/lt/apinger.po
+++ b/applications/luci-app-apinger/po/lt/apinger.po
@@ -1,0 +1,283 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-08 11:22+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Aktyvūs priminimai"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Pridėti atidėjimo/delsos priminimą"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Pridėti išjungimo priminimą"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Pridėti sąsajos ir/arba sietuvo egzempliorių"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Pridėti praradimo priminimą"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Pridėti taikomąjį"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Adresas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Adresas: taikomojo, kurį reikia stebėti"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Priminimo atidėjimas"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Priminimas išjungtas/išgalintas"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Priminimo praradimas"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "„Apinger“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "„Apinger“ – atidėti priminimus"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "„Apinger“ – išjungti/išgalinti priminimą"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "„Apinger“ – sąsajos ir/arba sietuvai"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "„Apinger“ – prarasti priminimai"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "„Apinger“ – taikomieji"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "„Apinger“ taikomieji"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "„Apinger“ taikomųjų „RRD“ grafikas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Vidutinis atidėjimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Vidutinis atidėjimas ir praradimas: atidėjimas (imtyse), po kurio "
+"apskaičiuojami praradimai, be šito, atidėjimai didesni nei intervalas būs "
+"laikomi kaip praradimai"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Vidutinis atidėjimas: kiek atsakymų reikėtų naudoti, norint apskaičiuoti "
+"vidutinį atidėjimą"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Vidutinis praradimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Vidutinis praradimas/atidėjimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+"Vidutinis praradimas: kiek zondų reikia naudoti, norint apskaičiuoti "
+"vidutinius praradimus"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Derinimas/Trukdžių šalinimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Atidėti priminimą"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Viršutinė atidėjimo riba (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Apatinė atidėjimo riba (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Išjungimo/Išgalinimo priminimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Sugeneruoti „RRD“ grafikus"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Duoti prieigą prie „LuCI“ programėles – „Apinger“"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Grafikai"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Sąsaja ir/arba Sietuvas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr ""
+"Sąsaja ir/arba sietuvas: sąsaja ir/arba sietuvas, naudojama/-as nusekti "
+"taikomąjį"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Sąsajos ir/arba Sietuvai"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Delsà"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Praradimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Praradimo priminimas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Viršutinė praradimo riba (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Apatinė praradimo riba (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+"Pavadinimai turi sutapti su sąsajos ir/arba sietuvo pavadinimu, esančiu – „/"
+"etc/config/network“ faile."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Nėra prieigos prie serverio failo"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Nėra pasiekiamų duomenų"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Apžiūra"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Ryšio atsako intervalas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Ryšio atsako intervalas: kaip dažnai turėtų būti siunčiamas zondas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "„RRD“ rinkimo intervalas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Gauti/-os"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Išsiųsti/-os"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Tarnyba nėra vykdoma"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "Šaltinio IP"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Būklės/Būsenos atnaujinimo intervalas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Taikomoji"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Taikomieji"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "Nėra aktyvių taikomųjų"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Šis priminimas bus atšauktas, kai atidėjimas nukris žemiau „apatinės "
+"atidėjimo ribos“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+"Šis priminimas bus atšauktas, kai praradimas nukris žemiau „apatinės "
+"atidėjimo ribos“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+"Šis priminimas bus suaktyvintas, kai paketų praradimas viršys „viršutinę "
+"praradimo ribą“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+"Šis priminimas bus suaktyvintas, kai taikomasis neatsakys per nustatytą "
+"„laiką“"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Laikas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Laikas (s)"

--- a/applications/luci-app-apinger/po/pl/apinger.po
+++ b/applications/luci-app-apinger/po/pl/apinger.po
@@ -1,0 +1,275 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 17:29+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Aktywne alarmy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Dodaj alarm opóźnienia"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Dodaj alarm awarii"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Dodaj instancję interfejsu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Dodaj alarm utraty"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Dodaj cel"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Adres"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Adres: adres docelowy do śledzenia"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Alarmuj o opóźnieniu"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Alarmuj o awarii"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Alarmuj o utracie"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger - Alarmy opóźnienia"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - Alarmy awarii"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - Interfejsy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger - Alarmy utraty"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - Cele"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Cele Apingera"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Wykres RRD celów Apingera"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Średnie opóźnienie"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Średnie opóźnienie i utrata: opóźnienie (w próbkach), po którym obliczana "
+"jest utrata. Bez tego opóźnienia większe niż interwał byłyby traktowane jako "
+"utrata"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Średnie opóźnienie: ile odpowiedzi należy użyć do obliczenia średniego "
+"opóźnienia"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Średnia utrata"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Średnia utrata/opóźnienie"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr "Średnia utrata: ile sond należy użyć do obliczenia średniej utraty"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Debugowanie"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Alarm opóźnienia"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Opóźnienie wysokie (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Opóźnienie niskie (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Alarm awarii"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Wygeneruj wykresy RRD"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Udziel dostępu do aplikacji LuCI Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Wykresy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Interfejs"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "Interfejs: interfejs służący do śledzenia celu"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Interfejsy"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Opóźnienie"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Utrata"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Alarm utraty"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Utrata wysoka (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Utrata niska (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+"Nazwa musi być zgodna z nazwą interfejsu znajdującą się w /etc/config/"
+"network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Brak dostępu do pliku serwera"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Brak dostępnych danych"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Przegląd"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Interwał pingu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Interwał pingu: jak często należy wysyłać sondę"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "Interwał zbierania RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Otrzymano"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Wysłano"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Usługa nie działa"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "Źródłowy adres IP"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Interwał aktualizacji statusu"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Cel"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Cele"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "Brak aktywnych celów"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Alarm zostanie anulowany, gdy opóźnienie spadnie poniżej „Opóźnienia "
+"niskiego”"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr "Alarm zostanie anulowany, gdy utrata spadnie poniżej „Utraty niskiej”"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+"Alarm zostanie uruchomiony, gdy utrata pakietów przekroczy wartość „Utraty "
+"wysokiej”"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "Alarm zostanie uruchomiony, gdy cel nie odpowie w ciągu „Czasu”"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Czas"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Czas (s)"

--- a/applications/luci-app-apinger/po/pt_BR/apinger.po
+++ b/applications/luci-app-apinger/po/pt_BR/apinger.po
@@ -1,0 +1,263 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-17 16:40+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationsapinger/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Visão geral"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr ""

--- a/applications/luci-app-apinger/po/ru/apinger.po
+++ b/applications/luci-app-apinger/po/ru/apinger.po
@@ -1,0 +1,273 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-24 15:13+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Активные тревоги"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Добавить тревогу по задержке"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Добавить тревогу по недоступности"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Добавить экземпляр интерфейса"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Добавить тревогу по потерям"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Добавить цель"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Адрес"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Адрес: адрес цели для отслеживания"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Тревога по задержке"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Тревога по недоступности"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Тревога по потере"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger — тревоги по задержке"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger — тревога по недоступности"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger — интерфейсы"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger — тревоги по потерям"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger — цели"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Цели Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "График RRD-целей Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Средняя задержка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Средняя задержка и потери: задержка (в отсчетах), после которой вычисляются "
+"потери; без этого задержки, превышающие интервал, рассматривались бы как "
+"потери"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Средняя задержка: сколько ответов использовать для расчета средней задержки"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Средние потери"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Средние потери/задержка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr "Средние потери: сколько проб использовать для расчета средних потерь"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Отладка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Тревога по задержке"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Верхний порог задержки (мс)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Нижний порог задержки (мс)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Тревога по недоступности"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Создавать графики RRD"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Предоставить доступ к LuCI-приложению Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Графики"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Интерфейс"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "Интерфейс: интерфейс для отслеживания цели"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Интерфейсы"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Задержка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Потери"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Тревога по потерям"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Верхний порог потерь (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Нижний порог потерь (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr "Имена должны совпадать с именем интерфейса из /etc/config/network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Нет доступа к файлу на сервере"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Нет данных"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Обзор"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Интервал пинга"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Интервал пинга: как часто отправлять пробу"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "Интервал сбора RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Принято"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Отправлено"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Служба не запущена"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "IP-адрес источника"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Интервал обновления статуса"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Цели"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Цели"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "Нет активных целей"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Тревога будет отменена, когда задержка опустится ниже «Нижнего порога "
+"задержки»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+"Тревога будет отменена, когда потери опустятся ниже «Нижнего порога потерь»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+"Тревога сработает, когда потери пакетов превысят «Верхний порог потерь»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "Тревога сработает, если цель не отвечает в течение заданного «Времени»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Время"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Время (с)"

--- a/applications/luci-app-apinger/po/templates/apinger.pot
+++ b/applications/luci-app-apinger/po/templates/apinger.pot
@@ -1,0 +1,254 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr ""

--- a/applications/luci-app-apinger/po/uk/apinger.po
+++ b/applications/luci-app-apinger/po/uk/apinger.po
@@ -1,0 +1,274 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-12 09:06+0000\n"
+"Last-Translator: Oleksandr Yurov <oyurov@icloud.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsapinger/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "Активні тривоги"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "Додати тривогу затримки"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "Додати тривогу недоступності"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "Додати екземпляр інтерфейсу"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "Додати тривогу втрат"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "Додати ціль"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "Адреса"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "Адреса: адреса цілі, яку потрібно відстежувати"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "Тривога затримки"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "Тривога недоступності"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "Тривога втрат"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger — тривоги затримки"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger — тривога недоступності"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger — інтерфейси"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger — тривоги втрат"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger — цілі"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Цілі Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Графік RRD цілей Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "Середня затримка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"Середня затримка та втрати: затримка (у вибірках), після якої обчислюються "
+"втрати; без цього затримки, більші за інтервал, вважалися б втратами"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+"Середня затримка: скільки відповідей використовувати для обчислення "
+"середньої затримки"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "Середні втрати"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "Середні втрати/затримка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+"Середні втрати: скільки проб використовувати для обчислення середніх втрат"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "Налагодження"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "Тривога затримки"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "Верхня межа затримки (мс)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "Нижня межа затримки (мс)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "Тривога недоступності"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "Створювати графіки RRD"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "Надати доступ до додатка LuCI Apinger"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "Графіки"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "Інтерфейс"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "Інтерфейс: інтерфейс для відстеження цілі"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "Інтерфейси"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "Затримка"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "Втрати"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "Тривога втрат"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "Верхня межа втрат (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "Нижня межа втрат (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr ""
+"Імена мають відповідати назві інтерфейсу, знайденій у /etc/config/network."
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "Немає доступу до файлу сервера"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "Дані недоступні"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "Огляд"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Інтервал пінгу"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Інтервал пінгу: як часто має надсилатися проба"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "Інтервал збору RRD"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "Отримано"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "Надіслано"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "Службу не запущено"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "IP-адреса джерела"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "Інтервал оновлення стану"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "Ціль"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "Цілі"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "Немає активних цілей"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+"Цю тривогу буде скасовано, коли затримка спаде нижче «Нижньої межі затримки»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+"Цю тривогу буде скасовано, коли втрати спадуть нижче «Нижньої межі втрат»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+"Цю тривогу буде активовано, коли втрати пакетів перевищать «Верхню межу "
+"втрат»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "Цю тривогу буде активовано, коли ціль не відповідатиме протягом «Часу»"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "Час"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "Час (с)"

--- a/applications/luci-app-apinger/po/zh_Hans/apinger.po
+++ b/applications/luci-app-apinger/po/zh_Hans/apinger.po
@@ -1,0 +1,266 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-18 07:48+0000\n"
+"Last-Translator: 大王叫我来巡山 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsapinger/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr "活动中的告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr "添加 延迟/时延 告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr "添加断线告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "添加接口实例"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr "添加丢包告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "添加目标"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "地址"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr "地址：要追踪的目标地址"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr "延迟告警"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr "离线告警"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr "丢包告警"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr "Apinger - 延迟告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr "Apinger - 离线告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - 接口监控"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr "Apinger - 丢包告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - 目标"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Apinger 目标"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Apinger 目标状态图表"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "平均延迟"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+"平均延迟与丢包判定：计算丢包时允许的最大延迟时间。若未配置此项，延迟超过探测"
+"间隔的包将被判定为丢包"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr "平均延迟采样数：用于计算平均延迟的应答包数量"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr "平均丢包"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr "平均 丢包/延迟"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr "平均丢包采样数：用于计算平均丢包率的探测包数量"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "调试"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr "延迟告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr "最大延迟 (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr "最小延迟 (ms)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr "离线告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "生成状态图表"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "授予LuCI app Apinger 访问权限"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "图表"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "接口"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "接口：用于追踪你需要的目标接口"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "接口"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "延迟"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr "丢失"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr "丢包告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr "最大丢失 (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr "最小丢失 (%)"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr "名称必须与 /etc/config/network 中的接口名称一致。"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr "无法访问服务器文件"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "无可用数据"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "概况"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Ping 间隔"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr "Ping 间隔：发送探测包的频率"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "状态图表数据收集频率"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "已接收"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "已发送"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr "服务未运行"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "源 IP"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "状态更新频率"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "目标"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "目标"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr "无活动的目标"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr "当延迟降低至“最小延迟”以下时，该告警将自动解除"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr "当丢失数据降低至“最小丢失”以下时，该告警将自动解除"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr "当丢包率超过“最大丢失”时，将触发此告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr "当监控目标在“设定指定时间”内未响应时，将触发此告警"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "时间"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr "时间"

--- a/applications/luci-app-apinger/po/zh_Hant/apinger.po
+++ b/applications/luci-app-apinger/po/zh_Hant/apinger.po
@@ -1,0 +1,263 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-14 17:39+0000\n"
+"Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsapinger/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:26
+msgid "Active Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:16
+msgid "Add Delay/Latency Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:15
+msgid "Add Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:15
+msgid "Add Interface Instance"
+msgstr "新增介面實例"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:16
+msgid "Add Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:33
+msgid "Add Target"
+msgstr "新增目標"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:21
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:40
+msgid "Address"
+msgstr "位址"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:23
+msgid "Address: Target address to be tracked"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:48
+msgid "Alarm Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:39
+msgid "Alarm Down"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:57
+msgid "Alarm loss"
+msgstr ""
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:3
+msgid "Apinger"
+msgstr "Apinger"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:9
+msgid "Apinger - Delay Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:9
+msgid "Apinger - Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:9
+msgid "Apinger - Interfaces"
+msgstr "Apinger - 介面"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:9
+msgid "Apinger - Loss Alarms"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:21
+msgid "Apinger - Targets"
+msgstr "Apinger - 目標"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:57
+msgid "Apinger Targets"
+msgstr "Apinger 目標"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:40
+msgid "Apinger Targets RRD Graph"
+msgstr "Apinger 目標 RRD 圖表"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:46
+msgid "Average Delay"
+msgstr "平均延遲"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:27
+msgid ""
+"Average Delay and Loss: The delay (in samples) after which loss is computed, "
+"without this delays larger than interval would be treated as loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:25
+msgid "Average Delay: How many replies should be used to compute average delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:49
+msgid "Average Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:52
+msgid "Average Loss/Delay"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:26
+msgid "Average Loss: How many probes should be used to compute average loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:17
+msgid "Debug"
+msgstr "除錯"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:65
+msgid "Delay Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:23
+msgid "Delay High (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:18
+msgid "Delay Low (ms)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:59
+msgid "Down Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:55
+msgid "Generate RRD Graphs"
+msgstr "產生 RRD 圖表"
+
+#: applications/luci-app-apinger/root/usr/share/rpcd/acl.d/luci-app-apinger.json:3
+msgid "Grant access to LuCI app Apinger"
+msgstr "授予存取 luci-app-apinger 的權限"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:21
+msgid "Graphs"
+msgstr "圖表"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:18
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:35
+msgid "Interface"
+msgstr "介面"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:22
+msgid "Interface: Interface to use to track target"
+msgstr "介面: 要用來追蹤目標的介面"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:30
+msgid "Interfaces"
+msgstr "介面"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:24
+msgid "Latency"
+msgstr "延遲"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:25
+msgid "Loss"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:71
+msgid "Loss Alarm"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:23
+msgid "Loss High (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:18
+msgid "Loss Low (%)"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:10
+msgid "Names must match the interface name found in /etc/config/network."
+msgstr "名稱必須與 /etc/config/network 中找到的介面名稱相符。"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:54
+msgid "No access to server file"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:51
+msgid "No data available"
+msgstr "無資料可用"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:12
+msgid "Overview"
+msgstr "概覽"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:43
+msgid "Ping Interval"
+msgstr "Ping 間隔"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/targets.js:24
+msgid "Ping Interval: How often the probe should be sent"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:25
+msgid "RRD Collection Interval"
+msgstr "RRD 收集間隔"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:23
+msgid "Received"
+msgstr "已接收"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:22
+msgid "Sent"
+msgstr "已發送"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/graphs.js:34
+msgid "Service is not running"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:20
+msgid "Source IP"
+msgstr "來源 IP"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/interfaces.js:21
+msgid "Status Update Interval"
+msgstr "狀態更新間隔"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:19
+msgid "Target"
+msgstr "目的"
+
+#: applications/luci-app-apinger/root/usr/share/luci/menu.d/luci-app-apinger.json:66
+msgid "Targets"
+msgstr "目標"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:51
+msgid "There are no active targets"
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_delay.js:11
+msgid "This alarm will be canceled, when the delay drops below \"Delay Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:11
+msgid "This alarm will be canceled, when the loss drops below \"Loss Low\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_loss.js:10
+msgid "This alarm will be fired when packet loss goes over \"Loss High\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:10
+msgid "This alarm will be fired when target does not respond for \"Time\""
+msgstr ""
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/overview.js:27
+msgid "Time"
+msgstr "時間"
+
+#: applications/luci-app-apinger/htdocs/luci-static/resources/view/apinger/alarm_down.js:17
+msgid "Time (s)"
+msgstr ""

--- a/applications/luci-app-babeld/po/cs/babeld.po
+++ b/applications/luci-app-babeld/po/cs/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-07 08:02+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Udělit luci-app-babeld přístup do UCI nastavování"

--- a/applications/luci-app-babeld/po/de/babeld.po
+++ b/applications/luci-app-babeld/po/de/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-02 19:29+0000\n"
+"Last-Translator: ssantos <ssantos@web.de>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/de/>\n"
+"Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Gewähre UCI Zugriff auf luci-app-babeld"

--- a/applications/luci-app-babeld/po/es/babeld.po
+++ b/applications/luci-app-babeld/po/es/babeld.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Conceder acceso UCI para luci-app-babeld"

--- a/applications/luci-app-babeld/po/ga/babeld.po
+++ b/applications/luci-app-babeld/po/ga/babeld.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Deonaigh rochtain UCI do luci-app-babeld"

--- a/applications/luci-app-babeld/po/ko/babeld.po
+++ b/applications/luci-app-babeld/po/ko/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 12:32+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "luci-app-babeld의 UCI 접근 권한 부여"

--- a/applications/luci-app-babeld/po/lo/babeld.po
+++ b/applications/luci-app-babeld/po/lo/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "ອະນຸຍາດການເຂົ້າເຖິງ UCI ສໍາລັບ luci-app-babeld"

--- a/applications/luci-app-babeld/po/lt/babeld.po
+++ b/applications/luci-app-babeld/po/lt/babeld.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-08 22:10+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "„Babeld“"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Suteikti „UCI“ prieigą – „luci-app-babeld“"

--- a/applications/luci-app-babeld/po/lv/babeld.po
+++ b/applications/luci-app-babeld/po/lv/babeld.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-12 14:48+0000\n"
+"Last-Translator: \"ℂ𝕠𝕠𝕠𝕝 (𝕘𝕚𝕥𝕙𝕦𝕓.𝕔𝕠𝕞/ℂ𝕠𝕠𝕠𝕝)\" <coool@mail.lv>\n"
+"Language-Team: Latvian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/lv/>\n"
+"Language: lv\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= "
+"19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Piešķirt luci-app-babeld UCI piekļuvi"

--- a/applications/luci-app-babeld/po/pl/babeld.po
+++ b/applications/luci-app-babeld/po/pl/babeld.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 15:40+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Przyznaj luci-app-babeld dostęp do UCI"

--- a/applications/luci-app-babeld/po/pt/babeld.po
+++ b/applications/luci-app-babeld/po/pt/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-02 19:29+0000\n"
+"Last-Translator: ssantos <ssantos@web.de>\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/pt/>\n"
+"Language: pt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Conceder acesso UCI ao luci-app-babeld"

--- a/applications/luci-app-babeld/po/ru/babeld.po
+++ b/applications/luci-app-babeld/po/ru/babeld.po
@@ -1,0 +1,21 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-22 23:36+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Предоставить доступ к UCI для luci-app-babeld"

--- a/applications/luci-app-babeld/po/templates/babeld.pot
+++ b/applications/luci-app-babeld/po/templates/babeld.pot
@@ -1,0 +1,10 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr ""
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr ""

--- a/applications/luci-app-babeld/po/uk/babeld.po
+++ b/applications/luci-app-babeld/po/uk/babeld.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-09 19:42+0000\n"
+"Last-Translator: Oleksandr Yurov <oyurov@icloud.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsbabeld/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "Надати доступ до UCI для luci-app-babeld"

--- a/applications/luci-app-babeld/po/zh_Hans/babeld.po
+++ b/applications/luci-app-babeld/po/zh_Hans/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-04 04:55+0000\n"
+"Last-Translator: konno_he <h3114931694@gmail.com>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsbabeld/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "授予 luci-app-babeld 访问 UCI 的权限"

--- a/applications/luci-app-babeld/po/zh_Hant/babeld.po
+++ b/applications/luci-app-babeld/po/zh_Hant/babeld.po
@@ -1,0 +1,19 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 11:53+0000\n"
+"Last-Translator: EESF-2 <eesf-2@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsbabeld/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-babeld/root/usr/share/luci/menu.d/luci-app-babeld.json:4
+msgid "Babeld"
+msgstr "Babeld"
+
+#: applications/luci-app-babeld/root/usr/share/rpcd/acl.d/luci-app-babeld.json:3
+msgid "Grant UCI access for luci-app-babeld"
+msgstr "授予 luci-app-babeld 存取 UCI 的權限"

--- a/applications/luci-app-chrony/po/cs/chrony.po
+++ b/applications/luci-app-chrony/po/cs/chrony.po
@@ -1,0 +1,336 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-08 17:30+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "(Log_2 tj. y=2ˣ) interval mezi čteními vnitřních hodin síťové karty."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(výchozí)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 mikrosekund)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Pevné obousměrné zpoždění (v sekundách) které použít namísto toho z "
+"předchozích měření."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Jediné symetrické přiřazení umožňuje protějškům být si vzájemne3 jak "
+"servery, tak klienty."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+"Pokud zamýšlíte přístup z wan, je zapotřebí ještě další nastavení brány "
+"firewall."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Umožnit"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Povolený rozsah umožňuje přístup pro chronyc z určených IP adres k chronyd."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Kontrolovat přítomnost %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Zvolte IP rozsahy z tohoto rozhraní pro jejich nastavení coby povolené "
+"rozsahy."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr "Zvolte wan rozhraní které povolit z veškerých IP adres."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Proces služby chrony NTP/NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Opravuje systémové hodiny okamžitým pokročením pokud je rozsynchronizované "
+"tak, že by postupnější proces zabral příliš dlouhou dobu."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "Pokud chcete umožnit všechny lokální IP adresy, smažte tuto sekci."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+"Pokud chybí hodiny reálného času, vypíná kontroly času certifikátu "
+"prostřednictvím %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Dokumentace"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Umožněn je exponenciální a desítkový zápis."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Prvních X aktualizací hodin"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Udělit luci-app-chrony přístup do UCI nastavování"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Název hostitele"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Rozhraní"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "Prokládat"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Režim přestupné sekundy"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Pouze přestupné sekundy"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Limit"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Zaznamenat všechny změny více než"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Zaznamenávání událostí"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "Nejvýše PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Nejvýše wander"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Nejdelší prodleva"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Nejvyšší posun frekvence uhlazeného času ke sledovanému NTP času (v ppm)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Dotaz nejvýše"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+"Nejvyšší četnost s jakou je dovoleno posunu frekvence se měnit (v ppm / "
+"sekundu)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Nejvýše vzorků"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Nejnižší zpoždění"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Minimální dotazování"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Nejméně vzorků"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "Zabezpečení síťového času (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "Počet vzorků které má chronyd uchovávat pro každý zdroj."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Vyhlazovány jsou pouze přestupné sekundy (ignorovat běžné změny posunu a "
+"frekvence)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Předvolby pro servery poskytované tomuto hostiteli prostřednictvím DHCP(v6) "
+"(například prostřednictvím WAN)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Protějšek"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Fond"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Přesnost"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Přesnost systémových hodin (v sekundách)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Upřednostňovat"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "Kontrola hodin reálného času"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Vzdálené NTP servery pro váš chronyd"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Sekund plovoucí hodnota."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Prahová hodnota (sekundy) pro doladění systémových hodin která vytvoří "
+"zprávu v syslog."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Server"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Vyhlazování"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "Určuje fond NTP serverů namísto jediného serveru."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Určuje symetrickou asociaci s NTP protějškem."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Pokročení"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr "Strategie pro zúčtování přestupných sekund v UTC a slunečním časem."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Systémové hodiny"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Je očekáváno, že název fondu bude překládán na vícero adres, které se v čase "
+"mohou měnit."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Práh spouštějícího množství"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Důvěryhodné certifikáty"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Použijte pouze pokud klienti nejsou nastavení tak, aby se dotazovali také "
+"jiného NTP serveru (protože by to mohlo tento server odmítnout coby falešný "
+"nebo úplně nezdařit výběr zdroje)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Použít systémovou sadu certif. autorit"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "iburst"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "sekund"

--- a/applications/luci-app-chrony/po/es/chrony.po
+++ b/applications/luci-app-chrony/po/es/chrony.po
@@ -1,0 +1,344 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "Intervalo (Log_2 i.e. y=2^x) entre lectura del reloj NIC."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(predeterminado)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 microsegundos)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Se utilizará un retraso de ida y vuelta fijo en segundos en lugar del de las "
+"mediciones anteriores."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Una única asociación simétrica permite que los pares sean a la vez "
+"servidores y clientes entre sí."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+"Se requiere una configuración de cortafuegos adicional si pretende acceder a "
+"la WAN."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Permitir"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Un intervalo concedido permite el acceso de chronyc desde IP específicas a "
+"chronyd."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Comprueba la presencia de %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Elija intervalos de IP desde este interfaz para fijarlos como intervalos "
+"concedidos."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr "Elija una interfaz wan para permitir desde todas las IP."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Demonio NTP/NTS Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Corrige el reloj del sistema avanzando inmediatamente cuando está tan "
+"atrasado que el proceso de giro tomaría mucho tiempo."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "Elimina esta sección para permitir todas las IPs locales."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+"Desactiva las comprobaciones de tiempo del certificado a través de %s si RTC "
+"está ausente."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Documentación"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Se permiten notaciones exponenciales y decimales."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Primeras actualizaciones del reloj x"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Conceder acceso UCI para luci-app-chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Nombre de host"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Interfaz"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "Intercalar"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Modo segundo de intercalar"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Sólo segundos intercalares"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Límite"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Registrar cualquier cambio más de"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Registro"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "PPM máx"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Deambulado máx"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Retardo máximo"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Frecuencia de desplazamiento máximo del tiempo suavizado para el tiempo NTP "
+"seguido (en ppm)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Encuesta máxima"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+"Velocidad máxima a la que se permite cambiar el desplazamiento de frecuencia "
+"(en ppm por segundo)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Muestras máximas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Retardo mínimo"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Encuesta mínima"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Muestras mínimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "Network Time Security (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "Número de muestras que chronyd conservaría por cada origen."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Sólo se suavizan los segundos intercalares; ignore los cambios normales de "
+"frecuencia y desplazamiento."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Opciones para servidores proporcionados a este host a través de DHCP(v6) (a "
+"través de la WAN, por ejemplo)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Par"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Sondeo"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Precisión"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Precisión del reloj del sistema (en segundos)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Preferencia"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "Comprobación del RTC"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Servidores NTP remotos para su chronyd"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Segundo valor flotante."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Umbral de segundos para el ajuste del reloj del sistema que generará un "
+"mensaje de syslog."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Servidor"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Suavizado"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr ""
+"Especifica un grupo de servidores NTP en lugar de un único servidor NTP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Especifica una asociación simétrica con un par NTP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Escalado"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+"Estrategia para conciliar los segundos intercalares en UTC con el tiempo "
+"solar."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Reloj del sistema"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Se esperaba que el nombre del pool se resuelva en múltiples direcciones los "
+"cuales cambiarían con el tiempo."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Umbral de cantidad para la activación"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Certificados de confianza"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Úselo solo cuando los clientes no estén configurados para sondear también "
+"otro servidor NTP, ya que podrían rechazar este servidor como un ticker "
+"falso o no seleccionar una fuente por completo."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Utilice el paquete CA del sistema"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "estadillo"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "segundos"

--- a/applications/luci-app-chrony/po/ga/chrony.po
+++ b/applications/luci-app-chrony/po/ga/chrony.po
@@ -1,0 +1,337 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "(Log_2 i.e. y=2^x) eatramh idir léamha clog an NIC."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(réamhshocraithe)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 micrishoicind)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Moill sheasta ar an turas cruinn i soicindí le húsáid in ionad na tomhais "
+"roimhe seo."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Le comhlachas siméadrach aonair, is féidir leis na piaraí a bheith ina "
+"bhfreastalaithe agus ina gcliaint dá chéile."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+"Tá cumraíocht bhreise balla dóiteáin ag teastáil má tá sé beartaithe agat "
+"rochtain WAN a fháil."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Ceadaigh"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Ceadaíonn raon ceadaithe rochtain do chronyc ó IPanna sonracha chuig chronyd."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Seiceáil an bhfuil %s i láthair."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Roghnaigh raonta IP ón gcomhéadan seo chun iad a shocrú mar raonta ceadaithe."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr "Roghnaigh comhéadan WAN le ceadú ó gach IP."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Daemon Chrony NTP/NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Ceartaíonn sé clog an chórais trí chéimniú láithreach nuair a bhíonn sé "
+"chomh fada ar seachrán go dtógfadh an próiseas sleamhnáin an-fhada."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "Scrios an chuid seo chun gach IP áitiúil a cheadú."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Míchumasaithe"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+"Díchumasaíonn sé seiceálacha ama deimhnithe trí %s mura bhfuil RTC ann."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Doiciméadú"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Ceadaítear nótaíocht easpónantúil agus deachúil."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Nuashonruithe ar an gcéad x clog"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Deonaigh rochtain UCI do luci-app-chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Ainm óstach"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Comhéadan"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "Idirleagan"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Mód soicind léim"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Soicindí léim amháin"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Teorainn"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Logáil aon athrú níos mó ná"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Ag logáil"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "Uasmhéid PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Uasmhéid fánaíochta"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Uasmhoill"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Fritháireamh minicíochta uasta an ama réidhithe i gcomparáid leis an am NTP "
+"rianaithe (i ppm)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Uasmhéid vótaíochta"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+"An ráta uasta ag a gceadaítear don fhritháireamh minicíochta athrú (i ppm in "
+"aghaidh an tsoicind)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Uasmhéid samplaí"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Moill íosta"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Íosmhéid vótaíochta"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Samplaí íosta"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "Slándáil Ama Líonra (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "Líon na samplaí ba chóir do chronyd a choinneáil do gach foinse."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Ní dhéantar ach na soicindí léim a réidhiú; déan neamhaird ar athruithe "
+"gnáth-fhritháireamh agus minicíochta."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Roghanna do fhreastalaithe a chuirtear ar fáil don óstach seo trí DHCP(v6) "
+"(tríd an WAN mar shampla)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Piara"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Linn"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Beachtas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Beachtas chloig an chórais (i soicindí)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Is fearr"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "Seiceáil RTC"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Freastalaithe NTP iargúlta chun do chronyd"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Luach snámhphointe soicindí."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Tairseach soicind le haghaidh coigeartú clog an chórais a ghinfidh "
+"teachtaireacht syslog."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Freastalaí"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Smúdáil"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "Sonraíonn sé linn freastalaithe NTP seachas freastalaí NTP aonair."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Sonraíonn sé comhlachas siméadrach le piaraí NTP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Céimniú"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+"Straitéis chun réiteach a dhéanamh idir soicindí léim in UTC agus am gréine."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Clog an Chórais"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Táthar ag súil go réiteofar ainm an linn snámha chuig il-seoltaí a "
+"d'fhéadfadh athrú le himeacht ama."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Tairseach Méid an Spreagtha"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Teastais iontaofa"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Ná húsáid ach amháin nuair nach bhfuil na cliaint cumraithe chun freastalaí "
+"NTP eile a vótáil freisin, mar d'fhéadfaidís an freastalaí seo a dhiúltú mar "
+"bhréagthicéir nó mainneachtain foinse a roghnú go hiomlán."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Úsáid pacáiste CA an chórais"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "iburst"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "soicindí"

--- a/applications/luci-app-chrony/po/ko/chrony.po
+++ b/applications/luci-app-chrony/po/ko/chrony.po
@@ -1,0 +1,309 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-25 13:04+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "(Log_2 i.e. y=2^x) NIC 클럭을 읽어오는 시간 간격을 지정합니다."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(기본값)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 마이크로초)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr ""
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Chrony NTP/NTS 데몬"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "비활성화"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr ""
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "luci-app-chrony의 UCI 접근 권한 부여"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "호스트 이름"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "인터페이스"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "제한"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "로그 기록"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "최대 PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "최대 지연 시간"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "최대 폴링 주기"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "최대 샘플 수"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "최소 지연 시간"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "최소 폴링 주기"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "최소 샘플 수"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "피어"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "정밀도"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "RTC 확인"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "서버"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "평활화"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "시스템 클럭"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "신뢰할 수 있는 인증서"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "시스템 CA 번들 사용"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "초"

--- a/applications/luci-app-chrony/po/lt/chrony.po
+++ b/applications/luci-app-chrony/po/lt/chrony.po
@@ -1,0 +1,340 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-10 15:13+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "(Log_2, т.е. y=2^x) laiko intervalas tarp „NIC“ laikrodžio rodmenų."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(numatyta/-s/-ai)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "„8e-6“ (8-ios mikrosekundės"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Fiksuotas kelionės į abi puses atidėjimas sekundėmis, kuris bus naudojamas "
+"vietoj ankstesnių matavimų."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Viena simetrinė asociacija leidžia lygiarangiams mazgams būti ir serveriais, "
+"ir klientais vienas kitam."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+"Papildoma užkardos konfigūraciją yra reikalinga, jei Jūs ketinate naudoti "
+"„WAN“ prieigą."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Leisti"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Leidimo diapazonas suteikia „chronyc“ prieigą prie – „chronyd“ iš savitų IP "
+"(dgs.)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Patikrinti, ar yra %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Pasirinkti IP diapazonus iš šios/-o sąsajos ir/arba sietuvo, kad "
+"nustatytumėte juos kaip leidžiamus diapazonus."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr ""
+"Pasirinkite „WAN“ sąsają ir/arba sietuvą, kuri/-is leis prisijungti iš visų "
+"IP (dgs.)."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "„Chrony“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "„Chrony NTP/NTS“ paslaugų teikimo sistema"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Koreguoja sistemos laikrodį nedelsiant, kai jis yra taip smarkiai "
+"paslinktas, kad poslinkio vyksmas užtruktų labai ilgai."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "„DHCP(v6)“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "Ištrinkite šitą skyrių, kad leistumėte visus vietinius IP (dgs.)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Išjungta/Neįgalinta (-s/-i)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+"Išjungią/Išgaliną sertifikato laiko patikros per – „%s“, jei nėra „RTC“."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Dokumentacija"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Eksponentiniai ir dešimtainiai užrašai yra leidžiami."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Pirmieji x laikrodžio atnaujinimai"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Suteikti „UCI“ prieigą prie – „luci-app-chrony“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Įrenginio (t.y skleidėjo/vedėjo) pavadinimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Sąsaja ir/arba Sietuvas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "kaitaliojimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Šuolinės sekundės veiksena"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Tik šuolinės sekundės"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Riba"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Žurnalinti bet kokius pakeitimus daugiau nei"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Žurnalinimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "Maksimalus „PPM“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Maksimali klajonė"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Maksimalus atidėjimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Maksimalus išlyginto laiko dažnio poslinkis, palyginti su sekamu „NTP“ laiku "
+"(ppm)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Maksimali apklausa"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+"Maksimalus leidžiamas dažnio poslinkio kitimo greitis (ppm per sekundę)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Maksimalūs pavyzdžiai"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Minimalus atidėjimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Minimali apklausa"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Minimalūs pavyzdžiai"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "„NTS“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "„Network Time Security“ („NTS“)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "Kiekvieno šaltinio pavyzdžių skaičius, kurį „chronyd“ turėtų saugoti."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Išlyginamos tik šuolinės sekundės; ignoruoti įprastą poslinkį ir dažnio "
+"pakeitimus."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Šiam skleidėjui/vedėjui per „DHCP“ (v6) teikiamų serverių parinktys "
+"(pavyzdžiui, per „WAN“)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Lygiarangis"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Telkinys"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Tikslumas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Sistemos laikrodžio tikslumas (sekundėmis)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Pageidauti"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "„RTC“ patikrinimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Nuotoliniai „NTP“ serveriai, skirti Jūsų – „chronyd“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Reikšmė sekundėmis (trupmeninė)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Sistemos laikrodžio koregavimo sekundžių slenkstis, kuris sugeneruos "
+"„syslog“ pranešimą."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Serveris"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Išlyginimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "Nurodo „NTP“ serverių telkinį, o ne vieną „NTP“ serverį."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Nurodo simetrišką asociaciją su „NTP“ lygiarangiu."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Šuolio tipo koregavimas"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+"Strategija, kaip sutaikyti šuolines sekundes „UTC“ laiku su saulės laiku."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Sistemos laikrodis"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Tikėtina, kad telkinio pavadinimas bus išspręstas į kelis adresus, kurie "
+"laikui bėgant gali keistis."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Suaktyvinimo kiekio slenkstis"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Patikimi sertifikatai"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Naudokite tik tada, kai klientai nėra sukonfigūruoti apklausti ir kitą „NTP“ "
+"serverį, nes jie gali atmesti šį serverį kaip klaidingą arba visai "
+"nesugebėti pasirinkti šaltinio."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Naudoti sistemos „CA“ rinkinį"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "„iburst“"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "sekundės"

--- a/applications/luci-app-chrony/po/pl/chrony.po
+++ b/applications/luci-app-chrony/po/pl/chrony.po
@@ -1,0 +1,338 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-03 18:00+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "(Log_2, tj. y=2^x) odstęp pomiędzy odczytami zegara karty sieciowej."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(domyślne)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 mikrosekund)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Stałe opóźnienie w obie strony wyrażone w sekundach, które należy stosować "
+"zamiast poprzedniego pomiaru."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Pojedyncze powiązanie symetryczne pozwala peerom być dla siebie jednocześnie "
+"serwerami i klientami."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr "Wymagana jest dodatkowa konfiguracja zapory do uzyskania dostępu WAN."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Zezwól"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Zakres dozwolonych ustawień pozwala na dostęp chronyc z określonych adresów "
+"IP do chronyd."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Sprawdź obecność %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Wybierz zakresy adresów IP z tego interfejsu, aby ustawić je jako zakresy "
+"dozwolone."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr ""
+"Wybierz interfejs WAN, który będzie dozwolony ze wszystkich adresów IP."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Chrony — demon NTP/NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Koryguje zegar systemowy, natychmiast go zmieniając, gdy jest tak bardzo "
+"rozbieżny, że proces przestawiania zająłby bardzo dużo czasu."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCPv6"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "Usuń tę sekcję, aby zezwolić na wszystkie lokalne adresy IP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+"Wyłącza sprawdzanie czasu certyfikatu za pomocą %s, jeśli RTC jest nieobecny."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Dokumentacja"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Dozwolone jest stosowanie notacji wykładniczej i dziesiętnej."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Pierwsze x aktualizacji zegara"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Udziel dostępu UCI do luci-app-chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Nazwa hosta"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Interfejs"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "Przeplataj"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Tryb sekundy przestępnej"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Tylko sekundy przestępne"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Limit"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Rejestruj każdą zmianę częściej niż"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Rejestrowanie"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "Maksimum PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Maksimum wędrowania"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Maksimum opóźnienia"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Maksimum przesunięcia częstotliwości wygładzonego czasu w stosunku do "
+"śledzonego czasu NTP (w ppm)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Maksimum sondowania"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+"Maksimum dopuszczalnej szybkości zmiany przesunięcia częstotliwości (w ppm "
+"na sekundę)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Maksimum próbek"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Minimum opóźnienia"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Minimum sondowania"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Minimum próbek"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "Network Time Security (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "Liczba próbek, które chronyd powinien zachować dla każdego źródła."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Wygładzane są tylko sekundy przestępne; nie należy uwzględniać normalnych "
+"zmian przesunięcia i częstotliwości."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Opcje dla serwerów udostępnianych temu hostowi poprzez DHCPv6 (na przykład "
+"poprzez WAN)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Peer"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Pula"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Dokładność"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Dokładność zegara systemowego (w sekundach)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Preferuj"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "Sprawdzenie RTC"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Zdalne serwery NTP dla chronyd"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Wartość zmiennoprzecinkowa sekund."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Próg sekund dla regulacji zegara systemowego, który wygeneruje komunikat "
+"dziennika systemowego."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Serwer"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Wygładzanie"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "Określa pulę serwerów NTP zamiast pojedynczego serwera NTP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Określa symetryczne powiązanie z peerem NTP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Korekcja"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+"Strategia uzgadniania sekund przestępnych w czasie UTC z czasem słonecznym."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Zegar systemowy"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Nazwa puli powinna przekierowywać do wielu adresów, które mogą ulegać "
+"zmianom w czasie."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Próg wartości wyzwalacza"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Zaufane certyfikaty"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Używaj wyłącznie, gdy klienty nie są skonfigurowane do odpytywania innego "
+"serwera NTP, ponieważ mogą odrzucić ten serwer jako falseticker lub w ogóle "
+"nie wybrać źródła."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Używaj systemowego pakietu CA"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "iburst"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "sekundy"

--- a/applications/luci-app-chrony/po/pt_BR/chrony.po
+++ b/applications/luci-app-chrony/po/pt_BR/chrony.po
@@ -1,0 +1,309 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-18 07:49+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationschrony/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr ""
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Desativado"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr ""
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Hostname"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Registros do sistema"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr ""

--- a/applications/luci-app-chrony/po/ru/chrony.po
+++ b/applications/luci-app-chrony/po/ru/chrony.po
@@ -1,0 +1,340 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-24 15:14+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr ""
+"(Log_2, т.е. y=2^x) интервал между считываниями часов сетевого адаптера."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(по умолчанию)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 микросекунд)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Фиксированная задержка приёма-передачи в секундах, которая будет "
+"использоваться вместо значений, полученных при предыдущих измерениях."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Симметричная ассоциация позволяет узлам быть одновременно и серверами, и "
+"клиентами друг для друга."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+"Требуется дополнительная настройка межсетевого экрана, если предполагается "
+"доступ из WAN."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Разрешить"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Диапазон разрешённых адресов предоставляет доступ chronyc к chronyd с "
+"указанных IP."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Проверять наличие %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Выберите диапазоны IP-адресов с этого интерфейса, чтобы добавить их в список "
+"разрешённых."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr "Выберите WAN-интерфейс, чтобы разрешить доступ со всех IP-адресов."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Демон Chrony NTP/NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Корректирует системные часы мгновенным скачком, когда рассинхронизация "
+"слишком велика и плавная подстройка заняла бы чрезмерно много времени."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr ""
+"Удалите этот раздел, чтобы разрешить доступ со всех локальных IP-адресов."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Отключено"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr ""
+"Отключает проверку времени действия сертификатов через %s при отсутствии RTC."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Документация"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Допускается экспоненциальная и десятичная запись."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Первые x обновлений часов"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Предоставить доступ к UCI для luci-app-chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Имя хоста"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Интерфейс"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "Чередование"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Режим високосной секунды"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Только високосные секунды"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Лимит"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Записывать в лог изменения более чем на"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Журналирование"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "Макс. PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Макс. дрейф"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Максимальная задержка"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Максимальное частотное смещение сглаженного времени относительно "
+"отслеживаемого времени NTP (в PPM)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Макс. интервал опроса"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr "Максимальная скорость изменения частотного смещения (в PPM в секунду)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Макс. количество выборок"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Минимальная задержка"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Мин. интервал опроса"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Мин. количество выборок"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "Network Time Security (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr ""
+"Количество выборок, которые chronyd должен хранить для каждого источника."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Сглаживаются только високосные секунды; обычные изменения смещения и частоты "
+"игнорируются."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Параметры серверов, предоставленных этому хосту через DHCP(v6) (например, "
+"через WAN)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Пир"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Пул"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Точность"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Точность системных часов (в секундах)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Предпочтение"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "Проверка RTC"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Удалённые NTP-серверы для вашего chronyd"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Значение в секундах (дробное)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Пороговое значение в секундах для корректировки системных часов, при "
+"превышении которого генерируется сообщение в системный журнал."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Сервер"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Сглаживание"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "Задаёт пул NTP-серверов, а не один конкретный сервер."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Задаёт симметричную ассоциацию с NTP-пиром."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Скачкообразная коррекция"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr "Стратегия согласования високосных секунд UTC с солнечным временем."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Системные часы"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Предполагается, что имя пула разрешается в несколько адресов, которые могут "
+"меняться со временем."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Порог срабатывания"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Доверенные сертификаты"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Используйте только если клиенты не настроены на опрос других NTP-серверов, "
+"иначе они могут отвергнуть этот сервер как недостоверный или не выбрать "
+"источник вообще."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Использовать системный набор корневых сертификатов"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "iburst"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "секунды"

--- a/applications/luci-app-chrony/po/uk/chrony.po
+++ b/applications/luci-app-chrony/po/uk/chrony.po
@@ -1,0 +1,337 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-15 10:43+0000\n"
+"Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationschrony/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5.dev0\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr ""
+"Інтервал (у форматі log_2, тобто y=2^x) між зчитуваннями годинника мережевої "
+"карти."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(типово)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 мікросекунд)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+"Фіксована затримка зворотного проходження у секундах, яка використовується "
+"замість значень із попередніх вимірювань."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+"Окрема симетрична асоціація дозволяє одноранговим вузлам бути одночасно "
+"серверами та клієнтами один для одного."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+"Якщо ви плануєте доступ через WAN, потрібно додатково налаштувати брандмауер."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "Дозволити"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+"Дозволений діапазон надає chronyc можливість звертатися до chronyd із певних "
+"IP-адрес."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "Перевіряти наявність %s."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+"Виберіть діапазони IP-адрес із цього інтерфейсу, щоб задати їх як дозволені."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr "Виберіть інтерфейс WAN, щоб дозволити доступ з усіх IP-адрес."
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Служба NTP/NTS Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"Коригує системний годинник миттєвим стрибком, коли його відхилення настільки "
+"велике, що плавне підлаштування тривало б дуже довго."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "Видаліть цей розділ, щоб дозволити всі локальні IP-адреси."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr "Вимикає перевірку часу сертифікатів через %s, якщо RTC відсутній."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "Документація"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "Дозволено експоненціальний та десятковий записи."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "Перші x оновлень годинника"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "Надати доступ до UCI для luci-app-chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "Імʼя вузла"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "Інтерфейс"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "Перемежування"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "Режим високосної секунди"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "Лише високосні секунди"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "Межа"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "Журналювати будь-яку зміну, більшу за"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "Журналювання"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "Макс. PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "Максимальне відхилення"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "Максимальна затримка"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+"Максимальний зсув частоти згладженого часу відносно відстежуваного часу NTP "
+"(у ppm)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "Максимальний інтервал опитування"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+"Максимальна швидкість, з якою може змінюватися зсув частоти (у ppm за "
+"секунду)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "Максимальна кількість вибірок"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "Мінімальна затримка"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "Мінімальний інтервал опитування"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "Мінімальна кількість вибірок"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "Network Time Security (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "Кількість вибірок, які chronyd зберігатиме для кожного джерела."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+"Згладжуються лише високосні секунди; звичайні зміни зсуву та частоти "
+"ігноруються."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+"Параметри для серверів, отриманих цим вузлом через DHCP(v6) (наприклад, "
+"через WAN)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "Одноранговий вузол"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "Пул"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "Точність"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "Точність системного годинника (у секундах)."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "Перевага"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "Перевірка RTC"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "Віддалені NTP-сервери для chronyd"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "Значення в секундах із дробовою частиною."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+"Поріг у секундах для коригування системного годинника, при перевищенні якого "
+"буде створено повідомлення системного журналу."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "Сервер"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "Згладжування"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "Визначає пул серверів NTP замість одного NTP-сервера."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "Визначає симетричну асоціацію з одноранговим NTP-вузлом."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "Стрибок"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr "Стратегія узгодження високосних секунд UTC із сонячним часом."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "Системний годинник"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+"Очікується, що імʼя пулу розвʼязуватиметься в декілька адрес, які можуть "
+"змінюватися з часом."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "Поріг величини активації"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "Довірені сертифікати"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"Вмикати лише тоді, коли клієнти не налаштовані опитувати ще якийсь NTP-"
+"сервер, інакше вони можуть відхилити цей сервер як falseticker або взагалі "
+"не вибрати джерело."
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "Використовувати системний набір сертифікатів CA"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "iburst"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "секунди"

--- a/applications/luci-app-chrony/po/zh_Hans/chrony.po
+++ b/applications/luci-app-chrony/po/zh_Hans/chrony.po
@@ -1,0 +1,312 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-03 13:36+0000\n"
+"Last-Translator: Peng Liu <littlenewton6@gmail.com>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationschrony/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "(以 2 为底的对数，即 y=2^x) 读取网卡 (NIC) 时钟的间隔。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(默认)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 微秒)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr "使用固定的双向延迟（秒），而非使用之前测量得到的延迟值。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr "单一对称关联允许对等体互为服务端与客户端。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr "如果打算通过 wan 访问，则需要额外的防火墙配置。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "允许"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr "允许范围用于授权特定 IP 段访问 chronyd 服务。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr "检查 %s 是否存在。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr "从此接口选择 IP 范围并将其设为允许访问的范围。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr "选择一个 WAN 接口以允许所有 IP 访问。"
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony 时钟同步"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Chrony NTP/NTS 守护进程"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+"当时钟偏差过大以至于平滑调整耗时过长时，通过立即步进（跳变）来校准系统时钟。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "删除此部分以允许所有本地 IP 访问。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "已禁用"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr "若 RTC 不存在，则通过 %s 禁用证书时间检查。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "文档"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "允许使用指数计数法和十进制计数法。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "前 x 次时钟更新"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "授予 luci-app-chrony 对 UCI 的访问权限"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "主机名"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "接口"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "交错模式"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "闰秒处理模式"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "仅处理闰秒"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "限制"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "记录任何超过以下值的变更"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "日志"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "最大 PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr "最大漂移"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "最大延迟"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr "平滑处理后的时间与追踪的 NTP 时间之间的最大频率偏移（单位 PPM）。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr "最大轮询间隔"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr "频率偏移允许改变的最大速率（单位 PPM/秒）。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "最大样本数"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "最小延迟"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr "最小轮询间隔"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "最小样本数"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS (网络时间安全)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "网络时间安全 (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr "chronyd 应为每个时钟源保留的样本数量。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr "仅对闰秒进行平滑处理；忽略正常的偏差和频率变化。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr "通过 DHCP(v6)（例如 WAN 口）为此主机提供的服务器选项。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "对端"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr "地址池"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "精度"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "系统时钟的精度（秒）。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "优先"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "RTC 检查"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "用于 chronyd 的远程 NTP 服务器"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr "秒数（浮点值）。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr "触发系统日志消息记录的系统时钟调整阈值（秒）。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "服务器"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr "平滑处理"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr "指定 NTP 服务器池而非单一 NTP 服务器。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr "指定与 NTP 对等体的对称关联。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr "步进校准 (Stepping)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr "协调 UTC 闰秒与太阳时（Solar Time）的策略。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "系统时钟"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr "服务器池名称应能解析为多个随时间可能发生变化的 IP 地址。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "触发阈值量"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "受信任的证书"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+"仅在客户端未配置其他轮询 NTP 服务器时使用，否则客户端可能会将此服务器判定为错"
+"误源（falseticker）或导致无法选择时钟源。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "使用系统 CA 证书束"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "快速同步 (iburst)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "秒"

--- a/applications/luci-app-chrony/po/zh_Hant/chrony.po
+++ b/applications/luci-app-chrony/po/zh_Hant/chrony.po
@@ -1,0 +1,309 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-07-02 06:28+0000\n"
+"Last-Translator: 為什麼不加空格 <c++23@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationschrony/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:198
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:210
+msgid "(Log_2 i.e. y=2^x) interval between readings of the NIC clock."
+msgstr "NIC 時鐘讀取間隔 (Log_2 例如 y=2^x)。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:103
+msgid "(default)"
+msgstr "(預設)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:98
+msgid "8e-6 (8 microseconds)"
+msgstr "8e-6 (8 微秒)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:222
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:228
+msgid ""
+"A fixed round-trip delay in seconds to be used instead of that of the "
+"previous measurements."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:150
+msgid ""
+"A single symmetric association allows the peers to be both servers and "
+"clients to each other."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:38
+msgid "Additional firewall configuration is required if you intend wan access."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "Allow"
+msgstr "允許"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:30
+msgid "An allow range permits access for chronyc from specific IPs to chronyd."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:50
+msgctxt "Check for RTC character device"
+msgid "Check for the presence of %s."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:36
+msgid "Choose IP ranges from this interface to set them as allowed ranges."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:37
+msgid "Choose a wan interface to allow from all IPs."
+msgstr ""
+
+#: applications/luci-app-chrony/root/usr/share/luci/menu.d/luci-app-chrony.json:3
+msgid "Chrony"
+msgstr "Chrony"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:25
+msgid "Chrony NTP/NTS daemon"
+msgstr "Chrony NTP/NTS 常駐程式"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:64
+msgid ""
+"Corrects the system clock by stepping immediately when it is so far adrift "
+"that the slewing process would take a very long time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:156
+msgid "DHCP(v6)"
+msgstr "DHCP(v6)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:31
+msgid "Delete this section to allow all local IPs."
+msgstr "刪除此部分以允許所有本地 IP。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:168
+msgid "Disabled"
+msgstr "已停用"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:51
+msgid "Disables certificate time checks via %s if RTC is absent."
+msgstr "若 RTC 不存在，透過 %s 停用憑證時間檢查。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:27
+msgid "Documentation"
+msgstr "文件"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:223
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:229
+msgid "Exponential and decimal notation are allowed."
+msgstr "允許指數與十進位表示法。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:75
+msgid "First x clock updates"
+msgstr "前 x 次時鐘更新"
+
+#: applications/luci-app-chrony/root/usr/share/rpcd/acl.d/luci-app-chrony.json:3
+msgid "Grant UCI access for luci-app-chrony"
+msgstr "授予 luci-app-chrony 存取 UCI 的權限"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:172
+msgid "Hostname"
+msgstr "主機名稱"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:35
+msgid "Interface"
+msgstr "介面"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:194
+msgid "Interleave"
+msgstr "交錯"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:101
+msgid "Leap second mode"
+msgstr "閏秒模式"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:128
+msgid "Leap seconds only"
+msgstr "僅閏秒"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:74
+msgid "Limit"
+msgstr "限制"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:84
+msgid "Log any change more than"
+msgstr "記錄任何超過此值的變更"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:80
+msgid "Logging"
+msgstr "紀錄"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:116
+msgid "Max PPM"
+msgstr "最大 PPM"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:122
+msgid "Max wander"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:227
+msgid "Maximum delay"
+msgstr "最大延遲"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:117
+msgid ""
+"Maximum frequency offset of the smoothed time to the tracked NTP time (in "
+"ppm)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:209
+msgid "Maximum poll"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:123
+msgid ""
+"Maximum rate at which the frequency offset is allowed to change (in ppm per "
+"second)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:240
+msgid "Maximum samples"
+msgstr "最大樣本數"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:221
+msgid "Minimum delay"
+msgstr "最小延遲"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:197
+msgid "Minimum poll"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:233
+msgid "Minimum samples"
+msgstr "最小樣本數"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:184
+msgid "NTS"
+msgstr "NTS"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:45
+msgid "Network Time Security (NTS)"
+msgstr "網路時間安全 (NTS)"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:241
+msgid "Number of samples that chronyd should keep for each source."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:129
+msgid ""
+"Only leap seconds are smoothed out; ignore normal offset and frequency "
+"changes."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:157
+msgid ""
+"Options for servers provided to this host via DHCP(v6) (via the WAN for "
+"example)."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:148
+msgid "Peer"
+msgstr "對等點"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:140
+msgid "Pool"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:95
+msgid "Precision"
+msgstr "精度"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:96
+msgid "Precision of the system clock (in seconds)."
+msgstr "系統時鐘精度 (以秒為單位)。"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:191
+msgid "Prefer"
+msgstr "偏好"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:49
+msgid "RTC Check"
+msgstr "RTC 檢查"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:134
+msgid "Remote NTP servers for your chronyd"
+msgstr "您的 chronyd 使用的遠端 NTP 伺服器"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:70
+msgid "Seconds float value."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:85
+msgid ""
+"Seconds threshold for the adjustment of the system clock that will generate "
+"a syslog message."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:133
+msgid "Server"
+msgstr "伺服器"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:111
+msgid "Smoothing"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:141
+msgid "Specifies a pool of NTP servers rather than a single NTP server."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:149
+msgid "Specifies a symmetric association with an NTP peer."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:63
+msgid "Stepping"
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:102
+msgid "Strategy to reconcile leap seconds in UTC with solar time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:91
+msgid "System Clock"
+msgstr "系統時鐘"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:142
+msgid ""
+"The pool name is expected to resolve to multiple addresses which might "
+"change over time."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:69
+msgid "Trigger Amount Threshold"
+msgstr "觸發總量閾值"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:57
+msgid "Trusted certificates"
+msgstr "信任的憑證"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:112
+msgid ""
+"Use only when the clients are not configured to poll another NTP server "
+"also, because they could reject this server as a falseticker or fail to "
+"select a source completely."
+msgstr ""
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:54
+msgid "Use system CA bundle"
+msgstr "使用系統 CA 組合包"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:178
+msgid "iburst"
+msgstr "iburst"
+
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:206
+#: applications/luci-app-chrony/htdocs/luci-static/resources/view/chrony.js:218
+msgid "seconds"
+msgstr "秒"

--- a/applications/luci-app-csshnpd/po/cs/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/cs/csshnpd.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-04 14:23+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Dodatečné argumenty"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Službu zapnete zaškrtnutím zde"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Nastavení procesu služby"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "Zařízení atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "Je třeba, aby zařízení bylo nastaveno"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Název zařízení"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Název zařízení smí obsahovat pouze a-z 0-9 _ nebo - (např.: "
+"„moje_vecicka1\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Povoleno"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Zapsat se"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "Zapsání se OTP/SPP"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Existující klíč nalezen v:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "První znak by mělo být malé písmeno (např. „a“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "Další argumenty příkazového řádku pro proces služby NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Udělit luci-app-csshnpd přístup do UCI nastavování"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "Správce atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "Nejdelší možná délka názvu zařízení je 36 znaků."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Je třeba, aby bylo dlouhé alespoň jeden znak (např. „a“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Je třeba, aby bylo 6 znaků (např. „S3CR3T“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "Nemůže být nevyplněné a mělo by začínat na @ (např. „@a“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "Nastavení pro NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "NoPorts zapsání se"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "Zapsání se NoPorts atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "Je třeba, aby bylo nastavené OTP. To je možné nechat vytvořit pomocí:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "Jednorázové přístupové heslo (OTP) pro atSign zapsání se zařízení"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Klikněte na tlačítko Zapsat se, poté spusťte tento příkaz na systému kde"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "Zařízení atSign např. @zařízení"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "Správce atSign např. @správce"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "Název tohoto zařízení – např. openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "Je třeba, aby bylo nastavené atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "nastavení pro sshnpd"

--- a/applications/luci-app-csshnpd/po/de/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/de/csshnpd.po
@@ -1,0 +1,136 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-22 19:35+0000\n"
+"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/de/>\n"
+"Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Zusätzliche Argumente"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr ""

--- a/applications/luci-app-csshnpd/po/es/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/es/csshnpd.po
@@ -1,0 +1,145 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Argumentos adicionales"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Marque aquí para activar el servicio"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Configuración del demonio"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "Dispositivo atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "El dispositivo debe estar configurado"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Nombre del dispositivo"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Los nombres de los dispositivos pueden contener a-z 0-9 _ o - (por ejemplo, "
+"«mi_cosa1»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Activado"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Inscribirse"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "Inscripción OTP/SPP"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Clave existente encontrada en:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "El primer carácter debe ser una letra minúscula (por ejemplo, «a»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "Más argumentos de línea de comandos para el demonio NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Conceder acceso UCI para luci-app-csshnpd"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "Administrador atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "La longitud máxima del nombre del dispositivo es 36 caracteres."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Debe tener al menos un carácter (por ejemplo, «a»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Debe tener seis caracteres (por ejemplo, «S3CR3T»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "No debe estar vacío y debe comenzar con @ (por ejemplo, «@a»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "Configuración de NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "Inscripción en NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "Inscripción en NoPorts atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "Se debe configurar una OTP. Se puede generar una OTP usando:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr ""
+"Código de acceso de un solo uso (OTP) para la inscripción del dispositivo en "
+"atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Presione el botón Inscribirse y luego ejecute este comando en un sistema "
+"donde"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "El dispositivo atSign, por ejemplo @device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "El administrador de Sign, por ejemplo, @manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "El nombre de este dispositivo, por ejemplo, openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "atSign debe estar configurado"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "configuración de sshnpd"

--- a/applications/luci-app-csshnpd/po/ga/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/ga/csshnpd.po
@@ -1,0 +1,141 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Argóintí breise"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Seiceáil anseo chun an tseirbhís a chumasú"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Cumraíocht Daemon"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "Gléas agSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "Ní mór an gléas a chumrú"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Ainm an ghléis"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Féadfaidh a-z 0-9 _ nó - (e.g., \"mo_rud1\") a bheith in ainmneacha "
+"gléasanna."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Cumasaithe"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Cláraigh"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "OTP/SPP Clárúcháin"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Eochair atá ann cheana aimsithe ag:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "Ba chóir go mbeadh an chéad charachtar ina litir bheag (m.sh., \"a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "Tuilleadh argóintí líne ordaithe don daemon NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Deonaigh rochtain UCI do luci-app-csshnpd"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "Bainisteoir ag Sign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "Is é 36 carachtar uasmhéid fad ainm an ghléis."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Ní mór carachtar amháin ar a laghad a bheith ann (m.sh., \"a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Caithfidh sé a bheith sé charachtar (m.sh., \"S3CR3T\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr ""
+"Ní féidir é a bheith folamh agus ba chóir go dtosódh sé le @ (m.sh., \"@a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "Cumraíocht NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "Clárú NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "Clárú NoPorts atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "Ní mór OTP a chumrú. Is féidir OTP a ghiniúint trí úsáid a bhaint as:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "Paschód Aonuaire (OTP) le haghaidh clárú gléas atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Brúigh an cnaipe Cláraigh agus ansin rith an t-ordú seo ar chóras ina bhfuil"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "An gléas agSign m.sh. @device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "An bainisteoir agSign m.sh. @manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "Ainm na feiste seo m.sh. openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "Ní mór atSign a chumrú"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "cumraíocht sshnpd"

--- a/applications/luci-app-csshnpd/po/ko/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/ko/csshnpd.po
@@ -1,0 +1,138 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-06 19:59+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "추가 인수"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "서비스를 활성화하려면 선택합니다"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "데몬(Daemon) 설정"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "장치 atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "장치를 설정해야 합니다"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "장치 이름"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"장치 이름에는 영문 소문자, 숫자, '_' 또는 '-'만 사용할 수 있습니다. (예: "
+"'my_thing1')"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "활성화"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "등록"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "등록 OTP/SPP"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "첫 글자는 영문 소문자여야 합니다. (예: \"a\")"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "luci-app-csshnpd의 UCI 접근 권한 부여"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "관리자 atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "장치 이름은 최대 36자까지만 가능합니다."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "최소 한 글자 이상이어야 합니다. (예: \"a\")"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "NoPorts 설정"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "NoPorts 등록"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "NoPorts atSign 등록"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "장치 atSign을 입력하세요. (예: @device)"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "관리자 atSign을 입력하세요. (예: @manager)"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "장치 이름을 입력하세요. (예: openwrt)"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "atSign을 설정해야 합니다"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "sshnpd 설정"

--- a/applications/luci-app-csshnpd/po/lo/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/lo/csshnpd.po
@@ -1,0 +1,136 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "ພາລາມິເຕີເພີ່ມເຕີມ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "ໝາຍທີ່ນີ້ເພື່ອເປີດໃຊ້ບໍລິການ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "ການຕັ້ງຄ່າ Daemon"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "atSign ຂອງອຸປະກອນ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "ອຸປະກອນຕ້ອງໄດ້ຮັບການຕັ້ງຄ່າ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "ຊື່ອຸປະກອນ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr "ຊື່ອຸປະກອນສາມາດປະກອບມີ a-z 0-9 _ ຫຼື - (ຕົວຢ່າງ: \"my_thing1\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "ເປີດໃຊ້ງານ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "ລົງທະບຽນ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "OTP/SPP ສໍາລັບການລົງທະບຽນ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "ພົບກະແຈທີ່ມີຢູ່ແລ້ວທີ່:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "ຕົວອັກສອນທຳອິດຄວນເປັນຕົວພິມນ້ອຍ (ຕົວຢ່າງ: \"a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "ພາລາມິເຕີຄຳສັ່ງເພີ່ມເຕີມສຳລັບ NoPorts daemon"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "ອະນຸຍາດໃຫ້ luci-app-csshnpd ເຂົ້າເຖິງ UCI"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "atSign ຂອງຜູ້ຈັດການ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "ຄວາມຍາວສູງສຸດຂອງຊື່ອຸປະກອນແມ່ນ 36 ຕົວອັກສອນ."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "ຕ້ອງມີຄວາມຍາວຢ່າງໜ້ອຍໜຶ່ງຕົວອັກສອນ (ຕົວຢ່າງ: \"a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "ຕ້ອງມີຫົກຕົວອັກສອນ (ຕົວຢ່າງ: \"S3CR3T\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "ຕ້ອງບໍ່ຫວ່າງເປົ່າ ແລະ ຄວນເລີ່ມຕົ້ນດ້ວຍ @ (ຕົວຢ່າງ: \"@a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "ການຕັ້ງຄ່າ NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "ການລົງທະບຽນ NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "ການລົງທະບຽນ atSign ຂອງ NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "ຕ້ອງມີການກຳນົດຄ່າ OTP. ສາມາດສ້າງ OTP ໄດ້ໂດຍການໃຊ້:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "ລະຫັດຜ່ານຄັ້ງດຽວ (OTP) ສຳລັບການລົງທະບຽນ atSign ຂອງອຸປະກອນ"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr "ກົດປຸ່ມລົງທະບຽນ ແລ້ວແລ່ນຄຳສັ່ງນີ້ໃນລະບົບທີ່"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "atSign ຂອງອຸປະກອນ ຕົວຢ່າງ @device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "atSign ຂອງຜູ້ຈັດການ ຕົວຢ່າງ @manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "ຊື່ສຳລັບອຸປະກອນນີ້ ຕົວຢ່າງ openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "ຕ້ອງມີການກຳນົດຄ່າ atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "ການຕັ້ງຄ່າ sshnpd"

--- a/applications/luci-app-csshnpd/po/lt/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/lt/csshnpd.po
@@ -1,0 +1,142 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-24 04:42+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Papildomi argumentai"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Patikrinkite čia, kad įjungtumėte/įgalintumėte tarnybą"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Paslaugo teikimo sistemos konfigūracija"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "Įrenginio „atSign“"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "Įrenginys turi būti sukonfigūruotas"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Įrenginio pavadinimas"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Įrenginio pavadinimuose gali būti a–z, 0–9, _ arba – (pvz.: „my_thing1“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Įjungta/Įgalinta (-s/-i)"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Registruoti/-s"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "Registracija per „OTP/SPP“"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Egzistuojantis raktas rastas adresu:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "Pirma rašmuo turi būti mažąją raidę (pvz.: „a“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr ""
+"Tolimesnės komandos eilutės argumentas, skirtas „NoPorts“ paslaugų teikimo "
+"sistemai"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Suteikti „UCI“ prieigą – „luci-app-csshnpd“"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "Tvarkytuvo/Tvarkytuvės „atSign“"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "Maksimalus įrenginio pavadinimo ilgis yra 36-ios rašmenys."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Turi būti bent vienos rašmens ilgio (pvz.: „a“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Turi būti šešių rašmenų (pvz.: „S3CR3T“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "Neturi būti tuščias ir turi prasidėti „@“ simboliu (pvz.: „@a“)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "„NoPorts“"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "„NoPorts“ konfigūracija"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "„NoPorts“ registravimas"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "„NoPorts atSign“ registravimas"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "„OTP“ turi būti sukonfigūruotas. „OTP“ galima sugeneruoti naudojant:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "„One Time Passcode („OTP“)“, skirtas įrenginio „atSign“ registravimui"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Spauskite „Registruoti/-s“ mygtuką, tada vykdykite šią komandą sistemoje, "
+"kurioje"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "Įrenginio „atSign“, pvz.: @įrenginys"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "Tvarkytuvo/Tvarkytuvės „atSign“, pvz.: @tvarkytuvas/tvarkytuvė"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "Šio įrenginio pavadinimas, pvz.: „openwrt“"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "„atSign“ turi būti sukonfigūruotas"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "„sshnpd“ konfigūracija"

--- a/applications/luci-app-csshnpd/po/pl/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/pl/csshnpd.po
@@ -1,0 +1,141 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 16:04+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Dodatkowe argumenty"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Zaznacz tutaj, aby włączyć usługę"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Konfiguracja demona"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "Urządzenie atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "Urządzenie musi być skonfigurowane"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Nazwa urządzenia"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Nazwy urządzeń mogą zawierać znaki a-z 0-9 _ lub - (np. „moja_rzecz1”)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Włączone"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Zarejestruj"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "Rejestracja OTP/SPP"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Znaleziono istniejący klucz w:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "Pierwszy znak powinien być małą literą (np. „a”)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "Więcej argumentów wiersza poleceń dla demona NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Przyznaj luci-app-csshnpd dostęp do UCI"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "Menedżer atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "Maksymalna długość nazwy urządzenia wynosi 36 znaków."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Musi mieć co najmniej jeden znak (np. „a”)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Musi mieć sześć znaków (np. „S3KR3T”)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "Nie może być pusta i powinna zaczynać się od znaku @ (np. \"@a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "Konfiguracja NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "Rejestracja NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "Rejestracja NoPorts atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr ""
+"Należy skonfigurować hasło jednorazowe (OTP). Można je wygenerować za pomocą:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "Hasło jednorazowe (OTP) do rejestracji urządzenia w atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Naciśnij przycisk „Zarejestruj”, a następnie uruchom to polecenie w "
+"systemie, w którym"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "Urządzenie atSign, np. @device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "Menedżer atSign np. @manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "Nazwa tego urządzenia, np. openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "atSign należy skonfigurować"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "Konfiguracja sshnpd"

--- a/applications/luci-app-csshnpd/po/pt_BR/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/pt_BR/csshnpd.po
@@ -1,0 +1,136 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-01 22:50+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationscsshnpd/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Ativado"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr ""

--- a/applications/luci-app-csshnpd/po/ru/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/ru/csshnpd.po
@@ -1,0 +1,141 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-24 00:23+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Дополнительные аргументы"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Отметьте для включения службы"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Конфигурация демона"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "atSign устройства"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "Устройство должно быть настроено"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Имя устройства"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Имена устройств могут содержать буквы (a-z), цифры (0-9), символы (_) и (-). "
+"Например: \"my_thing1\"."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Включено"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Зарегистрировать"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "OTP/SPP для регистрации"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Найден существующий ключ:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "Первый символ должен быть строчной буквой (например, \"a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "Дополнительные аргументы командной строки для демона NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Предоставить доступ к UCI для luci-app-csshnpd"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "atSign менеджера"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "Максимальная длина имени устройства — 36 символов."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Должно содержать не менее одного символа (например, \"a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Должно состоять из шести символов (например, \"S3CR3T\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "Не должно быть пустым и должно начинаться с @ (например, \"@a\")."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "Настройка NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "Регистрация NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "Регистрация atSign для NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "Необходимо настроить OTP. Сгенерировать OTP можно командой:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "Одноразовый пароль (OTP) для регистрации atSign устройства"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Нажмите «Зарегистрировать», затем выполните эту команду на системе, где"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "atSign устройства, например @device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "atSign менеджера, например @manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "Имя этого устройства, например openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "Необходимо настроить atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "Настройка sshnpd"

--- a/applications/luci-app-csshnpd/po/templates/csshnpd.pot
+++ b/applications/luci-app-csshnpd/po/templates/csshnpd.pot
@@ -1,0 +1,127 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr ""
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr ""

--- a/applications/luci-app-csshnpd/po/uk/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/uk/csshnpd.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-12 09:06+0000\n"
+"Last-Translator: Oleksandr Yurov <oyurov@icloud.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationscsshnpd/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "Додаткові аргументи"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "Поставте позначку, щоб увімкнути службу"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "Конфігурація служби"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "@-ідентифікатор пристрою"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "Пристрій має бути налаштовано"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "Назва пристрою"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr ""
+"Назви пристрою можуть містити a-z 0-9 _ або - (наприклад, «my_thing1»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "Зареєструвати"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "OTP/SPP для реєстрації"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "Наявний ключ знайдено за шляхом:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "Перший символ має бути малою літерою (наприклад, «a»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "Додаткові аргументи командного рядка для служби NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "Надати доступ до UCI для luci-app-csshnpd"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "@-ідентифікатор менеджера"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "Максимальна довжина назви пристрою — 36 символів."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "Має містити щонайменше один символ (наприклад, «a»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "Має містити шість символів (наприклад, «S3CR3T»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "Не може бути порожнім і має починатися з @ (наприклад, «@a»)."
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "Налаштування NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "Реєстрація NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "Реєстрація @-ідентифікатора NoPorts"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "OTP має бути налаштовано. OTP можна згенерувати за допомогою:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "Одноразовий пароль (OTP) для реєстрації @-ідентифікатора пристрою"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+"Натисніть кнопку «Зареєструвати», а потім виконайте цю команду в системі, де"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "@-ідентифікатор пристрою, наприклад @device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "@-ідентифікатор менеджера, наприклад @manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "Назва цього пристрою, наприклад openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "@-ідентифікатор має бути налаштовано"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "конфігурація sshnpd"

--- a/applications/luci-app-csshnpd/po/zh_Hans/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/zh_Hans/csshnpd.po
@@ -1,0 +1,136 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-04 04:12+0000\n"
+"Last-Translator: konno_he <h3114931694@gmail.com>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationscsshnpd/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "附加参数"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "勾选以启用服务"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "守护进程配置"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr "设备 atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "必须配置设备"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "设备名"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr "名称由小写英文字母、数字、下划线或短横线组成（示例：\"my_thing1\")。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "已启用"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "注册"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "注册验证码 (OTP/SPP)"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "检测到现有密钥路径："
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "首字母必须为小写(例如： \"a\")。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "NoPorts 守护进程附加参数"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "授予 luci-app-csshnpd 访问 UCI 的权限"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr "主控端 atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "最大设备名称长度为36字符。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "长度必须至少为一个字符（例如：“a”）。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "必须由六个字符组成（例如：“S3CR3T”）。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "不能为空且必须以“@”开头（例如：“@a”）。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "NoPorts 配置"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "NoPorts 注册"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr "NoPorts atSign 注册"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr "必须配置验证码 (OTP)。可以通过以下命令生成："
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr "设备 atSign 注册的一次性验证码 (OTP)"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr "点击‘注册’按钮，然后在设备上运行此命令"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr "输入设备 atSign 例如：@device"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr "输入管理端 atSign 例如：@manager"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "输入本设备名称 例如：openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "必须配置 atSign"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "sshnpd 配置"

--- a/applications/luci-app-csshnpd/po/zh_Hant/csshnpd.po
+++ b/applications/luci-app-csshnpd/po/zh_Hant/csshnpd.po
@@ -1,0 +1,136 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-17 16:40+0000\n"
+"Last-Translator: 為什麼不加空格 <c++23@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationscsshnpd/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+msgid "Additional arguments"
+msgstr "額外參數"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+msgid "Check here to enable the service"
+msgstr "檢查這裡以啟用服務"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+msgid "Daemon Configuration"
+msgstr "常駐程式配置"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+msgid "Device atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
+msgid "Device must be configured"
+msgstr "裝置必須配置"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+msgid "Device name"
+msgstr "裝置名稱"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
+msgstr "裝置名稱可以包含 a-z、0-9、_ 或 - (例如「my_thing1」)。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+msgid "Enabled"
+msgstr "已啟用"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:60
+msgid "Enroll"
+msgstr "註冊"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+msgid "Enrollment OTP/SPP"
+msgstr "註冊 OTP/SPP"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:84
+msgid "Existing key found at:"
+msgstr "在這裡找到現存金鑰:"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+msgid "First character should be a lowercase letter (e.g., \"a\")."
+msgstr "首個字元應該為小寫字母 (例如「a」)。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+msgid "Further command line arguments for the NoPorts daemon"
+msgstr "NoPorts 常駐程式的更多命令列引數"
+
+#: applications/luci-app-csshnpd/root/usr/share/rpcd/acl.d/luci-app-csshnpd.json:3
+msgid "Grant UCI access for luci-app-csshnpd"
+msgstr "授予 luci-app-csshnpd 存取 UCI 的權限"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+msgid "Manager atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+msgid "Maximum device name length is 36 characters."
+msgstr "最大裝置名稱長度為 36 個字元。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+msgid "Must be at least one character long (e.g., \"a\")."
+msgstr "必須至少一個字元長 (例如「a」)。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+msgid "Must be six characters (e.g., \"S3CR3T\")."
+msgstr "必須為六個字元 (例如「S3CR3T」)。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+msgid "Must not be empty and should start with @ (e.g., \"@a\")."
+msgstr "必須不為空並應該以 @ 作為開頭 (例如「@a」)。"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
+msgid "NoPorts"
+msgstr "NoPorts"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:14
+msgid "NoPorts Config"
+msgstr "NoPorts 配置"
+
+#: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:23
+msgid "NoPorts Enrollment"
+msgstr "NoPorts 註冊"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:79
+msgid "NoPorts atSign Enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:82
+msgid "OTP must be configured. An OTP can be generated using:"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+msgid "One Time Passcode (OTP) for device atSign enrollment"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:49
+msgid "Press the Enroll button then run this command on a system where"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+msgid "The device atSign e.g. @device"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+msgid "The manager atSign e.g. @manager"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+msgid "The name for this device e.g. openwrt"
+msgstr "此裝置的名稱，例如: openwrt"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:80
+msgid "atSign must be configured"
+msgstr "atSign 必須配置"
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+msgid "sshnpd config"
+msgstr "sshnpd 配置"

--- a/applications/luci-app-dawn/po/cs/dawn.po
+++ b/applications/luci-app-dawn/po/cs/dawn.po
@@ -1,0 +1,724 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-01-07 14:02+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsdawn/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.15.1\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "Metriky 2.4G pásma"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "Metriky 5G pásma"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "802.11 kód když je ASSOCIATION odepřeno"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "802.11 kód když je AUTHENTICATION odepřeno"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr "Parametr DURATION 802.11k požadavku BEACON"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "Přístupový bod"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+"Veškeré hodnoty časovače jsou v sekundách. Jsou hlavním mechanizmem pro DAWN "
+"shromažďování a správa mnoha dat, na kterých závisí."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "Váha přístup. bodu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "K dispozici"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "Průměrné vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "Práh přenosové kapacity (Mbitů/s)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr ""
+"Základní hodnocení pro přístupový bod, založené na frekv. pásmu, ve kterém "
+"operuje"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "Všesměrové vysílání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "IP adresa všesměrového vysílání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr "Port všesměrového vysílání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "Kanál"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr "Vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr "Hodnota vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "Zkontrolovat služby spouštěné po startu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "Klient"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "Klienti"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr "Při zvažování vykopnutí porovnat počty připojených stanic"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "Připojeno k síti"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "Překročen časový limit spojení"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr "Řídí zda jsou pro odmítnutí vyhodnocovány rámce ASSOCIATION"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr "Řídí zda jsou pro odmítnutí vyhodnocovány rámce AUTHENTICATION"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr "Řídí zda jsou pro odmítnutí vyhodnocovány rámce PROBE"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "Nastavení DAWN formuláře."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "Služba DAWN není k dispozici"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "TRVÁNÍ"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr "Hlubší trasování pro opravu chyb – pro účely ladění"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "Výchozí hodnota"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "Důvod odepření asociace"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "Důvod odepření ověření"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr "Délka hlášení odasociovaného souseda"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr "Vyhodnocený požadavek na asociaci"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr "Vyhodnocený požadavek na ověření"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr "Vyhodnocený požadavek na sondu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "Frekvence"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "Globální metrika"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "Udělit luci-app-dawn přístup do UCI nastavování"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "Podpora HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "Mapa „slyšení“"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "Vysoká propustnost"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Složka s hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "IP adresa pro všesměrové a vícesměrové vysílání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "IP adresa když není používáno UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "IP port pro všesměrové a vícesměrové vysílání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "Počáteční hodnocení"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "Rozhraní"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "Vykopávání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr "Práh pro vykopávání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "Lokální"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "Stupeň podrobnosti záznamu událostí"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "Nízké RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "Nízká hodnota RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "Nižší práh pro špatné vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "Nejvyšší umožněné vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "Hodnota nejvyššího vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr "Nejvyšší rozdíl stanic"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+"Nejvyšší hlášená propustnost mezi přístupovým bodem a klientem při "
+"vykopnutí. Pokud chcete tuto kontrolu vypnout, nastavte na nulu (0)."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr "Metoda síťování mezi instancemi DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr "Metoda pro výběr klientů k přesunutí na lepší přístupový bod"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr "Metoda použitá pro nastavování hlášení o sousedech na přístupovém bodu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr "Střední bod pro vážené vyhodnocování RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr "Nejnižší počet pro vykopnutí"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr "Nejnižší počet sond"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr ""
+"Nejnižší rozdíl hodnocení pro zvážení vykopnutí na alternativní přístupový "
+"bod"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+"Další informace pro pomoc s dosledováním, kde algormitmy mohou dělat chybu – "
+"pro účely ladění"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "Vícesměrové vysílání"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "Sousedé"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "Síť"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "Přehled sítě"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "Předvolba sítě"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "Ne"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "Bez podpory HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "Bez podpory VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "Nejsou k dispozici žádné přístupové body."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "Nepřipojeni žádní klienti."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "Není k dispozici"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr "Počet připojených stanic pro zvažování „lepšího“ pro use_station_count"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+"Počet po sobě následujících okamžiků po kterých by měl být klient vyhodnocen "
+"jako připraven k vykopnutí ještě než se tak skutečně stane"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr "Počet položek které zahrnout do 802.11v DISASSOCIATE hlášení sousedů"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr "Počet období sběru vzorků pro zprůměrování hodnot využití kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr "Kolikrát by se klient měl znovu pokusit o PROBE než bude přijat"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "Popis umístění běhových informaci z hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "Váhy pro jednotlivé přístupové body"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "Přírůstek na dB pro vážené vyhodnocování RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "Port pro TCP síťování"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+"Upřednostňované pořadí pro použití BEACON informace Passive, Active nebo "
+"Table 802.11k"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "Režim RRM"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "Střed RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "Hodnota RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "Váha RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "Obdržená indikace energie kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "Obdržený indikátor signál/šum"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "Odebrat přístupový bod"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "Odebrat klienta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "Odebrat sondu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "Hlášení při standardním chování"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "Hodnocení"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "Přidání hodnocení pokud signál přesáhne prahovou hodnotu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "Přidání hodnocení pokud je signál pod prahovou hodnotou"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "Přírůstek hodnocení pokud HT není podporováno"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "Přírůstek hodnocení pokud HT je podporováno"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "Přírůstek hodnocení pokud VHT není podporováno"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "Přírůstek hodnocení pokud VHT je podporováno"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "Přírůstek hodnocení pokud je využití kanálu nad max_chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "Přírůstek hodnocení pokud je využití kanálu pod max_chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "Vážná porucha / neočekávané chování"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "IP adresa serveru"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "Nastavit hlášení o sousedech z hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "Signál"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "Něco se jeví špatné, ale zotavitelné"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr ""
+"Mezerou oddělovaný seznam MAC adres které používat ve „statickém“ hlášení "
+"sousedů přístupového bodu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "Standardní chování stojí za to hlásit vždy"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "Připojených stanic"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "TCP port"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "TCP s/bez UMDNS objevováním"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "TCP s UMDNS objevováním"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "Práh pro dobré RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "Práh pro špatné RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+"Časovač (opětnovné) registrace pro zprávy hostapd pro každé lokální BSSID"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr "Časovač požádání všech připojených klientů o nové BEACON REPORT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+"Časovač získání stávající hodnoty vytížení kanálu pro každé lokální BSSID"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+"Časovač znovunačtení / odebrání TCP spojení s ostatním instancemi DAWN, "
+"nalezenými prostřednictvím uMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+"Časovač znovunačtení informací o lolálním spojení a odeslání revidovaného "
+"NEIGHBOR REPORT všem klientům"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr ""
+"Časovač odebrání položek přístupvých bodů se skončenou platností z hlavní "
+"datové sady"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+"Časovač odebrání položek PROBE a BEACON se skončenou platností z hlavní "
+"datové sady"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr ""
+"Časovač pro odebrání položek klientů se skončenou platností z hlavní datové "
+"sady"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "Časy"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "Časové rozpětí, než je na spojení pohlíženo jak ona odpojené"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr ""
+"Nebylo možné dotázat službu DAWN prostřednictvím ubus – služba se zdá být "
+"zastavená."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "Zaktualizovat hlášení o beacon"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "Zaktualizovat vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "Zaktualizovat klienta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "Zaktualizovat hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "Zaktualizovat TCP spojení"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "Horní hranice pro dobré vytížení kanálu"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr "Použít počet stanic"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "Vytížení"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "Podpora VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr "Podrobnost zpráv v syslog"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "Velmi vysoká propustnost"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "Ano"

--- a/applications/luci-app-dawn/po/ga/dawn.po
+++ b/applications/luci-app-dawn/po/ga/dawn.po
@@ -1,0 +1,735 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-24 00:23+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsdawn/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "Banda Méadrach 2.4G"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "Méadrach Banda 5G"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "Cód 802.11 a úsáidtear nuair a dhiúltaítear don Chomhlachas"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "Cód 802.11 a úsáidtear nuair a dhiúltaítear FÍORÚ"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr "Iarratas BEACON 802.11k paraiméadar FAD"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "Pointe Rochtana"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+"Is i soicindí atá na luachanna uile ar an lasc ama. Is iad an phríomh-"
+"mheicníocht a úsáideann DAWN chun cuid mhór den fhaisnéis a bhfuil sé ag "
+"brath uirthi a bhailiú agus a bhainistiú."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "Meáchan Ap"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "Ar fáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "Meánúsáid cainéil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "Tairseach Bandaleithid (Mbits/s)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr "Scór bonn le haghaidh AP bunaithe ar bhanda oibriúcháin"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "Craoladh"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "IP Craolta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr "PORT Craolta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "Cainéal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr "Úsáid Cainéal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr "Luach Úsáide Cainéal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "Seiceáil seirbhísí Tosaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "Cliant"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "Cliaint"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr ""
+"Déan comparáid idir líon na stáisiún ceangailte agus tú ag smaoineamh ar "
+"chiceáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "Ceangailte le Líonra"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "Am Teorann Ceangail"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr "Rialú an ndéantar frámaí COMHLACHA a mheasúnú le haghaidh diúltaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr ""
+"Rialú an ndéantar frámaí FÍORDHÉARDMHEASA a mheasúnú le haghaidh diúltaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr "Rialú an ndéantar frámaí PROBE a mheasúnú le haghaidh diúltaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "Cumraíocht Foirme DAWN."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "Seirbhís DAWN ar fáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "FAD"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr "Rianú níos doimhne chun fabhtanna a shocrú - le haghaidh dífhabhtaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "Luach Réamhshocraithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "Cúis leis an gCumann a Dhiúltú"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "Cúis údaraithe a dhiúltú"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr "Fad na Tuairisce ar an gComharsa a Dhícheanglaíocht"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr "Iarratas Comhlachais Measúnaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr "Iarratas Údaraithe Measúnaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr "Iarratas ar Thástáil Measúnaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "Minicíocht"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "Méadrach Domhanda"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "Deonaigh rochtain UCI do luci-app-dawn"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "Tacaíocht HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "Léarscáil Éisteachta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "Ard-Tréchur"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Eolaire Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "Seoladh IP le haghaidh craolta agus ilchraolta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "Seoladh IP nuair nach bhfuil UMDNS in úsáid"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "Port IP le haghaidh craolta agus ilchraolta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "Scór Tosaigh"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "Comhéadan"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "Ag ciceáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr "Tairseach Ciceáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "Áitiúil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "Leibhéal Logála"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "RSSI Íseal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "Luach Íseal RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "Tairseach níos ísle le haghaidh drochúsáid chainéil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "Uasúsáid Cainéal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "Uasluach Úsáide Cainéal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr "Difríocht Uasta Stáisiúin"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+"An bandaleithead uasta tuairiscithe atá ceadaithe ag cliant AP agus é á "
+"chiceáil. Socraigh go náid chun an seiceáil a dhíchumasú."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr "Modh líonraithe idir cásanna DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr "Modh chun cliaint a roghnú le bogadh chuig AP níos fearr"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr "Modh a úsáidtear chun Tuarascáil Chomharsanachta a shocrú ar AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr "Lárphointe le haghaidh meastóireachta RSSI ualaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr "Íoslíon le Ciceáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr "Líon Íosta na dTástálacha"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr ""
+"Difríocht scór íosta le breithniú a dhéanamh ar chiceáil chuig AP malartach"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+"Tuilleadh eolais chun cabhrú le rianú cá bhféadfadh halgartaim a bheith ag "
+"dul amú - le haghaidh dífhabhtaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "Ilchraoladh"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "Comharsana"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "Líonra"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "Forbhreathnú ar an Líonra"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "Rogha líonra"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "Níl"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "Gan Tacaíocht HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "Gan Tacaíocht VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "Níl aon phointí rochtana ar fáil."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "Gan aon chliaint ceangailte."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "Níl sé ar fáil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+"Líon na stáisiún nasctha le breithniú mar \"níos fearr\" le "
+"húsáid_líon_stáisiúin"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+"Líon na n-uaireanta as a chéile ba chóir cliant a mheas mar réidh le ciceáil "
+"sula ndéanann sé é i ndáiríre"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr ""
+"Líon na n-iontrálacha le cur san áireamh i dTuarascáil Chomharsanachta "
+"DÍCHEANGLAITHE 802.11v"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr ""
+"Líon na dtréimhsí samplála chun meánluachanna úsáide cainéil a bhaint amach "
+"thar"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr ""
+"Líon na n-uaireanta ba chóir do chliant ath-thriail a dhéanamh ar PROBE sula "
+"nglactar leis"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "Cosán chuig faisnéis rith-ama hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "Ualú in aghaidh an AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "In aghaidh an mhéadaithe dB le haghaidh meastóireachta RSSI ualaithe"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "Port le haghaidh líonrú TCP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+"An t-ord is fearr le haghaidh úsáid faisnéise BEACON Éighníomhach, Gníomhach "
+"nó Tábla 802.11k"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "Mód RRM"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "Ionad RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "Luach RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "Meáchan RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "Táscaire Cumhachta Cainéal Faighte"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "Táscaire Comhartha Faighte go Torann"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "Bain AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "Bain Cliant"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "Bain an Tóireadóir"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "Tuairisciú ar iompar caighdeánach"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "Scór"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "Breis scóir nuair a sháraíonn an comhartha an tairseach"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "Breis scóir nuair a bhíonn an comhartha faoi bhun na tairsí"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "Méadú scóir mura dtacaítear le HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "Méadú scóir má thacaítear le HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "Méadú scóir mura dtacaítear le VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "Méadú scóir má thacaítear le VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "Méadú scóir má tá úsáid an chainéil os cionn max_chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "Méadú scóir má tá úsáid an chainéil faoi bhun chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "Mífheidhmiú tromchúiseach / iompar gan choinne"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "IP an fhreastalaí"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "Socraigh Tuarascáil Chomharsa Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "Comhartha"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "Is cosúil go bhfuil rud éigin cearr, ach is féidir é a aisghabháil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr ""
+"Liosta MACS scartha ag spásanna le húsáid i dTuarascáil Chomharsanachta AP "
+"\"statach\""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "Is fiú i gcónaí iompar caighdeánach a thuairisciú"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "Stáisiúin Ceangailte"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "Port TCP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "TCP gan fionnachtain UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "TCP le fionnachtain UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "Tairseach le haghaidh RSSI maith"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "Tairseach le haghaidh RSSI lochtach"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+"Amaire chun (ath)chlárú le haghaidh teachtaireachtaí hostapd do gach BSSID "
+"áitiúil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr "Amaire chun TUARASCÁIL BHEACON nua a iarraidh ar gach cliant nasctha"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+"Amaire chun figiúr úsáide cainéil le déanaí a fháil do gach BSSID áitiúil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+"Amadóir chun naisc TCP le cásanna DAWN eile a fuarthas trí uMDNS a "
+"athnuachan / a bhaint"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+"Amadóir chun faisnéis nasc áitiúil a athnuachan agus TUARASCÁIL COMHARSANTA "
+"athbhreithnithe a sheoladh chuig gach cliant"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr ""
+"Amadóir chun iontrálacha AP atá imithe in éag a bhaint as an tacar sonraí "
+"lárnacha"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+"Amaire chun iontrálacha PROBE agus BEACON atá imithe in éag a bhaint as an "
+"tacar sonraí lárnacha"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr ""
+"Amadóir chun iontrálacha cliant atá imithe in éag a bhaint as an tacar "
+"sonraí lárnach"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "Amanna"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "Tréimhse ama go dtí go bhfeictear nasc mar nasc dícheangailte"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr ""
+"Ní féidir fiosrúchán a dhéanamh ar sheirbhís DAWN trí ubus, is cosúil go "
+"bhfuil an tseirbhís stoptha."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "Nuashonraigh tuarascálacha Beacon"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "Nuashonraigh úsáid an chainéil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "Nuashonraigh an Cliant"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "Nuashonraigh Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "Nuashonraigh naisc TCP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "Tairseach uachtarach le haghaidh dea-úsáid chainéil"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr "Úsáid Líon na Stáisiún"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "Úsáid"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "Tacaíocht VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr "Focúlacht na dteachtaireachtaí sa syslog"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "Tréchur An-Ard"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "Tá"

--- a/applications/luci-app-dawn/po/ko/dawn.po
+++ b/applications/luci-app-dawn/po/ko/dawn.po
@@ -1,0 +1,708 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-16 23:09+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsdawn/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "2.4G 대역 평가 기준"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "5G 대역 평가 기준"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "연결이 거부되었을 때 사용하는 802.11 표준 사유 코드"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "인증이 거부되었을 때 사용하는 802.11 표준 사유 코드"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr "802.11k 비콘 요청 측정 시간 매개변수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "액세스 포인트(AP)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+"모든 시간 설정 값은 초 단위입니다. 해당 설정은 DAWN이 운용 데이터를 수집하고 "
+"관리하는 핵심 기제입니다."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "AP 가중치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "사용 가능"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "평균 채널 이용률"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "대역폭 임계값 (Mbits/s)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr "운용 대역별 AP 기본 평가 지수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "브로드캐스트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "브로드캐스트 IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr "브로드캐스트 포트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "채널"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr "채널 이용률"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr "채널 이용률 값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "시작 서비스 확인"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "클라이언트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "클라이언트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr "단말 추방 판단 시 연결 단말 수 비교"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "네트워크 연결"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "연결 시간 초과"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr "연결 프레임을 평가하여 거부 여부 결정"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr "인증 프레임을 평가하여 거부 여부 결정"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr "프로브 프레임을 평가하여 거부 여부 결정"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "DAWN 설정을 구성합니다."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "DAWN 서비스를 사용할 수 없음"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "측정 지속 시간"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr "버그 수정을 위한 정밀 추적 - 디버그용"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "기본값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "연결 거부 사유"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "인증 거부 사유"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr "연결 해제 인접 리포트 길이"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr "연결 요청 심사"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr "인증 요청 심사"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr "프로브 요청 심사"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "주파수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "공통 평가 기준"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "luci-app-dawn의 UCI 접근 권한 부여"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "HT 지원"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "단말 탐지 현황"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "고처리량(High Throughput)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Hostapd 디렉터리"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "브로드캐스트 및 멀티캐스트 IP 주소"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "UMDNS 미사용 시의 IP 주소"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "브로드캐스트 및 멀티캐스트 IP 포트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "초기 평가 지수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "인터페이스"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "추방"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr "추방 임계값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "로컬"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "로그 수준"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "RSSI 미약"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "RSSI 미약 값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "채널 상태 불량 판정 기준 채널 이용률 임계값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "최대 채널 이용률"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "최대 채널 이용률 값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr "최대 단말 수 차이"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+"AP-클라이언트 대역폭이 해당 설정값보다 낮아지면 클라이언트를 추방합니다. 0으"
+"로 설정하면 기능을 끕니다."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr "DAWN 인스턴스 간 네트워크 통신 방식"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr "최적 AP 전환 대상 클라이언트 선정 방식"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr "AP 인접 리포트 설정 방식"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr "가중 RSSI 평가 기준점"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr "최소 추방 시도 횟수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr "최소 프로브 시도 횟수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr "다른 AP로의 전환을 위해 추방을 검토할 최소 평가 지수 차이"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr "알고리즘 오류 지점 추적을 위한 추가 정보 - 디버그용"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "멀티캐스트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "이웃"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "네트워크"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "네트워크 개요"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "네트워크 옵션"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "아니요"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "HT 미지원"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "VHT 미지원"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "사용 가능한 액세스 포인트가 없습니다."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "연결 클라이언트가 없습니다."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "미지원"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+"연결 단말 수 활용(use_station_count) 시 최적 AP로 평가할 단말 수 차이 기준"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr "단말을 실제로 추방하기까지 추방 요건을 연속으로 충족해야 하는 횟수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr "802.11v 연결 해제 인접 리포트에 포함할 항목의 개수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr "채널 이용률 값의 평균을 산출하기 위한 샘플링 주기 횟수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr ""
+"클라이언트의 접속을 허용하기까지 프로브 시도가 연속으로 확인되어야 하는 횟수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "hostapd 실행 정보 경로"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "AP별 지정 가중치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "가중 RSSI 평가 시 1dB 증가당 지수 가산치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "TCP 통신 포트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+"802.11k 비콘 정보 수집 방식 우선순위 조합 (p: 수동 측정, a: 능동 측정, t: 자"
+"체 표 참조)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "RRM 모드"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "RSSI 기준점"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "RSSI 값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "RSSI 가중치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "수신 채널 전력 지표(Received Channel Power Indication)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "수신 신호 대 잡음 지표(Received Signal to Noise Indicator)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "AP 삭제"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "클라이언트 삭제"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "프로브 삭제"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "모든 표준 동작"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "평가 지수"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "신호 임계값 초과 시 평가 지수 가산치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "신호 임계값 미만 시 평가 지수 조정값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "HT 미지원 시 평가 지수 조정값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "HT 지원 시 평가 지수 가산치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "VHT 미지원 시 평가 지수 조정값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "VHT 지원 시 평가 지수 가산치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "최대 채널 이용률 값(max_chan_util_val) 초과 시 평가 지수 조정값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "채널 이용률 값(chan_util_val) 미만 시 평가 지수 가산치"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "심각한 고장 또는 예기치 않은 동작"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "서버 IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "Hostapd 인접 리포트 설정"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "신호"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "오류 발생 (복구 가능)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr "\"정적\" AP 인접 리포트에서 사용할 MAC 주소 목록 (공백으로 구분)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "주요 표준 동작"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "연결 단말"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "TCP 포트"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "TCP (UMDNS 탐색 미사용)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "TCP (UMDNS 탐색 사용)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "RSSI 좋음(Good) 임계값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "RSSI 나쁨(Bad) 임계값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr "각 로컬 BSSID의 hostapd 메시지 수신을 (재)등록하는 주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr "연결된 모든 클라이언트에 새로운 비콘 리포트를 요청하는 주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr "각 로컬 BSSID의 최근 채널 이용률 수치를 가져오는 주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+"uMDNS를 통해 찾은 다른 DAWN 인스턴스와의 TCP 연결을 새로 고치거나 삭제하는 주"
+"기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+"로컬 연결 정보를 새로 고치고 수정된 인접 리포트를 모든 클라이언트에 전송하는 "
+"주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr "핵심 데이터 세트에서 만료된 AP 항목을 삭제하는 주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr "핵심 데이터 세트에서 만료된 프로브 및 비콘 항목을 삭제하는 주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr "핵심 데이터 세트에서 만료된 클라이언트 항목을 삭제하는 주기"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "시간 설정"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "연결이 끊긴 것으로 판단하기까지의 시간"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr ""
+"ubus를 통해 DAWN 서비스에 연결할 수 없습니다. 서비스가 중지된 상태인 것 같습"
+"니다."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "비콘 리포트 갱신"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "채널 이용률 갱신"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "클라이언트 갱신"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "Hostapd 갱신"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "TCP 연결 갱신"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "채널 상태 우수 판정 기준 채널 이용률 임계값"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr "연결 단말 수 활용"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "이용률"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "VHT 지원"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr "Syslog 메시지의 상세 수준"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "초고처리량(Very High Throughput)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "예"

--- a/applications/luci-app-dawn/po/pt_BR/dawn.po
+++ b/applications/luci-app-dawn/po/pt_BR/dawn.po
@@ -1,0 +1,694 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-17 16:40+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationsdawn/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "Métrica da Banda 2.4G"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "Métrica da Banda 5G"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "Código 802.11 usado quando a ASSOCIAÇÃO é negada"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "Código 802.11 usado quando a AUTENTICAÇÃO é negada"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "Ponto de acesso"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "Cliente"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr ""
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr ""

--- a/applications/luci-app-dawn/po/ru/dawn.po
+++ b/applications/luci-app-dawn/po/ru/dawn.po
@@ -1,0 +1,725 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-22 23:36+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsdawn/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "Метрика диапазона 2.4 ГГц"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "Метрика диапазона 5 ГГц"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "Код ошибки 802.11 при отклонении ассоциации"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "Код ошибки 802.11 при отклонении аутентификации"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr "Длительность запроса маячковых кадров (802.11k Beacon Request)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "Точка доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+"Все временные интервалы указываются в секундах и служат основным механизмом "
+"для сбора и управления данными в системе DAWN."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "Коэффициент приоритета точки доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "Доступно"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "Ср. загрузка канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "Порог пропускной способности (Мбит/с)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr "Базовый рейтинг AP по диапазону частот"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "Широковещательная рассылка"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "IP-вещание"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr "Порт широковещательной рассылки"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "Канал"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr "Загрузка канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr "Значение загрузки канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "Проверить службы автозагрузки"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "Клиент"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "Клиенты"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr ""
+"Сравнивать количество подключённых клиентов при принятии решения об "
+"отключении"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "Подключено к сети"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "Время oжидания соединения"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr "Оценивать фреймы ассоциации для принятия решения об отказе"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr "Оценивать фреймы аутентификации для принятия решения об отказе"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr "Оценивать пробные фреймы для принятия решения об отказе"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN (система управления Wi-Fi)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "Настройка параметров формы DAWN."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "Служба DAWN недоступна"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "ПРОДОЛЖИТЕЛЬНОСТЬ"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr "Более глубокое отслеживание для исправления ошибок — для отладки"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "Значение по умолчанию"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "Причина отказа в ассоциации"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "Причина отказа в авторизации"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr "Длина отчета об отключении от соседнего узла"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr "Проанализированный запрос на ассоциацию"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr "Проверенный запрос на аутентификацию"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr "Обработанный пробный запрос"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "Частота"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "Глобальная метрика"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "Предоставить доступ к UCI для luci-app-dawn"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT (High Throughput — Высокая пропускная способность)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "Поддержка стандарта 802.11n (HT)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "Карта покрытия"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "Стандарт высокой пропускной способности (HT)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Утилита hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Каталог hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "IP-адрес для широковещательной и многоадресной рассылки"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "IP-адрес при неиспользовании UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "IP-порт для широковещательной и многоадресной рассылки"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "Начальный балл"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "Интерфейс"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "Отключение клиента"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr "Порог для отключения клиентов"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "Локальный"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "Уровень журналирования"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "Низкий RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "Низкое значение RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "Верхний порог плохой загрузки канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "Максимальная загрузка канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "Максимальное значение загрузки канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr "Максимальное расстояние между станциями"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+"Максимально допустимая заявленная пропускная способность между точкой "
+"доступа и клиентом при отключении. Установите в ноль для отключения проверки."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr "Метод сетевого взаимодействия между экземплярами DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr ""
+"Метод выбора клиентов для переключения на более подходящую точку доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr "Метод формирования отчёта о соседних точках доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr "Центральная точка для взвешенной оценки RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr "Мин. количество для отключения"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr "Мин. количество пробных запросов"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr ""
+"Минимальная разница рейтинга для рассмотрения переключения на другую точку "
+"доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+"Дополнительная информация для трассировки потенциальных ошибок в алгоритмах "
+"— для отладки"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "Многоадресная рассылка"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "Соседние точки доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "Сеть"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "Обзор сети"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "Сетевой режим"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "Нет"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "Без поддержки HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "Без поддержки VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "Нет доступных точек доступа."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "Нет подключённых клиентов."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "Недоступно"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+"Количество подключённых станций, считающихся «лучшими» для параметра "
+"use_station_count"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+"Количество последовательных проверок, после которых клиент будет отключён"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr "Количество записей, включаемых в отчёт о соседях 802.11v DISASSOCIATE"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr "Количество периодов выборки для усреднения значений загрузки канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr "Количество попыток PROBE перед принятием клиента"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "Путь к каталогу данных hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "Коэффициент приоритета для каждой точки доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "Приращение за дБ при взвешенной оценке RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "Порт для TCP-соединений"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+"Приоритет использования пассивного, активного или табличного режима запроса "
+"маячковых кадров 802.11k BEACON"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI (индикатор мощности канала)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "Режим RRM"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI (отношение сигнал/шум)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI (уровень сигнала)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "Центральное значение RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "Значение RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "Вес RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "Индикация мощности принимаемого канала (RCPI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "Индикатор отношения сигнал/шум (RSNI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "Удаление точки доступа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "Удаление клиента"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "Удаление пробных запросов"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "Отчёт о стандартном поведении"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "Рейтинг"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "Прибавка к рейтингу при превышении порога сигнала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "Прибавка к рейтингу при уровне сигнала ниже порога"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "Прибавка к рейтингу при отсутствии поддержки HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "Прибавка к рейтингу при поддержке HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "Прибавка к рейтингу при отсутствии поддержки VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "Прибавка к рейтингу при поддержке VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "Прибавка к рейтингу при загрузке канала выше max_chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "Прибавка к рейтингу при загрузке канала ниже chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "Критическая ошибка / непредвиденное поведение"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "IP-адрес сервера"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "Формирование отчёта о соседях в hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "Сигнал"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "Обнаружена ошибка, но система может восстановиться"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr "Список MAC-адресов (через пробел) для статического отчёта о соседях"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "Стандартные события, всегда подлежащие регистрации"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "Подключённые станции"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "TCP-порт"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "TCP без обнаружения через UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "TCP с обнаружением через UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "Порог хорошего уровня сигнала (RSSI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "Порог плохого уровня сигнала (RSSI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+"Таймер повторной регистрации для приёма сообщений hostapd от каждого "
+"локального BSSID"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr ""
+"Таймер запроса новых отчётов маячковых кадров BEACON REPORT у всех "
+"подключённых клиентов"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+"Таймер получения последних данных о загрузке канала для каждого локального "
+"BSSID"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+"Таймер обновления / удаления TCP-подключений к другим экземплярам DAWN, "
+"найденным через uMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+"Таймер обновления информации о локальных подключениях и отправки "
+"обновлённого отчёта NEIGHBOR REPORT всем клиентам"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr ""
+"Таймер удаления устаревших записей точек доступа из основного набора данных"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+"Таймер удаления устаревших записей PROBE и BEACON из основного набора данных"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr "Таймер удаления устаревших записей клиентов из основного набора данных"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "Интервалы времени"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "Промежуток времени, после которого соединение считается разорванным"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr ""
+"Не удаётся опросить службу DAWN через ubus; похоже, служба остановлена."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "Обновление отчётов BEACON"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "Обновить информацию о загрузке канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "Обновить данные клиента"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "Обновить информацию hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "Обновить TCP-соединения"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "Верхний порог хорошей загрузки канала"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr "Учитывать количество клиентов"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "Загрузка"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "Поддержка VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr "Детализация сообщений в syslog"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "Очень высокая пропускная способность (VHT)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "Да"

--- a/applications/luci-app-dawn/po/sv/dawn.po
+++ b/applications/luci-app-dawn/po/sv/dawn.po
@@ -1,0 +1,695 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-22 17:11+0000\n"
+"Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
+"Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsdawn/sv/>\n"
+"Language: sv\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "2.4G Metriskt band"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "5G Metriskt band"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "Åtkomstpunkt"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "Vikt Åp"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "Tillgänglig"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "Genomsnittligt kanalutnyttjande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "Bandbreddsgräns (Mbit/s)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "Sänd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "Kanal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "Kolla uppstartstjänster"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "Klient"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "Klienter"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "Ansluten till nätverket"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "DAWN-tjänsten otillgänglig"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "VARAKTIGHET"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "Standardvärde"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "Orsak till nekad association"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "Orsak nekad autentisering"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "Frekvens"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "Globalt metrisk"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "Tillåt UCI-access för luci-app-dawn"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "HT-stöd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "Hörselkarta"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "Hög genomströmning"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Hostapd katalog"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "IP-adress för broadcast och multicast"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "IP-adress utan UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "IP-port för broadcast och multicast"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "Initialt resultat"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "Gränssnitt"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "Sparkar"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "Lokalt"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "Loggnivå"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "Låg RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "Lågt RSSI-värde"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "Låga gränsvärdet för dåligt kanal-utnyttjande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "Maximal kanalutnyttjande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "Värde för maximal kanalutnyttande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr "Metod för att välja klienter att flytt till bättre AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+"Mer information för att spåra när algoritmer kan göra fel - för debuggning"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "Multicast"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "Grannar"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "Nätverk"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "Nätverksöverblick"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "Nätverksalternativ"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "Nej"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "Inget stöd för HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "Inget stöd för VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "Ingen tillgänglig accesspunkt."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "Ingen ansluten klient."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "Inte tillgänglig"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "Katalog till körinformation för hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "Per PA-viktning"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "Per dB-ökning för viktad RSSI-utvärdering"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "Port för TCP-nätverk"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "RRM-läge"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "RSSI-centrum"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "RSSI-värde"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "RSSI-vikt"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "Indikator för mottagen kanals styrka"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "Indikator för mottagen Signal till Brus"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "Ta bort AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "Ta bort Klient"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "Ta bort Sond"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "Rapportering av standardbeteende"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "Resultat"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "Extra poäng när signalen överskrider gräns"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "Extra poäng när signalen svagare än gräns"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "Extra poäng om stöd för HT saknas"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "Extra poäng om HT stöds"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "Extra poäng om stöd för VHT saknas"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "Extra poäng om VHT stöds"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "Extra poäng om kanalutnyttjandet är över max_chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "Extra poäng om kanalutnyttjandet är under chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "Allvarlig felaktig funktion / ej förväntat beteende"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "Serverns IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "Signal"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "Något verkar vara fel, men reparerbart"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "Är värt att rapporterar standardbeteende"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "Anslutna stationer"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "Port för TCP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "TCP utan UMDNS-upptäckning"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "TCP med UMDNS-upptäckning"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "Gränsvärde för bra RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "Gränsvärde för dåligt RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "Tider"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "Tidsspann tills att en anslutning anses vara avslutad"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr "Kan inte utnyttja DAWN-tjänsten via ubus, tjänsten kan vara stoppad."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "Uppdatera Beacon-rapport"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "Uppdatera kanalutnyttjande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "Uppdatera klienten"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "Uppdatera Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "Uppdatera TCP-anslutningar"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "Övre gränsvärde för bra kanal-utnyttjande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "Utnyttjande"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "Stöd för VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "Väldigt hög genomströmning"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "Ja"

--- a/applications/luci-app-dawn/po/uk/dawn.po
+++ b/applications/luci-app-dawn/po/uk/dawn.po
@@ -1,0 +1,715 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-15 10:43+0000\n"
+"Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsdawn/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5.dev0\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "Метрика діапазону 2.4 ГГц"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "Метрика діапазону 5 ГГц"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "Код 802.11, що використовується, коли ASSOCIATION відхилено"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "Код 802.11, що використовується, коли AUTHENTICATION відхилено"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr "Параметр DURATION для запиту BEACON 802.11k"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "Точка доступу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+"Усі значення таймерів задаються у секундах. Це основний механізм, за "
+"допомогою якого DAWN збирає та керує більшістю даних, на які він спирається."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "Пріоритет точки доступу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "Доступно"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "Середнє використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "Поріг пропускної здатності (Мбіт/с)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr "Базовий бал для AP на основі робочого діапазону"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "Трансляція"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "IP трансляції"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr "Порт трансляції"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "Канал"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr "Використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr "Значення використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "Перевірити служби автозапуску"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "Клієнт"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "Клієнти"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr "Порівнювати кількість підключених станцій під час оцінки відключення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "Підключено до мережі"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "Тайм-аут зʼєднання"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr "Чи оцінюються кадри ASSOCIATION щодо відхилення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr "Чи оцінюються кадри AUTHENTICATION щодо відхилення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr "Чи оцінюються кадри PROBE щодо відхилення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "Конфігурація форми DAWN."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "Служба DAWN недоступна"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "DURATION"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr "Глибше трасування для виправлення помилок — для зневадження"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "Типове значення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "Причина відмови в асоціації"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "Причина відмови в авторизації"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr "Довжина звіту про роз’єднання сусідніх вузлів"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr "Оцінений запит на асоціацію"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr "Оцінений запит на автентифікацію"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr "Оцінюваний пробний запит"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "Частота"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "Загальна метрика"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "Надати доступ до UCI для luci-app-dawn"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "Підтримка HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "Карта чутності"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "Висока пропускна здатність"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Каталог hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "IP-адреса для трансляції та мультикасту"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "IP-адреса, коли UMDNS не використовується"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "IP-порт для трансляції та мультикасту"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "Початковий бал"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "Інтерфейс"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "Відключення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr "Поріг відключення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "Локальний"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "Рівень журналювання"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "Низький RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "Значення низького RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "Нижній поріг для поганого використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "Макс. використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "Значення макс. використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr "Макс. різниця станцій"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+"Максимальна повідомлена пропускна здатність AP-клієнт, дозволена під час "
+"відключення. Встановіть нуль, щоб вимкнути перевірку."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr "Метод мережевої взаємодії між екземплярами DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr "Метод вибору клієнтів для переміщення до кращої AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr "Метод встановлення Neighbor Report на AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr "Середня точка для зваженої оцінки RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr "Мінімальне число для відключення"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr "Мінімальна кількість PROBE"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr "Мінімальна різниця балів для розгляду відключення на іншу AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+"Додаткова інформація для відстеження ймовірних помилок алгоритмів — для "
+"зневадження"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "Мультикаст"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "Сусіди"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "Мережа"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "Огляд мережі"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "Параметр мережі"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "Ні"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "Немає підтримки HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "Немає підтримки VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "Немає доступних точок доступу."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "Немає підключених клієнтів."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "Недоступно"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+"Кількість підключених станцій, що вважається «кращою» для use_station_count"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+"Кількість послідовних оцінок клієнта як готового до відключення перед "
+"фактичним виконанням"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr "Кількість записів для включення у Neighbor Report 802.11v DISASSOCIATE"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr "Кількість періодів вибірки для усереднення значень використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr "Кількість повторень PROBE клієнтом до прийняття"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "Шлях до даних виконання hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "Вагові коефіцієнти на AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "Приріст на дБ для зваженої оцінки RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "Порт для TCP-мережі"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+"Бажаний порядок використання Passive, Active або Table даних BEACON 802.11k"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "Режим RRM"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "Центр RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "Значення RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "Вага RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "Індикатор потужності прийнятого каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "Індикатор співвідношення сигнал/шум при прийомі"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "Видалити AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "Видалити клієнта"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "Видалити PROBE"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "Звітування про стандартну поведінку"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "Бал"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "Приріст балу, коли сигнал перевищує поріг"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "Приріст балу, коли сигнал нижчий за поріг"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "Приріст балу, якщо HT не підтримується"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "Приріст балу, якщо HT підтримується"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "Приріст балу, якщо VHT не підтримується"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "Приріст балу, якщо VHT підтримується"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "Приріст балу, якщо використання каналу вище за max_chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "Приріст балу, якщо використання каналу нижче за chan_util_val"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "Серйозна несправність / неочікувана поведінка"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "IP сервера"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "Встановити Neighbor Report у Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "Сигнал"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "Щось пішло не так, але можна відновити"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr ""
+"Розділений пробілами список MAC-адрес для використання у «статичному» "
+"Neighbor Report AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "Стандартна поведінка, про яку завжди варто звітувати"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "Підключені станції"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "TCP-порт"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "TCP без виявлення UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "TCP з виявленням UMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "Поріг для доброго RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "Поріг для поганого RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+"Таймер (пере)реєстрації на повідомлення hostapd для кожного локального BSSID"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr "Таймер запиту нового BEACON REPORT у всіх підключених клієнтів"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+"Таймер отримання поточного показника використання каналу для кожного "
+"локального BSSID"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+"Таймер оновлення / видалення TCP-зʼєднань з іншими екземплярами DAWN, "
+"знайденими через uMDNS"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+"Таймер оновлення локальної інформації про зʼєднання та надсилання оновленого "
+"NEIGHBOR REPORT усім клієнтам"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr "Таймер видалення застарілих записів AP з основного набору даних"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+"Таймер видалення застарілих записів PROBE та BEACON з основного набору даних"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr "Таймер видалення застарілих записів клієнтів з основного набору даних"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "Таймери"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "Інтервал часу, після якого зʼєднання вважається розірваним"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr "Не вдається опитати службу DAWN через ubus, схоже, службу зупинено."
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "Оновлювати звіти маяків"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "Оновлювати використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "Оновлювати клієнтів"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "Оновлювати Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "Оновлювати TCP-зʼєднання"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "Верхній поріг для доброго використання каналу"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr "Використовувати кількість станцій"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "Використання"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "Підтримка VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr "Деталізація повідомлень у syslog"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "Дуже висока пропускна здатність"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "Так"

--- a/applications/luci-app-dawn/po/zh_Hans/dawn.po
+++ b/applications/luci-app-dawn/po/zh_Hans/dawn.po
@@ -1,0 +1,699 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-05 19:01+0000\n"
+"Last-Translator: 大王叫我来巡山 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsdawn/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "2.4G 频段权重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "5G 频段权重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr "拒绝 ASSOCIATION (关联) 时返回的 802.11 代码"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr "拒绝 AUTHENTICATION (认证) 时返回的 802.11 代码"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr "802.11k 信标 请求 持续时间 参数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "接入点 (AP)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+"所有定时器值均以秒为单位。这是 DAWN 收集和管理其所依赖的大部分数据的主要机"
+"制。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "AP 权重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "可用"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr "平均信道利用率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "带宽阈值 (Mbits/s)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr "基于工作频段的 AP 基准打分"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "广播"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "广播 IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr "广播端口"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "信道"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr "信道利用率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr "信道利用率值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "检查启动服务"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "客户端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "客户端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr "踢出设备时需要比较站点连接数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "已连接网络"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "连接超时"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr "对关联帧进行评估决定是否拒绝"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr "对认证帧进行评估决定是否拒绝"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr "对探测帧进行评估，确认是否拒绝"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "DAWN 选项配置。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "DAWN 服务不可用"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "持续时间"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr "深度追踪以修复bug - 仅供调试"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "默认值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr "拒绝关联原因"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "拒绝认证原因"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr "取消关联邻居报告长度"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr "已评估的关联请求"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr "已评估的认证请求"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr "已评估的探测请求"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "频率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "全局指标"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "授予 luci-app-dawn 访问 UCI 的权限"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT (高吞吐量)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "支持 HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr "接收信号图"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "高吞吐量 (HT)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Hostapd 目录"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr "广播和多播的 IP 地址"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr "不使用 UMDNS 时的 IP 地址"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr "广播和多播的 IP 端口"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "初始分数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "接口"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr "踢出控制"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr "踢出阈值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "本地"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "日志级别"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "低 RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "低 RSSI 值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr "低利用率坏信道判断"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr "最大信道利用率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr "最大信道利用率值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr "最大站点数量差"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr "踢出 AP 客户端时允许的最大带宽。设置为零可禁用此检查。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr "DAWN 实例之间的网络互联方式"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr "选择要移动到更好 AP 的客户端的方式"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr "用于在 AP 上设置邻居报告的方法"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr "加权 RSSI 评估的中间点"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr "触发踢出的最小数量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr "最小探测次数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr "将客户端踢出并转移到备用 AP 的最小分数差"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr "更多信息以帮助追踪算法哪里出错 - 仅供调试"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "组播"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "邻居"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "网络"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "网络概览"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "网络选项"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "不"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "不支持 HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "不支持 VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "没有可用的接入点。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "没有已连接的客户端。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "不可用"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr "在使用 use_station_count 时，判断为“更好”的站点已连接数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr "在实际执行踢出操作前，客户端被连续评估为准备踢出的次数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr "要在 802.11v 取消关联 邻居报告中包含的条目数量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr "用于计算信道利用率平均值的采样周期数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr "客户端在被接受前应重试 探测 的次数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "hostapd 运行时信息的路径"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr "每个 AP 的权重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr "加权 RSSI 评估中每 dB 的增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr "用于 TCP 网络的端口"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr "使用被动、主动或表格式时 802.11k信标信息的首选顺序"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "接收信道功率指示 (RCPI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "RRM 模式"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "接收信噪比指示 (RSNI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "接收信号强度指示 (RSSI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr "RSSI 中心点"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "RSSI 值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "RSSI 权重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr "接收信道功率 (RCPI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr "接收信噪比 (RSNI)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "移除 AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "移除客户端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr "移除探测请求"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr "标准行为报告"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "得分"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr "当信号超过阈值时的加分"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr "当信号低于阈值时的加分"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr "如果不支持 HT 时的加分增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr "如果支持 HT 时的加分增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr "如果不支持 VHT 时的加分增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr "如果支持 VHT 时的加分增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr "如果信道利用率高于 max_chan_util_val 时的加分增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr "如果信道利用率低于 chan_util_val 时的加分增量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr "严重故障 / 意外行为"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "服务器 IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "设置 Hostapd 邻居报告"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "信号强度"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "出现异常，但可恢复"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr "用于“静态”AP邻居报告中的一系列MAC地址，这些地址以空格分隔"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr "需要启用始终报告的行为"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr "已连接站点"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "TCP 端口"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr "不使用 UMDNS 发现的 TCP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr "使用 UMDNS 发现的 TCP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "良好 RSSI 的阈值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "较差 RSSI 的阈值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr "为每个本地 BSSID (重新)注册 hostapd 消息的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr "要求所有已连接客户端发送新 BEACON REPORT (信标报告) 的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr "获取每个本地 BSSID 的最新信道利用率数据的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr "刷新/移除通过 uMDNS 发现的其他 DAWN 实例的 TCP 连接的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+"刷新本地连接信息并向所有客户端发送更新后的 NEIGHBOR REPORT (邻居报告) 的定时"
+"器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr "从核心数据集中移除过期 AP 条目的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr "从核心数据集中移除过期的 PROBE (探测) 和 BEACON (信标) 条目的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr "从核心数据集中移除过期客户端条目的定时器"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr "计数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr "判定连接为已断开的时间"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr "无法通过 ubus 查询 DAWN 服务，服务可能已停止。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr "更新信标 (Beacon) 报告"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr "更新信道利用率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "更新客户端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "更新 Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr "更新 TCP 连接"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr "良好信道利用率的上限阈值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr "启用站点计数"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr "利用率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT (极高吞吐量)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "支持 VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr "syslog 中的消息详细程度"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "极高吞吐量 (VHT)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "是"

--- a/applications/luci-app-dawn/po/zh_Hant/dawn.po
+++ b/applications/luci-app-dawn/po/zh_Hant/dawn.po
@@ -1,0 +1,694 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-16 07:27+0000\n"
+"Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsdawn/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:389
+msgid "2.4G Band Metric"
+msgstr "2.4G 頻段指標"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:390
+msgid "5G Band Metric"
+msgstr "5G 頻段指標"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:292
+msgid "802.11 code used when ASSOCIATION is denied"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:298
+msgid "802.11 code used when AUTHENTICATION is denied"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:310
+msgid "802.11k BEACON request DURATION parameter"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:61
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:43
+msgid "Access Point"
+msgstr "存取點"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:217
+msgid ""
+"All timer values are in seconds. They are the main mechanism for DAWN "
+"collecting and managing much of the data that it relies on."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:399
+msgid "Ap Weight"
+msgstr "AP 權重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Available"
+msgstr "可用"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:285
+msgid "Average channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:279
+msgid "Bandwidth Threshold (Mbits/s)"
+msgstr "頻寬閾值 (Mbits/s)"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:424
+msgid "Base score for AP based on operating band"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:187
+msgid "Broadcast"
+msgstr "廣播"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:164
+msgid "Broadcast IP"
+msgstr "廣播 IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:169
+msgid "Broadcast PORT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:82
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:85
+msgid "Channel"
+msgstr "頻道"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:405
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:68
+msgid "Channel Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:411
+msgid "Channel Utilization Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:78
+msgid "Check Startup services"
+msgstr "檢查啟動服務"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:60
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:58
+msgid "Client"
+msgstr "用戶端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:51
+msgid "Clients"
+msgstr "用戶端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:385
+msgid "Compare connected station counts when considering kicking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:69
+msgid "Connected to Network"
+msgstr "已連線到網際網路"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:221
+msgid "Connection Timeout"
+msgstr "連線逾時"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:316
+msgid "Control whether ASSOCIATION frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:321
+msgid "Control whether AUTHENTICATION frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:326
+msgid "Control whether PROBE frames are evaluated for rejection"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:126
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:3
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:32
+msgid "DAWN"
+msgstr "DAWN"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:127
+msgid "DAWN Form Configuration."
+msgstr "DAWN 表單配置。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:76
+msgid "DAWN service unavailable"
+msgstr "DAWN 服務不可用"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:309
+msgid "DURATION"
+msgstr "DURATION"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:137
+msgid "Deeper tracing to fix bugs - for debugging"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:224
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:230
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:236
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:242
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:248
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:254
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:260
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:266
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:272
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:282
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:288
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:294
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:300
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:306
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:312
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:337
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:343
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:349
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:355
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:361
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:372
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:381
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:402
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:408
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:414
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:420
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:426
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:432
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:438
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:444
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:450
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:455
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:461
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:467
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:473
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:479
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:485
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:491
+msgid "Default Value"
+msgstr "預設值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:291
+msgid "Deny Association reason"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:297
+msgid "Deny auth reason"
+msgstr "拒絕認證原因"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:303
+msgid "Disassociate Neighbor Report length"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:315
+msgid "Evaluated Association Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:320
+msgid "Evaluated Auth Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:325
+msgid "Evaluated Probe Req"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:62
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:47
+msgid "Frequency"
+msgstr "頻率"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:275
+msgid "Global Metric"
+msgstr "全域計量"
+
+#: applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json:3
+msgid "Grant UCI access for luci-app-dawn"
+msgstr "授予 luci-app-dawn 存取 UCI 的權限"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "HT"
+msgstr "HT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:417
+msgid "HT Support"
+msgstr "HT 支援"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:49
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:23
+msgid "Hearing Map"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:63
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:49
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:59
+msgid "High Throughput"
+msgstr "高吞吐量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:146
+msgid "Hostapd"
+msgstr "Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:150
+msgid "Hostapd dir"
+msgstr "Hostapd 目錄"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:165
+msgid "IP address for broadcast and multicast"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:195
+msgid "IP address when not using UMDNS"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:170
+msgid "IP port for broadcast and multicast"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:423
+msgid "Initial Score"
+msgstr "初始分數"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:44
+msgid "Interface"
+msgstr "介面"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:330
+msgid "Kicking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:340
+msgid "Kicking Threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:130
+msgid "Local"
+msgstr "本地"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:134
+msgid "Log Level"
+msgstr "紀錄等級"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:429
+msgid "Low RSSI"
+msgstr "低 RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:435
+msgid "Low RSSI Value"
+msgstr "低 RSSI 值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:448
+msgid "Lower threshold for bad channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:45
+msgid "MAC"
+msgstr "MAC"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:441
+msgid "Max Channel Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:447
+msgid "Max Channel Utilization Value"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:346
+msgid "Max Station Diff"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:280
+msgid ""
+"Maximum reported AP-client bandwidth permitted when kicking. Set to zero to "
+"disable the check."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:185
+msgid "Method of networking between DAWN instances"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:331
+msgid "Method to select clients to move to better AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:376
+msgid "Method used to set Neighbor Report on AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:465
+msgid "Midpoint for weighted RSSI evaluation"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:352
+msgid "Min Number To Kick"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:358
+msgid "Min Probe Count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:341
+msgid "Minimum score difference to consider kicking to alternate AP"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:138
+msgid ""
+"More info to help trace where algorithms may be going wrong - for debugging"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:188
+msgid "Multicast"
+msgstr "多播"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:364
+msgid "Neighbors"
+msgstr "鄰居"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:156
+msgid "Network"
+msgstr "網路"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:30
+#: applications/luci-app-dawn/root/usr/share/luci/menu.d/luci-app-dawn.json:14
+msgid "Network Overview"
+msgstr "網路概覽"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:184
+msgid "Network option"
+msgstr "網路選項"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "No"
+msgstr "否"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:452
+msgid "No HT Support"
+msgstr "無 HT 支援"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:458
+msgid "No VHT Support"
+msgstr "無 VHT 支援"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:93
+msgid "No access points available."
+msgstr "無存取點可用。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:99
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:78
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:89
+msgid "No clients connected."
+msgstr "無用戶端已連線。"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:32
+msgid "Not available"
+msgstr "不可用"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:347
+msgid ""
+"Number of connected stations to consider \"better\" for use_station_count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:353
+msgid ""
+"Number of consecutive times a client should be evaluated as ready to kick "
+"before actually doing it"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:304
+msgid "Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:286
+msgid "Number of sampling periods to average channel utilization values over"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:359
+msgid "Number of times a client should retry PROBE before acceptance"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:151
+msgid "Path to hostapd runtime information"
+msgstr "Hostapd 執行時期資訊路徑"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:400
+msgid "Per AP weighting"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:483
+msgid "Per dB increment for weighted RSSI evaluation"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:204
+msgid "Port for TCP networking"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:370
+msgid ""
+"Preferred order for using Passive, Active or Table 802.11k BEACON information"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "RCPI"
+msgstr "RCPI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:369
+msgid "RRM Mode"
+msgstr "RRM 模式"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "RSNI"
+msgstr "RSNI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:470
+msgid "RSSI"
+msgstr "RSSI"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:464
+msgid "RSSI Center"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:476
+msgid "RSSI Value"
+msgstr "RSSI 值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:482
+msgid "RSSI Weight"
+msgstr "RSSI 權重"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:66
+msgid "Received Channel Power Indication"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:67
+msgid "Received Signal to Noise Indicator"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:227
+msgid "Remove AP"
+msgstr "移除 AP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:233
+msgid "Remove Client"
+msgstr "移除用戶端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:239
+msgid "Remove Probe"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:139
+msgid "Reporting on standard behaviour"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:70
+msgid "Score"
+msgstr "分數"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:471
+msgid "Score addition when signal exceeds threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:430
+msgid "Score addition when signal is below threshold"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:453
+msgid "Score increment if HT is not supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:418
+msgid "Score increment if HT is supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:459
+msgid "Score increment if VHT is not supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:489
+msgid "Score increment if VHT is supported"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:442
+msgid "Score increment if channel utilization is above max_chan_util_val"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:406
+msgid "Score increment if channel utilization is below chan_util_val"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:142
+msgid "Serious malfunction / unexpected behaviour"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:194
+msgid "Server IP"
+msgstr "伺服器 IP"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:375
+msgid "Set Hostapd Neighbor Report"
+msgstr "設定 Hostapd 鄰居報告"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:65
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:61
+msgid "Signal"
+msgstr "訊號"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:141
+msgid "Something appears wrong, but recoverable"
+msgstr "某件事情似乎不太對勁，但可恢復"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:365
+msgid "Space separated list of MACS to use in \"static\" AP Neighbor Report"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:140
+msgid "Standard behaviour always worth reporting"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:48
+msgid "Stations Connected"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:203
+msgid "TCP port"
+msgstr "TCP 連接埠"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:190
+msgid "TCP w/out UMDNS discovery"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:189
+msgid "TCP with UMDNS discovery"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:477
+msgid "Threshold for a good RSSI"
+msgstr "好 RSSI 閾值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:436
+msgid "Threshold for bad RSSI"
+msgstr "壞 RSSI 閾值"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:264
+msgid "Timer to (re-)register for hostapd messages for each local BSSID"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:246
+msgid "Timer to ask all connected clients for a new BEACON REPORT"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:252
+msgid "Timer to get recent channel utilization figure for each local BSSID"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:270
+msgid ""
+"Timer to refresh / remove the TCP connections to other DAWN instances found "
+"via uMDNS"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:258
+msgid ""
+"Timer to refresh local connection information and send revised NEIGHBOR "
+"REPORT to all clients"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:228
+msgid "Timer to remove expired AP entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:240
+msgid "Timer to remove expired PROBE and BEACON entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:234
+msgid "Timer to remove expired client entries from core data set"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:216
+msgid "Times"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:222
+msgid "Timespan until a connection is seen as disconnected"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:77
+msgid ""
+"Unable to query the DAWN service via ubus, the service appears to be stopped."
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:245
+msgid "Update Beacon reports"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:251
+msgid "Update Channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:257
+msgid "Update Client"
+msgstr "更新用戶端"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:263
+msgid "Update Hostapd"
+msgstr "更新 Hostapd"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:269
+msgid "Update TCP connections"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:412
+msgid "Upper threshold for good channel utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:384
+msgid "Use Station Count"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:46
+msgid "Utilization"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "VHT"
+msgstr "VHT"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:488
+msgid "VHT Support"
+msgstr "VHT 支援"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/network/dawn.js:135
+msgid "Verbosity of messages in syslog"
+msgstr ""
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/hearing_map.js:64
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:50
+#: applications/luci-app-dawn/htdocs/luci-static/resources/view/status/dawn/network_overview.js:60
+msgid "Very High Throughput"
+msgstr "超高吞吐量"
+
+#: applications/luci-app-dawn/htdocs/luci-static/resources/dawn/dawn-common.js:36
+msgid "Yes"
+msgstr "是"

--- a/applications/luci-app-libreswan/po/cs/libreswan.po
+++ b/applications/luci-app-libreswan/po/cs/libreswan.po
@@ -1,0 +1,490 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-08 17:32+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "Přijímanými hodnotami jsou celá čísla následovaná m, h, d"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Přidat návrh"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "Přidat tunel"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Povolené virtuální soukromé"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Metoda ověř."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Ověřování se"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "Automaticky aktualizovat adresu protějšku VTI rozhraní"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Vyčistit"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "DH skupina"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "DH skupina 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "DH skupina 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "DH skupina 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "DH skupina 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "DH skupina 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "DH skupina 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "DH skupina 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "DH skupina 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "DH skupina 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "DH skupina 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "DH skupina 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "DPD akce"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "DPD prodleva"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "DPD časový limit"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Záznamy ladících informací"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "Dole"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Povolit nflog na nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Metoda šifrování"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "Obecné"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Udělit k LuCI aplikaci Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "Algoritmus vytváření otisků"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Podržet"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "IKE životnost"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE V2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE verze 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE verze 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+"IP adresa na které očekávat spojení (výchozí závisí na „Rozhraní, na kterém "
+"očekávat spojení“)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "Globální nastavení pro IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec globální"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "IPSec návrhy"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "IPSec tunely"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "Souhrn IPSec tunelů"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Inicializovat"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Rozhraní"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Které rozhraní pro IPsec použít"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "Zanechané ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "Zanechaná IP/zařízení"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Zanechané rozhraní"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Očekávat spojení"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Adresa na které očekávat spojení"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Rozhraní na kterém očekávat spojení"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "Vypíše VTI rozhraní nastavená s ikey a okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Vypíše XFRM rozhraní ve formátu „ipsecN“ (N znamená ifid nebo xfrm rozhraní)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "Lokální zdrojová IP adresa"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Lokální podsíť"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Lokální podsítě"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Režim"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"Číslo NFLOG skupiny do které zaznamenávat veškerý provoz před šifrováním a "
+"po něm"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Název"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "Délka názvu by neměla překročit 15 znaků"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Žádné"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Přehled"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "Fáze 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "Návrhy fáze 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "Fáze 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "Návrhy fáze 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "Protokol fáze 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Předsdílený klíč"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "Je třeba, aby pro tunely byly nastavené návrhy"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Znovu opatřit klíčem"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Doba rezervy znovuopatření klíči"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Vzdálené"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "Vzdálená IP adresa"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "IP adresa vzdáleného zdroje"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Vzdálená podsíť"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Vzdálené podsítě"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Restartovat"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "Identif. vpravo"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Sdílené tajemství"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Stav"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Rozsahy IP adres které se mohou nacházet za NAT směrovačem přes který se "
+"klient připojuje"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "Nejsou zde žádné aktivní tunely"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+"Může se stát, že toto nesdílí stejný název jako ostatní návrhy nebo "
+"nastavené tunely."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "Rozhraní tunelu"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Neopakující se identifikace vzdálených"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Nebezpečné"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Nebezpečné, viz"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "Nahoře"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Zaktualizovat adresu protějšku"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Doba chodu"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+"Zda mají být identifikátory považovány za identifikující vzdálené strany bez "
+"opakování se"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "základ – střední zaznamenávání"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "využití-procesoru – zaznamenávání časování/vytížení"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto – veškeré záznamy týkající se šifrování"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "žádné – žádné zaznamenávání"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "private – zaznamenávání citlivých informací typu soukromý klíč / heslo"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi – příliš mnoho / přezpřílišné zaznamenávání"

--- a/applications/luci-app-libreswan/po/es/libreswan.po
+++ b/applications/luci-app-libreswan/po/es/libreswan.po
@@ -1,0 +1,489 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "Valores aceptables son un entero seguido por m, h, d"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Agregar propuesta"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "Añadir túnel"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Privado virtual permitido"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Método de autenticación"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "Actualización automática de la dirección de pares de la interfaz VTI"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Limpiar"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "Grupo DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "Grupo DH 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "Grupo DH 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "Grupo DH 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "Grupo DH 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "Grupo DH 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "Grupo DH 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "Grupo DH 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "Grupo DH 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "Grupo DH 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "Grupo DH 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "Grupo DH 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "Acción DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "Retraso DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "Tiempo de espera del DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Registros de depuración"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "Bajar"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Activar nflog en nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Método de cifrado"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "General"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Conceder acceso a la aplicación LuCI Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "Algoritmo Hash"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Mantener"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "Tiempo de vida IKE"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE v2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE versión 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE versión 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr "Dirección IP para escucha, por defecto depende en Interfaz Escucha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "Ajustes de IPSec global"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec globales"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "Propuestas IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "Túneles IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "Sumario de túneles IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Comenzar"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Interfaz"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Interfaz para IPsec a utilizar"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "ID izquierda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "IP izquierda/Dispositivo"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Interfaz izquierda"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "IPSec Libreswan"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Escucha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Dirección de escucha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Interfaz Escucha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "Lista los interfaces VTI configurados con ikey y okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Enumera interfaces XFRM en formato «ipsecN», N denota ifid de interfaz xfrm"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "IP de origen local"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Subred local"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Subredes locales"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Modo"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"Número de grupo NFLOG para bitácora de todo el tráfico pre-cifrado y post-"
+"cifrado a"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Nombre"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "La longitud del nombre no debe exceder los 15 caracteres"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Ninguno"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Vista general"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "Fase 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "Propuestas fase 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "Fase 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "Propuestas fase 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "Protocolo fase 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Clava pre-compartida"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "Propuestas deben ser configuradas para túneles"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Re-clave"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Tiempo de margen de Re-clave"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Remoto"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "IP remota"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "IP de origen remoto"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Subred remota"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Subredes remotas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "ID derecha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Rx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Secreto compartido"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Estado"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Los intervalos de dirección que pueden existir destrás de un enrutador NAT a "
+"través del cual un cliente se conecta"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "No hay túneles activos"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+"Esto puede no compartir el mismo nombre como otras propuestas o túneles "
+"configurados."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "Interfaz del túnel"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Tx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Únicamente identificar remotos"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Inseguro"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Inseguro, vea"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "Subir"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Actualizar la dirección del par"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Tiempo de actividad"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr "Si los ID serían considerados identificando únicamente partes remotas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base - Registro moderado"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "uso-cpu - Registro de tiempo/carga"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "cifrado - Todo el registro relacionado con cifrado"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "ninguno - Sin registro"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "privado - Registro confidencial de claves privadas y contraseñas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi - Registro excesivo/demasiado registro"

--- a/applications/luci-app-libreswan/po/ga/libreswan.po
+++ b/applications/luci-app-libreswan/po/ga/libreswan.po
@@ -1,0 +1,492 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "Is slánuimhir agus m, h, d ina ndiaidh luachanna inghlactha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Cuir Togra leis"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "Cuir Tollán leis"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Ardleibhéil"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Príobháideach Fíorúil Ceadaithe"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Modh Údaraithe"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Fíordheimhniú"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "Nuashonrú Uathoibríoch Seoladh Piaraí an chomhéadain VTI"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Soiléir"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "Grúpa DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "Grúpa DH 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "Grúpa DH 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "Grúpa DH 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "Grúpa DH 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "Grúpa DH 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "Grúpa DH 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "Grúpa DH 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "Grúpa DH 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "Grúpa DH 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "Grúpa DH 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "Grúpa DH 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "Gníomh DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "Moill DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "Am Teorann DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Logaí Dífhabhtaithe"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "Síos"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Cumasaigh nflog ar nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Modh Criptithe"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "Ginearálta"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Deonaigh rochtain ar aip LuCI Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "Algartam Hais"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Coinnigh"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "Am Saoil IKE"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE V2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE Leagan 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE Leagan 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+"Seoladh IP le héisteacht leis, braitheann an réamhshocrú ar an gComhéadan "
+"Éisteachta"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "Socruithe Domhanda IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec Domhanda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "Tograí IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "Tolláin IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "Achoimre ar Tholláin IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Tionscnamh"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Comhéadan"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Comhéadan le húsáid ag IPsec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "ID ar chlé"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "IP/Gléas Clé"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Comhéadan Clé"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Éist"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Seoladh Éist"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Comhéadan Éisteachta"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "Liostaíonn sé comhéadain VTI atá cumraithe le ikey agus okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Liostaíonn sé comhéadain XFRM i bhformáid \"ipsecN\", seasann N do ifid an "
+"chomhéadain xfrm"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "IP Foinse Áitiúil"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Fo-líonra Áitiúil"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Fo-líonraí áitiúla"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Mód"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"Uimhir ghrúpa NFLOG chun gach trácht réamhchriptithe agus iar-dhíchriptithe "
+"a logáil chuici"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Ainm"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "Ní fhéadfaidh fad an ainm a bheith níos mó ná 15 charachtar"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Dada"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Forbhreathnú"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "Céim 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "Tograí Céim 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "Céim 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "Tograí Céim 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "Prótacal Céim 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Eochair Réamhroinnte"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "Ní mór tograí a chumrú le haghaidh Tolláin"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Ath-eochair"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Ath-eochair Am Imeall"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Cianda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "IP cianda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "IP Foinse Cianda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Fo-líonra cianda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Fo-líonraí cianda"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Atosaigh"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "Aitheantas ceart"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Rx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Rún Comhroinnte"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Stádas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Na raonta seoltaí a d'fhéadfadh a bheith taobh thiar de ródaire NAT trína "
+"nascann cliant"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "Níl aon tolláin ghníomhacha ann"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+"B’fhéidir nach mbeidh an t-ainm céanna air seo agus atá ar thograí nó "
+"tolláin chumraithe eile."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "Comhéadan Tolláin"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Tx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Aithint Uathúil ar Chianrialtáin"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Contúirteach"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Contúirteach, Féach"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "Suas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Nuashonraigh Seoladh an Chomhghleacaí"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Am ar Fáil"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+"Cibé acu ba cheart a mheas gur sainaithnítear páirtithe iargúlta go huathúil "
+"iad aitheantais"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "bonn - Logáil Mheasartha"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "úsáid-cpu - Logáil Ama/Lódála"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "cripte - Gach logáil a bhaineann le cripte"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "gan aon cheann - Gan Logáil"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "príobháideach - Logáil íogair eochrach/pasfhocal príobháideach"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi - An iomarca logála/iomarcach"

--- a/applications/luci-app-libreswan/po/ko/libreswan.po
+++ b/applications/luci-app-libreswan/po/ko/libreswan.po
@@ -1,0 +1,479 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-07 18:23+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES-128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES-192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES-256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "제안 추가"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "터널 추가"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "고급"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "인증 방식"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "인증"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "초기화"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "DH 그룹"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "DH 그룹 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "DH 그룹 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "DH 그룹 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "DH 그룹 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "DH 그룹 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "DH 그룹 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "DH 그룹 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "DH 그룹 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "DH 그룹 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "DH 그룹 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "DH 그룹 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "DPD 동작"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "DPD 확인 주기"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "DPD 대기 시간"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "디버그 로그"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "비활성"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "암호화 방식"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "일반"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "LuCI 앱 Libreswan IPSec에 접근 권한 부여"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "해시 알고리즘"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "대기"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "IKE 수명"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE V2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE 버전 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE 버전 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "IPSec 전역 설정"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec 전역"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "IPSec 제안"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "IPsec 터널"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "IPSec 터널 요약"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "연결 시도"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "인터페이스"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "로컬 ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "로컬 IP/장치"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "로컬 인터페이스"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "수신 대기"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "수신 대기 주소"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "수신 인터페이스"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "로컬 출발지 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "로컬 서브넷"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "로컬 서브넷"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "모드"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "이름"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "이름은 최대 15자까지만 입력 가능"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "없음"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "개요"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "1단계"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "1단계 제안"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "2단계"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "2단계 제안"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "2단계 프로토콜"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "사전 공유 키"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "키 갱신"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "키 갱신 유예 시간"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "원격"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "원격 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "원격 출발지 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "원격 서브넷"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "원격 서브넷"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "재시작"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "원격 ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Rx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA-1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA-256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA-384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA-512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "공유 비밀"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "상태"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "활성 터널 없음"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "터널 인터페이스"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Tx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "원격지 고유 식별"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "안전하지 않음"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "활성"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "피어 주소 갱신"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "가동 시간"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr "ID를 기준으로 원격 접속자를 고유하게 식별할지 여부를 설정합니다"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base - 보통 수준 로그 기록"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto - 모든 암호화 관련 로그 기록"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "none - 로그 기록 안 함"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi - 지나치게 상세한 로그 기록"

--- a/applications/luci-app-libreswan/po/lo/libreswan.po
+++ b/applications/luci-app-libreswan/po/lo/libreswan.po
@@ -1,0 +1,479 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "ຄ່າທີ່ຍອມຮັບໄດ້ແມ່ນຕົວເລກຈຳນວນເຕັມ ຕາມດ້ວຍ m, h, d"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "ເພີ່ມຂໍ້ສະເໜີ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "ເພີ່ມອຸໂມງ (Tunnel)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "ຂັ້ນສູງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Virtual Private ທີ່ອະນຸຍາດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "ວິທີການຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "ການຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "ອັບເດດທີ່ຢູ່ Peer ຂອງອິນເຕີເຟດ VTI ອັດຕະໂນມັດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "ລ້າງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "ກຸ່ມ DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "ກຸ່ມ DH 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "ກຸ່ມ DH 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "ກຸ່ມ DH 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "ກຸ່ມ DH 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "ກຸ່ມ DH 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "ກຸ່ມ DH 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "ກຸ່ມ DH 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "ກຸ່ມ DH 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "ກຸ່ມ DH 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "ກຸ່ມ DH 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "ກຸ່ມ DH 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "ການກະທຳ DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "ຄວາມຊັກຊ້າ DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "ເວລາໝົດກຳນົດ DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "ບັນທຶກການດີບັກ (Debug)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "ປິດ (Down)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "ເປີດໃຊ້ງານ nflog ເທິງ nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "ວິທີການເຂົ້າລະຫັດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "ທົ່ວໄປ"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "ໃຫ້ສິດເຂົ້າເຖິງແອັບ LuCI Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "ອະລະກໍລິດ Hash"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Hold"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "ໄລຍະເວລາ IKE"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE V2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE ເວີຊັນ 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE ເວີຊັນ 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr "ທີ່ຢູ່ IP ທີ່ໃຊ້ຟັງ, ຄ່າເລີ່ມຕົ້ນຂຶ້ນຢູ່ກັບອິນເຕີເຟດທີ່ໃຊ້ຟັງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "ການຕັ້ງຄ່າທົ່ວໄປຂອງ IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec ທົ່ວໄປ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "ຂໍ້ສະເໜີ IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "ອຸໂມງ IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "ສະຫຼຸບອຸໂມງ IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "ເລີ່ມຕົ້ນການເຊື່ອມຕໍ່"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "ອິນເຕີເຟດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "ອິນເຕີເຟດສຳລັບ IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "Left ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "Left IP/ອຸປະກອນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Left ອິນເຕີເຟດ"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "ຟັງ (Listen)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "ທີ່ຢູ່ທີ່ໃຊ້ຟັງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "ອິນເຕີເຟດທີ່ໃຊ້ຟັງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "ລາຍການອິນເຕີເຟດ VTI ທີ່ຕັ້ງຄ່າດ້ວຍ ikey ແລະ okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr "ລາຍການອິນເຕີເຟດ XFRM ໃນຮູບແບບ \"ipsecN\", N ແມ່ນ ifid ຂອງອິນເຕີເຟດ xfrm"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "IP ແຫຼ່ງຂໍ້ມູນທ້ອງຖິ່ນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Subnet ທ້ອງຖິ່ນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Subnet ທ້ອງຖິ່ນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "ໂໝດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr "ໝາຍເລກກຸ່ມ NFLOG ເພື່ອບັນທຶກການຈະລາຈອນທັງໝົດກ່ອນເຂົ້າລະຫັດ ແລະ ຫຼັງຖອດລະຫັດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "ຊື່"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "ຄວາມຍາວຂອງຊື່ຕ້ອງບໍ່ເກີນ 15 ຕົວອັກສອນ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "ບໍ່ມີ"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "ພາບລວມ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "ໄລຍະ 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "ຂໍ້ສະເໜີໄລຍະ 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "ໄລຍະ 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "ຂໍ້ສະເໜີໄລຍະ 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "ໂປຣໂຕຄໍໄລຍະ 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Preshared Key"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "ຕ້ອງຕັ້ງຄ່າຂໍ້ສະເໜີສຳລັບອຸໂມງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Rekey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "ເວລາ Rekey Margin"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "ໄລຍະໄກ (Remote)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "IP ໄລຍະໄກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "IP ແຫຼ່ງຂໍ້ມູນໄລຍະໄກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Subnet ຝັ່ງທາງໄກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Subnet ໄລຍະໄກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "ຣີສະຕາດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "Right ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "ຮັບ (Rx)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Shared Secret"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "ສະຖານະ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr "ຊ່ວງທີ່ຢູ່ IP ທີ່ອາດຈະຢູ່ຫຼັງ NAT router ເຊິ່ງລູກຄ້າໃຊ້ເຊື່ອມຕໍ່"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "ບໍ່ມີອຸໂມງທີ່ໃຊ້ງານຢູ່"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr "ຊື່ນີ້ບໍ່ຄວນຊ້ຳກັບຂໍ້ສະເໜີອື່ນ ຫຼື ອຸໂມງອື່ນທີ່ຕັ້ງຄ່າໄວ້."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "ອິນເຕີເຟດອຸໂມງ (Tunnel)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "ສົ່ງ (Tx)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "ລະບຸຕົວຕົນຝ່າຍໄລຍະໄກຢ່າງເປັນເອກະລັກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "ບໍ່ປອດໄພ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "ບໍ່ປອດໄພ, ເບິ່ງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "ເປີດ (Up)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "ອັບເດດທີ່ຢູ່ Peer"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "ເວລາທີ່ເຮັດວຽກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr "ກຳນົດວ່າ IDs ຄວນຖືກໃຊ້ເພື່ອລະບຸຕົວຕົນຝ່າຍໄລຍະໄກຢ່າງເປັນເອກະລັກຫຼືບໍ່"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base - ບັນທຶກລະດັບປານກາງ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "cpu-usage - ບັນທຶກເວລາ/ໂຫຼດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto - ບັນທຶກທຸກຢ່າງທີ່ກ່ຽວກັບການເຂົ້າລະຫັດ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "none - ບໍ່ມີການບັນທຶກ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "private - ບັນທຶກຂໍ້ມູນລະອຽດອ່ອນເຊັ່ນ private-key/ລະຫັດຜ່ານ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi - ບັນທຶກຫຼາຍເກີນໄປ"

--- a/applications/luci-app-libreswan/po/lt/libreswan.po
+++ b/applications/luci-app-libreswan/po/lt/libreswan.po
@@ -1,0 +1,508 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-13 06:47+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5.dev0\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "„3DES“*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "„AES“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "„AES128“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "„AES192“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "„AES256“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "„AES_CBC“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "„AES_CTR“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr ""
+"Priimtinos reikšmės yra sveikasis skaičius, po kurio eina – m (min), h (val) "
+"ir d (diena)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Pridėti pasiūlymą"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr ""
+"Pridėti „tunelį“ – tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Pažangūs"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Leidžiami virtualūs privatūs tinklai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Autentifikavimo metodas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Autentifikavimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr ""
+"Automatiškai atnaujinti „VTI“ sąsajos ir/arba sietuvo lygiarangio adresą"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "„CAMELLIA_CBC“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Išvalyti"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "„DH“ grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "„DH“ 14-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "„DH“ 15-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "„DH“ 16-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "„DH“ 17-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "„DH“ 18-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "„DH“ 19-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "„DH“ 20-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "„DH“ 21-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "„DH“ 22-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "„DH“ 31-a grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "„DH“ 5-a* grupė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "„DPD“ veiksmas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "„DPD“ atidėjimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "„DPD“ pasibaigusios užklausos laikas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Derinimo/Trukdžių šalinimo žurnalai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "Išjungtas/-a/┃Išgalintas/-a"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Įjungti/Įgalinti „nflog“ ant „nfgroup“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Šifravimo metodas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "Bendra/-i/-ai/-s"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Duoti prieigą prie „LuCI“ programėles – „IPSec“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "maišos algoritmas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Laikyti"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "„IKE“ gyvavimo laikas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "„IKE V2“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "„IKE“ 1-oji versija"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "„IKE“ 2-oji versija"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+"Laukiamo prisijungimo/jungties ryšio IP adresas (numatytasis priklauso nuo "
+"laukiamo prisijungimo/jungties ryšio sąsajos ir/arba sietuvo)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "„IPSec“ išoriniai/visuotiniai nustatymai"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "„IPSec“ išoriniai/visuotiniai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "„IPSec“ pasiūlymai"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr ""
+"„IPSec tuneliai“ – tinklo protokolas, skirtas šifruoti/pereiti į kitus "
+"tinklus"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr ""
+"„IPSec tunelių“ tinklo protokolas, skirtas šifruoti/pereiti į kitus tinklus "
+"santrauka/suvestinė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Inicijuoti"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Sąsaja ir/arba Sietuvas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Sąsaja ir/arba sietuvas, skirta/-as „IPsec“ naudojimui"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "Vietinės pusės ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "Vietinės pusės IP/įrenginys"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Vietinės pusės sąsaja ir/arba sietuvas"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "„Libreswan IPSec“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Laukti prisijungimo/jungties ryšio"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Laukiamo prisijungimo/jungties ryšio adresas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Laukimo prisijungimo/jungties ryšio sąsaja ir/arba sietuvas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr ""
+"Išvardija „VTI“ sąsajas ir/arba sietuvus, sukonfigūruotas/-us su „ikey“ ir "
+"„okey“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Išvardija „XFRM“ sąsajų ir/arba sietuvu sąrašą formatu – „ipsecN“, kur „N“ "
+"rodo„xfrm“ sąsajos ir/arba sietuvo – „ifid“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "Vietinis šaltinio IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Vietinis potinklis"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Vietiniai potinkliai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "„MD5*“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Veiksena"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"„NFLOG“ grupės numeris, skirtas visam srautui prieš užšifravimą ir po "
+"iššifravimo žurnalinti"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Pavadinimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "Pavadinimo ilgis neturi viršyti 15-ą rašmenų"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Joks (-ia/-ie/-ios)"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Apžiūra"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "1-oji fazė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "1-osios fazės pasiūlymai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "2-oji fazė"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "2-osios fazės protokolai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "2-osios fazės protokolas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Išankstinis bendras raktas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr ""
+"Pasiūlymai turi būti sukonfigūruoti „tuneliams“ – tinklo protokolams, "
+"skirtiems šifruoti/pereiti į kitą tinklą"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Pakartoti rakto įvedimą"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Pakartotinio rakto įvedimo paraštės laikas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Nuotolinis"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "Nuotolinis IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "Nuotolinio šaltinio IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Nuotolinis potinklis"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Nuotoliniai potinkliai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Paleisti iš naujo"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "Nuotolinės pusės ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Atsiųsta/Gauta reaktyviai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "„SHA1*“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "„SHA-256“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "„SHA384“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "„SHA512“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Bendrinama „paslaptis“"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Būklė/Būsena"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Adresų diapazonai, kurie gali būti už „NAT“ maršrutizatoriaus, per kurį "
+"prisijungia klientas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr ""
+"Nėra aktyvių „tunelių“ – tinklo protokolas, skirtas šifruoti/pereiti į kitus "
+"tinklus"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+"Šis pavadinimas gali nesutapti su kitų pasiūlymų ar sukonfigūruotų „tunelių“ "
+"– tinklo protokolų, skirtų šifruoti/pereiti į kitų tinklų pavadinimais."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr ""
+"„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kito tinklo sąsaja "
+"ir/arba sietuvas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Nusiųsta/Įkelta reaktyviai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Unikalus nuotolinių šalių identifikavimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Nesaugu"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Nesaugu, žr."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "Viršun/Aukštyn"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Atnaujinti lygiarangio adresą"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Aktyvumo laikas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+"Ar ID (dgs.) turėtų būti laikomi unikaliais nuotolinių šalių "
+"identifikatoriais"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "„base“ – vidutinis žurnalinimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "„cpu-usage“ – laiko/įkėlimo┃apkrovos žurnalinimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "„crypto“ – visi kripto susiję žurnalinimai"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "„none“ – jokio žurnalinimo"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "„private“ – Jautrus privataus rakto/slaptažodžio žurnalinimas"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "„tmi“ – Perteklinis žurnalinimas"

--- a/applications/luci-app-libreswan/po/pl/libreswan.po
+++ b/applications/luci-app-libreswan/po/pl/libreswan.po
@@ -1,0 +1,491 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-18 07:48+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "Dopuszczalne wartości to liczba całkowita, po której następują m, h, d"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Dodaj propozycję"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "Dodaj tunel"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Dozwolone wirtualne prywatne"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Metoda uwierzytelniania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Uwierzytelnienie"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "Automatyczna aktualizacja adresu peera interfejsu VTI"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Wyczyść"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "Grupa DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "Grupa 14 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "Grupa 15 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "Grupa 16 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "Grupa 17 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "Grupa 18 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "Grupa 19 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "Grupa 20 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "Grupa 21DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "Grupa 20 DH*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "Grupa 31 DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "Grupa 5 DH*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "Akcja DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "Opóźnienie DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "Limit czasu DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Dzienniki debugowania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "W dół"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Włącz nflog w nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Metoda szyfrowania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "Ogólne"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Udziel dostępu do aplikacji LuCI Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "Algorytm haszujący"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Wstrzymaj"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "Czas trwania IKE"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKEv2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE w wersji 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE w wersji 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+"Adres IP do nasłuchiwania, domyślnie zależy od interfejsu nasłuchiwania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "Ustawienia globalne IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "Globalne IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "Propozycje IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "Tunele IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "Podsumowanie tuneli IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Inicjuj"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Interfejs"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Interfejs IPsec do używania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "Identyfikator lewy"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "IP/Urządzenie lewe"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Interfejs lewy"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Nasłuchuj"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Adres nasłuchiwania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Interfejs nasłuchiwania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "Wyświetla interfejsy VTI skonfigurowane za pomocą ikey i okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Wyświetla interfejsy XFRM w formacie „ipsecN”, gdzie N oznacza identyfikator "
+"interfejsu XFRM"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "Lokalny źródłowy adres IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Lokalna podsieć"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Lokalne podsieci"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Tryb"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"Numer grupy NFLOG do rejestrowania całego ruchu przed szyfrowaniem i po "
+"odszyfrowaniu"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Nazwa"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "Długość nazwy nie może przekraczać 15 znaków"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Brak"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Przegląd"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "Faza 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "Propozycje Fazy 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "Faza 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "Propozycje Fazy 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "Protokół Fazy 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Klucz współdzielony"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "Propozycje muszą być skonfigurowane dla tuneli"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Wznowienie klucza"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Czas marginesu wznowienia klucza"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Zdalny"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "Zdalny adres IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "Zdalny źródłowy adres IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Zdalna podsieć"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Zdalne podsieci"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Restartuj"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "Identyfikator prawy"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Rx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Wspólny sekret"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Status"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Zakresy adresów, które mogą znajdować się za routerem NAT, przez który łączy "
+"się klient"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "Brak aktywnych tuneli"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+"Nazwa ta może różnić się od nazwy innych propozycji lub skonfigurowanych "
+"tuneli."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "Interfejs tunelu"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Tx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Jednoznacznie identyfikuj zdalne"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Niebezpieczny"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Niebezpieczny, zobacz"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "W górę"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Aktualizuj adres peera"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Czas pracy"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+"Czy identyfikatory powinny być uważane za jednoznacznie identyfikujące "
+"strony zdalne"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base - Umiarkowane rejestrowanie"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "cpu-usage - Rejestrowanie czasu/obciążenia"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto - Rejestrowanie wszystkich zdarzeń kryptograficznych"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "none - Brak rejestrowania"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "private - Rejestrowanie poufnych kluczy prywatnych/haseł"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi - Rejestrowanie zbyt duże/nadmierne"

--- a/applications/luci-app-libreswan/po/pt_BR/libreswan.po
+++ b/applications/luci-app-libreswan/po/pt_BR/libreswan.po
@@ -1,0 +1,479 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-17 16:40+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationslibreswan/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Visão geral"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA-256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Tempo de atividade"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr ""

--- a/applications/luci-app-libreswan/po/ru/libreswan.po
+++ b/applications/luci-app-libreswan/po/ru/libreswan.po
@@ -1,0 +1,491 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-25 12:14+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr ""
+"Допустимые значения: целое число с суффиксом m (мин.), h (ч.) или d (дн.)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Добавить набор параметров"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "Добавить туннель"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Разрешённые виртуальные частные сети"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Метод аутентификации"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Аутентификация"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "Автоматически обновлять адрес узла для интерфейса VTI"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Сбросить"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "Группа DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "Группа DH 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "Группа DH 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "Группа DH 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "Группа DH 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "Группа DH 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "Группа DH 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "Группа DH 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "Группа DH 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "Группа DH 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "Группа DH 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "Группа DH 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "Действие DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "Интервал проверки DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "Тайм-аут DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Уровень журналирования"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "Отключён"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Включить nflog для nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Метод шифрования"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "Основные"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Предоставить доступ к LuCI-приложению Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "Алгоритм хеширования"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Приостановить"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "Время жизни IKE"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKEv2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE версии 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE версии 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+"Прослушиваемый IP-адрес (по умолчанию зависит от интерфейса прослушивания)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "Глобальные настройки IPsec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "Глобальные параметры IPsec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "Наборы параметров IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "Туннели IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "Сводка по туннелям IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Инициировать подключение"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Интерфейс"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Сетевой интерфейс для работы IPsec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "ID локальной стороны"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "IP/устройство локальной стороны"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Интерфейс локальной стороны"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPsec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Слушать"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Адрес прослушивания"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Интерфейс прослушивания"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "Список интерфейсов VTI, настроенных с параметрами ikey и okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Список интерфейсов XFRM в формате \"ipsecN\", где N — идентификатор (ifid) "
+"интерфейса"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "Локальный IP-адрес источника"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Локальная подсеть"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Локальные подсети"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Режим работы"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"Номер группы NFLOG для журналирования трафика до шифрования и после "
+"расшифровки"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Название"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "Длина имени не должна превышать 15 символов"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Отсутствует"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Обзор"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "Фаза 1 (IKE)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "Наборы параметров фазы 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "Фаза 2 (IPsec)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "Наборы параметров фазы 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "Протокол фазы 2 (ESP/AH)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Предварительно распределённый ключ (PSK)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "Перед созданием туннелей необходимо настроить наборы параметров"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Пересогласование ключей"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Интервал пересогласования ключей"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Удалённый узел"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "Удалённый IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "Удалённый IP-адрес источника"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Удалённая подсеть"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Удалённые подсети"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Перезапустить"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "ID удалённой стороны"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Получено (Rx)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA-256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Секретный ключ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Статус"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Диапазоны адресов, которые могут находиться за NAT-маршрутизатором, через "
+"который подключается клиент"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "Активные туннели отсутствуют"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr "Имя не должно совпадать с другими наборами параметров или туннелями."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "Интерфейс туннеля"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Передано (Tx)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Уникальная идентификация удалённых сторон"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Небезопасно"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Небезопасно, см."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "Работает"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Обновлять адрес узла"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Время работы"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+"Требовать, чтобы идентификаторы однозначно определяли каждую удалённую "
+"сторону"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base — умеренное журналирование"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "cpu-usage — загрузка ЦП и время выполнения"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto — всё, связанное с криптографией"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "none — без журналирования"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "private — конфиденциальные данные (ключи/пароли)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi — избыточное журналирование"

--- a/applications/luci-app-libreswan/po/templates/libreswan.pot
+++ b/applications/luci-app-libreswan/po/templates/libreswan.pot
@@ -1,0 +1,470 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr ""

--- a/applications/luci-app-libreswan/po/uk/libreswan.po
+++ b/applications/luci-app-libreswan/po/uk/libreswan.po
@@ -1,0 +1,487 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-15 10:43+0000\n"
+"Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationslibreswan/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5.dev0\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "Допустимі значення — ціле число з суфіксом m, h, d"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "Додати пропозицію"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "Додати тунель"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "Розширені"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "Дозволені приватні мережі"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "Метод автентифікації"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "Автентифікація"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "Автоматично оновлювати адресу віддаленого вузла для інтерфейсу VTI"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "Очистити"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "Група DH"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "Група DH 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "Група DH 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "Група DH 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "Група DH 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "Група DH 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "Група DH 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "Група DH 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "Група DH 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "Група DH 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "Група DH 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "Група DH 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "Дія DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "Затримка DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "Тайм-аут DPD"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "Журнали налагодження"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "Вимкнути"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "Увімкнути nflog для nfgroup"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "Метод шифрування"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "Загальне"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "Надати доступ до LuCI-застосунку Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "Алгоритм хешування"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "Утримувати"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "Час життя IKE"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE V2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "Версія IKE 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "Версія IKE 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+"IP-адреса для прослуховування; типово залежить від інтерфейсу прослуховування"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "Глобальні налаштування IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "Глобальні параметри IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "Пропозиції IPSec"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "Тунелі IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "Зведення тунелів IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "Ініціювати"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "Інтерфейс"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "Інтерфейс для роботи IPsec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "Локальний ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "Локальна IP/пристрій"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "Локальний інтерфейс"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "Прослуховувати"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "Адреса прослуховування"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "Інтерфейс прослуховування"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "Перелічує інтерфейси VTI, налаштовані з ikey та okey"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+"Перелічує інтерфейси XFRM у форматі \"ipsecN\", де N означає ifid xfrm-"
+"інтерфейсу"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "Локальна IP-адреса джерела"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "Локальна підмережа"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "Локальні підмережі"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "Режим"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+"Номер групи NFLOG для журналювання всього трафіку до шифрування та після "
+"розшифрування"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "Імʼя"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "Довжина імені не повинна перевищувати 15 символів"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "Немає"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "Огляд"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "Фаза 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "Пропозиції фази 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "Фаза 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "Пропозиції фази 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "Протокол фази 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "Спільний ключ"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "Для тунелів мають бути налаштовані пропозиції"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "Перегенерація ключів"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "Запас часу для перегенерації ключів"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "Віддалений вузол"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "Віддалена IP-адреса"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "Віддалена IP-адреса джерела"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "Віддалена підмережа"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "Віддалені підмережі"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "Перезапустити"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "Віддалений ID"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "Rx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA-256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "Спільний секрет"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "Стан"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+"Діапазони адрес, що можуть знаходитися за NAT-маршрутизатором, через який "
+"підключається клієнт"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "Активні тунелі відсутні"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr "Не може мати таке саме імʼя, як інші пропозиції чи налаштовані тунелі."
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "Інтерфейс тунелю"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "Tx"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "Унікально ідентифікувати віддалені вузли"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "Небезпечно"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "Небезпечно, дивіться"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "Увімкнути"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "Оновити адресу віддаленого вузла"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "Час безперервної роботи"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr "Чи слід вважати, що ID унікально ідентифікують віддалені сторони"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base — помірне журналювання"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "cpu-usage — журналювання таймінгу/навантаження"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto — журналювання всіх крипто-операцій"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "none — без журналювання"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "private — журналювання чутливих приватних ключів та паролів"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi — надмірне журналювання"

--- a/applications/luci-app-libreswan/po/zh_Hans/libreswan.po
+++ b/applications/luci-app-libreswan/po/zh_Hans/libreswan.po
@@ -1,0 +1,480 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-18 07:48+0000\n"
+"Last-Translator: 大王叫我来巡山 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationslibreswan/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr "允许的值为整数，后跟单位 m (分钟)、h (小时) 或 d (天)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "添加提议"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "添加隧道"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "高级"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr "允许的虚拟私有网络 (Virtual Private)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "认证方式"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "认证"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "自动更新 VTI 接口的对端地址"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "清除"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "DH 组"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "DH 组 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "DH 组 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "DH 组 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "DH 组 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "DH 组 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "DH 组 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "DH 组 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "DH 组 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "DH 组 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "DH 组 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "DH 组 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "DPD 动作"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "DPD 延迟"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "DPD 超时"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "调试日志"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "↓"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "在 nfgroup 上启用 nflog"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "加密方法"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "常规"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "授予 Libreswan IPSec 的 LuCI 访问权限"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "哈希算法"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr "保持"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "IKE 生存时间"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE v2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE 版本 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE 版本 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr "监听的 IP 地址，默认取决于监听接口"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "IPSec 全局设置"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec 全局选项"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "IPSec 提议"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "IPSec 隧道"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "IPSec 隧道总览"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "发起 (Initiate)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "接口"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "IPSec 使用的接口"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr "本端 ID (Left ID)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr "本端 IP/设备"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr "本端接口"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "监听"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "监听地址"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "监听接口"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr "列出配置了 ikey 和 okey 的 VTI 接口"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr "列出 XFRM 接口，格式为 \"ipsecN\"，N 表示 xfrm 接口的 ifid"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "本地源 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "本地子网"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "本地子网列表"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "模式"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr "NFLOG 组号，用于记录所有加密前和解密后的流量"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "名称"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "名称长度不得超过 15 个字符"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "无"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "概况"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "第一阶段 (Phase1)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "第一阶段提议"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "第二阶段 (Phase2)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "第二阶段提议"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "第二阶段协议"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "预共享密钥 (PSK)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr "必须为隧道配置提议"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr "重协商密钥 (Rekey)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr "重协商宽限时间"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "对端"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "对端 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "对端源 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "对端子网"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "对端子网列表"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "重启"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr "对端 ID (Right ID)"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "接收"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "共享密钥"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "状态"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr "客户端连接时可能位于 NAT 路由器后的地址范围"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr "当前没有活动的隧道"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr "该名称不能与其他提议或已配置的隧道同名。"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "隧道接口"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "发送"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr "唯一标识对端"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "不安全"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "不安全，详见"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "↑"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "更新对端地址"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "运行时间"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr "是否将 ID 视为唯一标识对端实体的凭据"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr "base - 适度日志记录"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr "cpu-usage - 耗时/负载日志记录"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr "crypto - 所有加密相关的日志记录"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr "none - 不记录日志"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr "private - 敏感私钥/密码日志记录"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr "tmi - 冗余/极详尽日志记录"

--- a/applications/luci-app-libreswan/po/zh_Hant/libreswan.po
+++ b/applications/luci-app-libreswan/po/zh_Hant/libreswan.po
@@ -1,0 +1,479 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-09 01:02+0000\n"
+"Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationslibreswan/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6\n"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:50
+msgid "3DES*"
+msgstr "3DES*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:51
+msgid "AES"
+msgstr "AES"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:54
+msgid "AES128"
+msgstr "AES128"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:55
+msgid "AES192"
+msgstr "AES192"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:56
+msgid "AES256"
+msgstr "AES256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:53
+msgid "AES_CBC"
+msgstr "AES_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:52
+msgid "AES_CTR"
+msgstr "AES_CTR"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:175
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Acceptable values are an integer followed by m, h, d"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:17
+msgid "Add Proposal"
+msgstr "新增提案"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:47
+msgid "Add Tunnel"
+msgstr "新增隧道"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:72
+msgid "Advanced"
+msgstr "進階"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:63
+msgid "Allowed Virtual Private"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:146
+msgid "Auth Method"
+msgstr "認證方式"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:70
+msgid "Authentication"
+msgstr "認證"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:268
+msgid "Auto Update Peer Address of VTI interface"
+msgstr "自動更新 VTI 介面的對等點位址"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:57
+msgid "CAMELLIA_CBC"
+msgstr "CAMELLIA_CBC"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:213
+msgid "Clear"
+msgstr "清除"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:59
+msgid "DH Group"
+msgstr "DH 群組"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:63
+msgid "DH Group 14"
+msgstr "DH 群組 14"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:64
+msgid "DH Group 15"
+msgstr "DH 群組 15"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:65
+msgid "DH Group 16"
+msgstr "DH 群組 16"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:66
+msgid "DH Group 17"
+msgstr "DH 群組 17"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:67
+msgid "DH Group 18"
+msgstr "DH 群組 18"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:68
+msgid "DH Group 19"
+msgstr "DH 群組 19"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:69
+msgid "DH Group 20"
+msgstr "DH 群組 20"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:70
+msgid "DH Group 21"
+msgstr "DH 群組 21"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:71
+msgid "DH Group 22*"
+msgstr "DH 群組 22*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:72
+msgid "DH Group 31"
+msgstr "DH 群組 31"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:62
+msgid "DH Group 5*"
+msgstr "DH 群組 5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:210
+msgid "DPD Action"
+msgstr "DPD 動作"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:218
+msgid "DPD Delay"
+msgstr "DPD 延遲"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:223
+msgid "DPD Timeout"
+msgstr "DPD 逾時"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:23
+msgid "Debug Logs"
+msgstr "除錯紀錄"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Down"
+msgstr "下移"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:56
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:240
+msgid "Enable nflog on nfgroup"
+msgstr "在 nfgroup 上啟用 nflog"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Encryption Method"
+msgstr "加密方式"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:38
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:69
+msgid "General"
+msgstr "一般"
+
+#: applications/luci-app-libreswan/root/usr/share/rpcd/acl.d/luci-app-libreswan.json:3
+msgid "Grant access to LuCI app Libreswan IPSec"
+msgstr "授予存取 luci-app-libreswan 的權限"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+msgid "Hash Algorithm"
+msgstr "雜湊演算法"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:214
+msgid "Hold"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:180
+msgid "IKE Life Time"
+msgstr "IKE 生命週期"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:161
+msgid "IKE V2"
+msgstr "IKE V2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:164
+msgid "IKE Version 1"
+msgstr "IKE 版本 1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:163
+msgid "IKE Version 2"
+msgstr "IKE 版本 2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:46
+msgid "IP address to listen on, default depends on Listen Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:17
+msgid "IPSec Global Settings"
+msgstr "IPSec 全域設定"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:20
+msgid "IPSec Globals"
+msgstr "IPSec 全域"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:11
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:29
+msgid "IPSec Proposals"
+msgstr "IPSec 提案"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:38
+msgid "IPSec Tunnels"
+msgstr "IPSec 隧道"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:73
+msgid "IPSec Tunnels Summary"
+msgstr "IPSec 隧道概要"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:77
+msgid "Initiate"
+msgstr "開始"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:71
+msgid "Interface"
+msgstr "介面"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:40
+msgid "Interface for IPsec to use"
+msgstr "IPsec 使用的介面"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:98
+msgid "Left ID"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:84
+msgid "Left IP/Device"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:79
+msgid "Left Interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:3
+msgid "Libreswan IPSec"
+msgstr "Libreswan IPSec"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:76
+msgid "Listen"
+msgstr "監聽"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:45
+msgid "Listen Address"
+msgstr "監聽位址"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:39
+msgid "Listen Interface"
+msgstr "監聽介面"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:250
+msgid "Lists VTI interfaces configured with ikey and okey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:249
+msgid ""
+"Lists XFRM interfaces in format \"ipsecN\", N denotes ifid of xfrm interface"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:114
+msgid "Local Source IP"
+msgstr "本地來源 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:36
+msgid "Local Subnet"
+msgstr "本地子網路"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:129
+msgid "Local Subnets"
+msgstr "本地子網路"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:42
+msgid "MD5*"
+msgstr "MD5*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:74
+msgid "Mode"
+msgstr "模式"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:57
+msgid "NFLOG group number to log all pre-crypt and post-decrypt traffic to"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:34
+msgid "Name"
+msgstr "名稱"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:32
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:63
+msgid "Name length shall not exceed 15 characters"
+msgstr "名稱長度不得超過 15 個字元"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:212
+msgid "None"
+msgstr "無"
+
+#: applications/luci-app-libreswan/root/usr/share/luci/menu.d/luci-app-libreswan.json:11
+msgid "Overview"
+msgstr "概覽"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:40
+msgid "Phase1"
+msgstr "階段1"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:167
+msgid "Phase1 Proposals"
+msgstr "階段 1 提案"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:41
+msgid "Phase2"
+msgstr "階段2"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:234
+msgid "Phase2 Proposals"
+msgstr "階段 2 提案"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:228
+msgid "Phase2 Protocol"
+msgstr "階段2 協定"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:154
+msgid "Preshared Key"
+msgstr "預共享金鑰"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:37
+msgid "Proposals must be configured for Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:193
+msgid "Rekey"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:198
+msgid "Rekey Margin Time"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:35
+msgid "Remote"
+msgstr "遠端"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:103
+msgid "Remote IP"
+msgstr "遠端 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:124
+msgid "Remote Source IP"
+msgstr "遠端來源 IP"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:37
+msgid "Remote Subnet"
+msgstr "遠端子網路"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:142
+msgid "Remote Subnets"
+msgstr "遠端子網路"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:215
+msgid "Restart"
+msgstr "重新啟動"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:109
+msgid "Right ID"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:39
+msgid "Rx"
+msgstr "接收"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:43
+msgid "SHA1*"
+msgstr "SHA1*"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:44
+msgid "SHA256"
+msgstr "SHA256"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:45
+msgid "SHA384"
+msgstr "SHA384"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:46
+msgid "SHA512"
+msgstr "SHA512"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:148
+msgid "Shared Secret"
+msgstr "共享密碼"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:42
+msgid "Status"
+msgstr "狀態"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:64
+msgid ""
+"The address ranges that may live behind a NAT router through which a client "
+"connects"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:67
+msgid "There are no active Tunnels"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:30
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:61
+msgid ""
+"This may not share the same name as other proposals or configured tunnels."
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:248
+msgid "Tunnel Interface"
+msgstr "隧道介面"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:38
+msgid "Tx"
+msgstr "發送"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:34
+msgid "Uniquely Identify Remotes"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:40
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:48
+msgid "Unsafe"
+msgstr "不安全"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/proposals.js:60
+msgid "Unsafe, See"
+msgstr "不安全，請見"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:61
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:62
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:63
+msgid "Up"
+msgstr "上移"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/tunnels.js:267
+msgid "Update Peer Address"
+msgstr "更新對等點位址"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/overview.js:43
+msgid "Uptime"
+msgstr "上線時間"
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:35
+msgid "Whether IDs should be considered identifying remote parties uniquely"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:27
+msgid "base - Moderate Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:28
+msgid "cpu-usage - Timing/Load Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:29
+msgid "crypto - All crypto related Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:26
+msgid "none - No Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:31
+msgid "private - Sensitive private-key/password Logging"
+msgstr ""
+
+#: applications/luci-app-libreswan/htdocs/luci-static/resources/view/libreswan/globals.js:30
+msgid "tmi - Too Much/Excessive Logging"
+msgstr ""

--- a/applications/luci-app-rustdesk-server/po/cs/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/cs/rustdesk-server.po
@@ -1,0 +1,497 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-04 14:23+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ALWAYS_USE_RELAY"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Další potkávací servery. Pro každý server přidejte zvlášť položku (název-"
+"hostitele nebo název-hostitele:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "Bude třeba přenastavit veškeré existující klienty."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr "Omezení přenosové rychlosti pro jednotlivá spojení v MB/s (0=výchozí)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Binární"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr ""
+"Nebylo možné znovu nechat vytvořit: zatím žádný veřejný klíč zatím ještě "
+"neexistuje."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"Službu nebylo možné spustit: nejprve je třeba v nastavení povolit ID serve "
+"nebo relay server."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Zaškrtněte „Povolit ID server“ nebo „Povolit Relay server“ níže a klikněte "
+"na „Uložit a uplatnit“."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Klient"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Součást"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Nastavení"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Nastavte v Síť → Brána firewall → Pravidla provozu."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "Pokračovat?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Zkopírovat"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Ladění"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Výchozí"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Výchozí předávací servery. Pro každý server zvlášť položka (název-stroje "
+"nebo název-stroje:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "Zjistit zda spojení přichází z LAN. Použijte CIDR zápis."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Zakázat"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Povolit"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "Nejprve povolte ID server nebo Relay server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "Nejprve v nastavení povolte ID server nebo Relay server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Povoleno"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Chyba"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Chyba:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Nepodařilo se restartovat službu:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Nepodařilo se spustit službu:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Nepodařilo se zastavit službu:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Nezdařilo se:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Je zapotřebí nastavení brány firewall"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Vynutit aby všechna spojení používala předávací servery"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Nalezeno"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "Obecné"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Udělit přístup k nastavování RustDesk serveru"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "NGGR (předávací server)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID server)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID server (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Info"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Zjištěny neplatné znaky"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Neplatné znaky."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Klíč (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Znovuvytvoření klíče se nezdařilo:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "Klíče smazány. Spouštění služby pro vytvoření nových klíčů…"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "Maska LAN (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "LIMIT_SPEED"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Načítání…"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Záznam událostí"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Stupeň podrobnosti záznamu událostí pro ID server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Stupeň podrobnosti záznamu událostí pro předávací server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "Ne"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "Nenalezeno"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Zatím ještě nevytvořeno – spusťte službu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Povolit pouze klienty se stejným klíčem. Pokud nevyplněno, použije "
+"automaticky vytvořený klíč"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "Povolená jsou pouze písmena a číslice a znaky base64 (+/=)."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Port (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Zpracování…"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Veřejný klíč"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Nechat znovu vytvořit klíč"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Znovu vytvořit dvojici klíčů (vyžaduje už existující klíč)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Znovu vytvořit dvojici klíčů (restartuje službu)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Znovuvytváření…"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Předávací server (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Předávací servery (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Nastavení serveru pro software pro vzdálenou plochu."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Potkávací servery (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+"Potřebné porty (při použití výchozích nastavení): TCP 21115-21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Restartovat"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Spuštěné"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "RustDesk server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "Záznam událostí v RustDesk serveru"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "SINGLE_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Sériové číslo (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Ovládání služby"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Stav služby"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Služba zakázána při zavádění systému"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Služba povolena při zavádění systému"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+"Mohlo se stát, že spouštění služby se nezdařilo. Podívejte se na stav "
+"uvedený výše."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Služba spuštěná s novým klíčem"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Nastaví velikost vyrovnávací paměti UDP (0 = systémové výchozí)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Nastaví sériové číslo aktualizace nastavení"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "Nastaví URL stahování RustDesk softwaru pro klienty"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "Nastaví port na kterém očekávat spojení pro ID/Randezvous server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "Nastaví port na kterém očekávat spojení pro předávací server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "URL pro stahování softwaru (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Omezení rychlosti pro spojení v Mb/s (0=výchozí)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Spustit"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Spouštět při startu systému"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "Doba kontroly startu pro přechod na starší verzi spojení"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Spustit službu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Pro vytvoření počátečního klíče nejdříve spusťte službu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Pro vytvoření počátečního klíče spusťte službu."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"Spuštění bude fungovat pouze pokud je v sekci nastavení níže zaškrtnuto "
+"alespoň „Povolit ID server“ nebo „Povolit Relay server“."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Zastavit"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Zastaveno"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "TOTAL_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Toto znovu vytvoří dvojici klíčů a restartuje službu."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "Prahová hodnota pro přechod na starší verzi spojení"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "Celkový limit pro využívání šířky pásma v MB/s (0 = výchozí)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Sledovat"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "Vyrovnávací paměť UDP příjmu (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "Je třeba, aby URL začínalo na http:// nebo https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Varování"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Ano"

--- a/applications/luci-app-rustdesk-server/po/de/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/de/rustdesk-server.po
@@ -1,0 +1,480 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-02 19:29+0000\n"
+"Last-Translator: ssantos <ssantos@web.de>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/de/>\n"
+"Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Protokoll"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Rückverfolgung"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr ""

--- a/applications/luci-app-rustdesk-server/po/es/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/es/rustdesk-server.po
@@ -1,0 +1,501 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-04-18 17:10+0000\n"
+"Last-Translator: Franco Castillo <castillofrancodamian@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ALWAYS_USE_RELAY"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Servidores rendezvous adicionales. Agrega un servidor por apunte "
+"(nombredehost o nombredehost:puerto)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "Todos los clientes necesitarán ser reconfigurados."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr "Límite del ancho de banda por conexión única en MB/s (0 = predet.)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Binario"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "No se puede regenerar: aún no existe ninguna clave pública."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"No se puede iniciar el servicio: primero active el ID del servidor o el "
+"servidor de retransmisión en la configuración."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Compruebe «Activar ID del servidor» o «Activar servidor de retransmisión» a "
+"continuación y pulse «Guardar y aplicar»."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Cliente"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Componente"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Configuración"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Configurar en Red → Cortafuegos → Reglas de tráfico."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "¿Continuar?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Copiar"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Depuración"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Predeterminado"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Servidores de retransmisión predeterminados. Agregue un servidor por entrada "
+"(nombre de host o nombre de host:puerto)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "Determine si la conexión viene desde LAN. Utilice notación CIDR."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Desactivar"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Activar"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "Active primero el ID del servidor o el servidor de retransmisión"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr ""
+"Activar primero el ID del servidor o servidor de retransmisión en la "
+"configuración"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Activado"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Error"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Error:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Fallo al reiniciar el servicio:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Fallo al iniciar el servicio:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Fallo al detener el servicio:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Fallo:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Se requiere configuración del cortafuegos"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Forzar todas las conexiones para utilizar servidores de retransmisión"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Encontrado"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "General"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Conceder acceso a la configuración del servidor RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (Servidor de retransmisión)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID Servidor)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID de servidor (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Informe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Detectado carácter no válido"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Caracteres no válidos."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Tecla (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Regeneración de tecla incorrecta:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "Teclas borradas. Iniciando servicio para generar teclas nuevas..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "Máscara LAN (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "LIMIT_SPEED"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Cargando..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Registro"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Nivel de acceso para el ID del servidor"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Nivel de acceso para el servidor de retransmisión"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "No"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "No encontrado"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Aún no generado - iniciar el servicio"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Solo permite clientes con la misma clave. Si está vacío, auto-genera la clave"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "Solo alfanumérico y caracteres de base64 (+/=) permitidos."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Puerto (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Procesando..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Clave pública"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Regenerar clave"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Regenerar el par de claves (requiere una clave existente)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Regenerar el par de claves (reiniciará el servicio)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Regenerando..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Servidor de retransmisión (nbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Servidores de retransmisión (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Configuración del servidor de software de escritorio remoto."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Servidores Rendezvpus (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+"Puertos requeridos (cuando utilice ajustes por defecto): TCP 21115-21119, "
+"UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Ejecutando"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "Servidor RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "Registro del servidor RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "SINGLE_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Número de serie (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Servidor"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Control de servicio"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Estado del servicio"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Servicio desactivado en el arranque"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Servicio activado en el arranque"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+"Es posible que el inicio del servicio haya fallado. Verifique el estado "
+"arriba."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Servicio iniciado con clave nueva"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Establece el tamaño del búfer de recepción UDP (0 =sistema predet.)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Establecer configuración de actualización del número serie"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "Establece el URL de descarga del software RustDesk para clientes"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "Establece el puerto de escucha para el ID/Servidor Rendezvous"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "Establece el puerto de escucha para el servidor de retransmisión"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "URL de descarga del software (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Límite de velocidad por conexión en Mb/s (0 = predet.)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Iniciar"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Iniciar en el arranque"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "Iniciar tiempo de comprobación para degradación de conexión"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Iniciar el servicio"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Inicia el primer servicio para generar la clave inicial"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Inicia el primer servicio para generar la clave inicial."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"El inicio solo funcionará si al menos está comprobado «Iniciar ID del "
+"servidor» o «Iniciar servidor de retransmisión» en la sección de "
+"configuración a continuación."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Detener"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Detenido"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "TOTAL_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Esto regenerará el par de claves y reiniciará el servicio."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "Umbral para conexión degradada"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "Límite del ancho de banda en MB/s (0 = predet.)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Rastro"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "Búfer de recepción UDP (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "URL debe inicial con http:// o https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Aviso"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Sí"

--- a/applications/luci-app-rustdesk-server/po/ga/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/ga/rustdesk-server.po
@@ -1,0 +1,498 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ÚSÁID_ATHSHEACHALÚ_I_GCÓNAÍ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Freastalaithe coinneála breise. Cuir freastalaí amháin leis in aghaidh gach "
+"iontrála (ainm óstach nó ainm óstach:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "Beidh gá gach cliant atá ann cheana a athchumrú."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+"Teorainn bandaleithead in aghaidh an naisc aonair i MB/s (0 = réamhshocrú)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Dénártha"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "Ní féidir athghiniúint: Níl aon eochair phoiblí ann fós."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"Ní féidir an tseirbhís a thosú: Cumasaigh an Freastalaí ID nó an Freastalaí "
+"Athsheolta sa chumraíocht ar dtús."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Seiceáil \"Cumasaigh Freastalaí Aitheantais\" nó \"Cumasaigh Freastalaí "
+"Athsheolta\" thíos agus cliceáil \"Sábháil & Cuir i bhFeidhm\"."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Cliant"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Comhpháirt"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Cumraíocht"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Cumraigh i Líonra → Balla Dóiteáin → Rialacha Tráchta."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "Leanúint ar aghaidh?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Cóipeáil"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "ÍOSGHRÁDÚ_TOS_SEICEÁIL"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "ÍOSGHRÁDÚ_TAIRSE"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Dífhabhtú"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Réamhshocrú"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Freastalaithe athsheachadta réamhshocraithe. Cuir freastalaí amháin leis in "
+"aghaidh gach iontrála (ainm óstach nó ainm óstach:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "Faigh amach an dtagann an nasc ó LAN. Bain úsáid as nótaíocht CIDR."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Díchumasaigh"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Míchumasaithe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Cumasaigh"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "Cumasaigh Freastalaí ID nó Freastalaí Athsheolta ar dtús"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr ""
+"Cumasaigh Freastalaí ID nó Freastalaí Athsheolta sa Chumraíocht ar dtús"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Cumasaithe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Earráid"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Earráid:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Theip ar an tseirbhís a atosú:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Theip ar an tseirbhís a thosú:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Theip ar an tseirbhís a stopadh:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Theip air:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Cumraíocht Balla Dóiteáin Riachtanach"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Éirigh ar gach nasc freastalaithe sealaíochta a úsáid"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Fuarthas"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "Ginearálta"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Deonaigh rochtain ar chumraíocht Freastalaí RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (Freastalaí Athsheolta)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (Freastalaí Aitheantais)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "Freastalaí Aitheantais (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Eolas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Carachtair neamhbhailí braite"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Carachtair neamhbhailí."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Eochair (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Theip ar athghiniúint eochrach:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "Eochracha scriosta. Seirbhís á tosú chun eochracha nua a ghiniúint..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "Masc LAN (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "TEORAINN_LUAS"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Ag lódáil..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Logáil"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Leibhéal logála don fhreastalaí aitheantais"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Leibhéal logála don fhreastalaí athsheolta"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "Níl"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "Níor aimsíodh"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Níor gineadh fós - cuir tús leis an tseirbhís"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Ní cheadaítear ach cliaint leis an eochair chéanna. Más folamh é, úsáidtear "
+"an eochair uathghinte"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr ""
+"Ní cheadaítear ach carachtair alfa-uimhriúla agus carachtair base64 (+/=)."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Port (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Ag próiseáil..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Eochair Phoiblí"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Athghinigh an Eochair"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Athghin an péire eochracha (tá eochair atá ann cheana ag teastáil)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Athghin an péire eochracha (atosóidh an tseirbhís)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Ag athghiniúint..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Freastalaí Athsheolta (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Freastalaithe Athsheolta (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Cumraíocht Freastalaí Bogearraí Deisce Cianda."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Freastalaithe Rendezvous (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+"Calafoirt riachtanacha (agus socruithe réamhshocraithe in úsáid): TCP "
+"21115-21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Atosaigh"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Ag rith"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "Freastalaí RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "Log Freastalaí RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "BANDALEITHEAD_AONAIR"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Uimhir Sraitheach (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Freastalaí"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Rialú Seirbhíse"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Stádas Seirbhíse"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Seirbhís díchumasaithe ag an tosaithe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Seirbhís cumasaithe ag an tosaithe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr "B’fhéidir gur theip ar thosú na seirbhíse. Seiceáil an stádas thuas."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Seirbhís tosaithe le heochair nua"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Socraíonn sé méid maoláin fála UDP (0 = réamhshocrú an chórais)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Socraíonn cumraíocht uimhir sraitheach nuashonraithe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "Socraíonn sé URL íoslódála bogearraí RustDesk do chliaint"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "Socraíonn sé an port éisteachta don fhreastalaí ID/Rendezvous"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "Socraíonn sé an port éisteachta don fhreastalaí athsheolta"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "URL Íoslódála Bogearraí (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Teorainn luais in aghaidh an naisc i Mb/s (0 = réamhshocrú)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Tosaigh"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Tosaigh ag Tosaithe"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "Am seiceála tosaigh le haghaidh íosghrádú nasc"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Tosaigh an tseirbhís"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Tosaigh an tseirbhís ar dtús chun an eochair tosaigh a ghiniúint"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Tosaigh an tseirbhís ar dtús chun an eochair tosaigh a ghiniúint."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"Ní oibreoidh an tosach ach amháin má tá tic sa rannán Cumraíochta thíos le "
+"\"Cumasaigh Freastalaí Aitheantais\" nó \"Cumasaigh Freastalaí Athsheolta\"."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Stop"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Stoptha"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "BANDALEITHEAD_IOMLÁN"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Athghinfidh sé seo an péire eochracha agus atosóidh sé an tseirbhís."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "Tairseach le haghaidh íosghrádú nasc"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "Teorainn iomlán bandaleithead i MB/s (0 = réamhshocrú)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Rian"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "Maolán Glactha UDP (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "Ní mór don URL tosú le http:// nó https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Rabhadh"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Tá"

--- a/applications/luci-app-rustdesk-server/po/ko/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/ko/rustdesk-server.po
@@ -1,0 +1,480 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-25 03:13+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "클라이언트"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "구성 요소"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "설정"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "네트워크 → 방화벽 → 트래픽 규칙에서 설정하세요."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "복사"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "디버그"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "기본값"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "비활성화"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "비활성화"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "활성화"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "활성화"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "오류(Error)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "오류:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "서비스 재시작 실패:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "서비스 시작 실패:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "서비스 중지 실패:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "실패:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "방화벽 설정 필요"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "일반"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "RustDesk 서버 설정에 접근 권한 부여"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (릴레이 서버)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID 서버)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID 서버 (HBBS)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "정보(Info)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "키 (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "키 재생성 실패:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "LAN 마스크 (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "속도 제한"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "불러오는 중..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "로그"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "아니요"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "포트 (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "처리 중..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "공개 키"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "Rust 로그"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "키 재생성"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "재생성 중..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "릴레이 서버 (HBBR)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "릴레이 서버 (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "원격 데스크톱 소프트웨어 서버 설정입니다."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "랑데부 서버 (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr "필수 포트 (기본 설정 사용 시): TCP 21115-21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "재시작"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "실행 중"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "RustDesk 서버"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "RustDesk 서버 로그"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "단일 대역폭"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "서버"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "서비스 제어"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "서비스 상태"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "시작"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "서비스 시작"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "중지"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "중지됨"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "총 대역폭"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "추적(Trace)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "경고(Warning)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "예"

--- a/applications/luci-app-rustdesk-server/po/lo/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/lo/rustdesk-server.po
@@ -1,0 +1,484 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ໃຊ້ລີເລສະເໝີ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr "ເຊີເວີຣັນເດວວູເພີ່ມເຕີມ. ເພີ່ມໜຶ່ງເຊີເວີຕໍ່ແຖວ (ຊື່ໂຮດ ຫຼື ຊື່ໂຮດ:ພອດ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "ໄຄລ໌ແອນທີ່ມີຢູ່ທັງໝົດຈະຕ້ອງຖືກຕັ້ງຄ່າໃໝ່."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr "ຈຳກັດແບນວິດຕໍ່ການເຊື່ອມຕໍ່ດຽວ ໃນໜ່ວຍ MB/s (0 = ຄ່າເລີ່ມຕົ້ນ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "ໄບນາຣີ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "ບໍ່ສາມາດສ້າງໃໝ່ໄດ້: ຍັງບໍ່ມີພັບບລິກຄີ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr "ບໍ່ສາມາດເລີ່ມບໍລິການໄດ້: ຕ້ອງເປີດໃຊ້ງານ ID Server ຫຼື Relay Server ໃນການຕັ້ງຄ່າກ່ອນ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"ໝາຍຕິກ \"ເປີດໃຊ້ງານ ID Server\" ຫຼື \"ເປີດໃຊ້ງານ Relay Server\" ຢູ່ດ້ານລຸ່ມ ແລ້ວກົດ \"ບັນທຶກ "
+"& ນຳໃຊ້\"."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "ລູກຄ້າ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "ອົງປະກອບ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "ການຕັ້ງຄ່າ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "ຕັ້ງຄ່າໃນ ເຄືອຂ່າຍ → ໄຟວໍ → ກົດລະບຽບການຈະລາຈອນ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "ດຳເນີນການຕໍ່?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "ຄັດລອກ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "ເວລາເລີ່ມກວດສອບການລົດລະດັບ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "ເກນສຳລັບການລົດລະດັບ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "ດີບັກ (Debug)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "ຄ່າເລີ່ມຕົ້ນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr "ເຊີເວີລີເລຄ່າເລີ່ມຕົ້ນ. ເພີ່ມໜຶ່ງເຊີເວີຕໍ່ແຖວ (ຊື່ໂຮດ ຫຼື ຊື່ໂຮດ:ພອດ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "ກຳນົດວ່າການເຊື່ອມຕໍ່ມາຈາກ LAN ຫຼືບໍ່. ໃຫ້ໃຊ້ຮູບແບບ CIDR."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "ປິດໃຊ້ງານ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "ປິດໃຊ້ງານ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "ເປີດໃຊ້ງານ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "ຕ້ອງເປີດໃຊ້ງານ ID Server ຫຼື Relay Server ກ່ອນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "ຕ້ອງເປີດໃຊ້ງານ ID Server ຫຼື Relay Server ໃນການຕັ້ງຄ່າກ່ອນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "ເປີດໃຊ້ງານ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "ຄວາມຜິດພາດ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "ຜິດພາດ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "ການຣີສະຕາດບໍລິການລົ້ມເຫຼວ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "ການເລີ່ມບໍລິການລົ້ມເຫຼວ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "ການຢຸດບໍລິການລົ້ມເຫຼວ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "ລົ້ມເຫຼວ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "ຕ້ອງການຕັ້ງຄ່າໄຟວໍ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "ບັງຄັບໃຫ້ທຸກການເຊື່ອມຕໍ່ໃຊ້ງານເຊີເວີລີເລ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "ພົບ"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "ທົ່ວໄປ"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "ໃຫ້ສິດໃນການເຂົ້າເຖິງການຕັ້ງຄ່າ RustDesk Server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (ເຊີເວີລີເລ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ເຊີເວີ ID)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ເຊີເວີ ID (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "ຂໍ້ມູນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "ກວດພົບຕົວອັກສອນທີ່ບໍ່ຖືກຕ້ອງ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "ຕົວອັກສອນບໍ່ຖືກຕ້ອງ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "ຄີ (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "ການສ້າງຄີໃໝ່ລົ້ມເຫຼວ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "ລຶບຄີອອກແລ້ວ. ກຳລັງເລີ່ມບໍລິການເພື່ອສ້າງຄີໃໝ່..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "LAN Mask (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "ຈຳກັດຄວາມໄວ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "ກຳລັງໂຫຼດ..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "ບັນທຶກການເຮັດວຽກ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "ລະດັບການບັນທຶກສຳລັບເຊີເວີ ID"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "ລະດັບການບັນທຶກສຳລັບເຊີເວີລີເລ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "ບໍ່"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "ບໍ່ພົບ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "ຍັງບໍ່ທັນສ້າງ - ໃຫ້ເລີ່ມບໍລິການກ່ອນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr "ອະນຸຍາດສະເພາະໄຄລ໌ແອນທີ່ມີຄີດຽວກັນ. ຖ້າປະວ່າງໄວ້ ຈະໃຊ້ຄີທີ່ສ້າງຂຶ້ນອັດຕະໂນມັດ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "ອະນຸຍາດສະເພາະຕົວອັກສອນຕົວເລກ, ຕົວອັກສອນ ແລະ ເຄື່ອງໝາຍ base64 (+/=) ເທົ່ານັ້ນ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "ພອດ (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "ກຳລັງປະມວນຜົນ..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "ພັບບລິກຄີ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "ສ້າງຄີໃໝ່"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "ສ້າງຄູ່ຄີໃໝ່ (ຕ້ອງມີຄີເກົ່າກ່ອນ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "ສ້າງຄູ່ຄີໃໝ່ (ຈະມີການຣີສະຕາດບໍລິການ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "ກຳລັງສ້າງໃໝ່..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "ເຊີເວີລີເລ (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "ເຊີເວີລີເລ (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "ການຕັ້ງຄ່າເຊີເວີຊອບແວຣີໂມດເດັສທັອບ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "ເຊີເວີຣັນເດວວູ (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr "ພອດທີ່ຕ້ອງການ (ເມື່ອໃຊ້ຄ່າເລີ່ມຕົ້ນ): TCP 21115-21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "ຣີສະຕາດ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "ກຳລັງເຮັດວຽກ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "RustDesk Server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "RustDesk Server Log"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "ແບນວິດດຽວ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "ເລກລຳດັບ (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "ເຊີບເວີ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "ການຄວບຄຸມບໍລິການ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "ສະຖານະບໍລິການ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "ປິດໃຊ້ງານບໍລິການຕອນເປີດເຄື່ອງ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "ເປີດໃຊ້ງານບໍລິການຕອນເປີດເຄື່ອງ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr "ການເລີ່ມບໍລິການອາດລົ້ມເຫຼວ. ໃຫ້ກວດສອບສະຖານະດ້ານເທິງ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "ເລີ່ມບໍລິການດ້ວຍຄີໃໝ່ແລ້ວ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "ຕັ້ງຄ່າຂະໜາດບັຟເຟີຮັບ UDP (0 = ຄ່າເລີ່ມຕົ້ນຂອງລະບົບ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "ຕັ້ງຄ່າເລກລຳດັບການອັບເດດ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "ຕັ້ງຄ່າ URL ດາວໂຫຼດຊອບແວ RustDesk ສຳລັບໄຄລ໌ແອນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "ຕັ້ງຄ່າພອດຟັງສຳລັບເຊີເວີ ID/Rendezvous"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "ຕັ້ງຄ່າພອດຟັງສຳລັບເຊີເວີລີເລ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "URL ດາວໂຫຼດຊອບແວ (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "ຈຳກັດຄວາມໄວຕໍ່ການເຊື່ອມຕໍ່ ໃນໜ່ວຍ Mb/s (0 = ຄ່າເລີ່ມຕົ້ນ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "ເລີ່ມ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "ເລີ່ມຕອນເປີດເຄື່ອງ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "ເວລາເລີ່ມກວດສອບການລົດລະດັບການເຊື່ອມຕໍ່"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "ເລີ່ມບໍລິການ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "ຕ້ອງເລີ່ມບໍລິການກ່ອນເພື່ອສ້າງຄີເບື້ອງຕົ້ນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "ຕ້ອງເລີ່ມບໍລິການກ່ອນເພື່ອສ້າງຄີເບື້ອງຕົ້ນ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"ການເລີ່ມຈະເຮັດວຽກໄດ້ກໍຕໍ່ເມື່ອມີການໝາຍຕິກ \"ເປີດໃຊ້ງານ ID Server\" ຫຼື \"ເປີດໃຊ້ງານ Relay "
+"Server\" ຢູ່ໃນພາກການຕັ້ງຄ່າດ້ານລຸ່ມນີ້."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "ຢຸດ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "ຢຸດແລ້ວ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "ແບນວິດລວມ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "ການກະທຳນີ້ຈະສ້າງຄູ່ຄີໃໝ່ ແລະ ຣີສະຕາດບໍລິການ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "ເກນສຳລັບການລົດລະດັບການເຊື່ອມຕໍ່"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "ຈຳກັດແບນວິດລວມ ໃນໜ່ວຍ MB/s (0 = ຄ່າເລີ່ມຕົ້ນ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "ການຕິດຕາມ (Trace)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "UDP Recv Buffer (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "URL ຕ້ອງເລີ່ມຕົ້ນດ້ວຍ http:// ຫຼື https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "ຄຳເຕືອນ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "ແມ່ນ"

--- a/applications/luci-app-rustdesk-server/po/lt/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/lt/rustdesk-server.po
@@ -1,0 +1,515 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-22 21:12+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "„ALWAYS_USE_RELAY“"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Papildomi susitikimų serveriai. Pridėkite po vieną serverį kiekvienai "
+"įvesčiai (įrenginio (t.y skleidėjo/vedėjo) pavadinimas arba įrenginio (t.y "
+"skleidėjo/vedėjo) pavadinimas:prievadas)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "Visus esamus klientus reikės iš naujo sukonfigūruoti."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+"Duomenų siuntimo ir perdavimo srauto pralaidumo riba vienam prisijungimui MB/"
+"s (0-is = numatytasis)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Dvejetainė"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "Negalima iš naujo sugeneruoti: viešojo rakto dar nėra."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"Negalima paleisti tarnybos: pirmiausia konfigūracijoje įjunkite ID serverį "
+"arba retransliavimo/perdavimo serverį."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Pažymėkite „Įjungti/Įgalinti ID serverį“ arba „Įjungti retransliavimo/"
+"perdavimo serverį“ apačioje ir spustelėkite – „Išsaugoti ir taikyti“."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Klientas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Komponentas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Konfigūracija"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Konfigūruoti per – Tinklas → Užkarda → Srauto taisyklės."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "Tęsti?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Kopijuoti"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Derinimas/Trukdžių šalinimas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Numatyta/-s/-ai"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Numatytieji retransliavimo/perdavimo serveriai. Pridėkite po vieną serverį "
+"kiekvienai įvesčiai (įrenginio (t.y skleidėjo/vedėjo) pavadinimas arba "
+"įrenginio (t.y skleidėjo/vedėjo) pavadinimas:prievadas)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "Nustatyti, jei ryšys atsiranda iš „LAN“. Naudoti „CIDR“ užrašą."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Išjungti/Išgalinti"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Išjungta/Neįgalinta (-s/-i)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Įjungti/Įgalinti"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr ""
+"Įjungti/Įgalinti ID serverį arba retransliavimo/perdavimo serverį pirmą"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr ""
+"Įjungti/Įgalinti ID serverį arba retransliavimo/perdavimo serverį "
+"konfigūracijoje pirmą"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Įjungta/Įgalinta (-s/-i)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Klaida"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Klaida:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Nepavyko paleisti iš naujo tarnybos:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Nepavyko paleisti tarnybos:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Nepavyko sustabdyti tarnybos:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Nepavyko/-ę:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Reikalingas užkardos konfigūravimas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Priversti visus ryšius naudoti retransliavimo/perdavimo serverius"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Rasta/-s/-i"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "Bendra/-i/-ai/-s"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Duoti prieigą prie – „RustDesk“ serverio konfigūracijos"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "„HBBR“ (retransliavimo/perdavimo serveris)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "„HBBS“ (ID serveris)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID serveris („hbbs“)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Informacija"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Aptiktos negalimos rašmenys"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Negalimos rašmenys."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Raktas (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Rakto sugeneravimas nepavyko:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "Raktai ištrinti. Pradedama tarnyba naujiems raktams generuoti..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "„LAN“ tinklavimo „kaukė“ – adresų segregatorius (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "„LIMIT_SPEED“"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Kraunama..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Žurnalas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Žurnalinimo lygis, skirtas ID serveriui"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Žurnalinimas lygis, skirtas retransliavimo/perdavimo serveriui"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "Ne"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "Nerasta/-s"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Dar nesugeneruota – pradėti tarnyba"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Leisti tik klientus su tuo pačiu raktu. Jei tuščia, naudojamas automatiškai "
+"sugeneruotas raktas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "Leidžiamos tik tekstinės ir „base64“ rašmenys (+/=)."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Prievadas (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Apdorojama..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Viešasis raktas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "„RUST_LOG“"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Iš naujo sugeneruoti raktą"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Iš naujo sugeneruoti rakto porą (reikalingas egzistuojamas raktas)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Iš naujo sugeneruoti raktų porą (tarnyba bus paleista iš naujo)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Iš naujo sugeneruojama..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Retransliavimo/Perdavimo serveris („hbbr“)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Retransliavimo/Perdavimo serveriai (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Nuotolinio darbalaukio taikomosios programos serverio konfigūracija."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Susitikimų serveriai (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+"Reikalingi prievadai (kai naudojami numatytieji nustatymai): „TCP“ "
+"21115-21119, „UDP“ 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Paleisti iš naujo"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Veikia"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "„RustDesk“ serveris"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "„RustDesk“ serverio žurnalas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "„SINGLE_BANDWIDTH“"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Serijos numeris (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Serveris"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Tarnybos valdymas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Tarnybos būsena"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Tarnyba išjungta/išgalinta paleidžiant"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Tarnyba įjungta/įgalinta paleidžiant"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+"Tarnybos paleidimas galėjo nepavykti. Patikrinkite būseną/būklę aukščiau."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Tarnyba pradėta su nauju raktu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Nustato „UDP“ gavimo buferio dydį (0-is = sistemos numatytasis)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Nustato konfigūravimo atnaujinimo serijos numerį"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr ""
+"Nustato „RustDesk“ taikomosios programos atsisiuntimo „URL“ – saitą klientams"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr ""
+"Nustato laukiamą prisijungimo/jungties ryšio prievadą, skirtą ID/susitikimų "
+"serveriui"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr ""
+"Nustato laukiamą prisijungimo/jungties ryšio prievadą, skirtą retransliavimo/"
+"perdavimo serveriui"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "Taikomosios programos atsisiuntimo „URL“ – saitas (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Greičio apribojimas vienam prisijungimui Mb/s (0-is = numatytasis)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Paleisti"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Paleisti paleidžiant"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr ""
+"Paleisti patikros laiką, skirtą prisijungimo aukštutinės versijos/programos/"
+"įrangos į senesniosios versijos sugrąžinimą"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Paleisti tarnyba"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Paleiskite tarnybą pirmą, norint sugeneruoti pradinį raktą"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Paleiskite tarnybą pirmą, norint sugeneruoti pradinį raktą."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"„Paleisti“ veiks tik tuo atveju, jei bent „Įjungti/Įgalinta ID serveri“ arba "
+"„Įjungti/Įgalinti retransliavimo/perdavimo serverį“ yra pažymėta žemiau "
+"esančiame skyriuje „Konfigūracija“."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Stabdyti"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Sustabdyta/-s/-i"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "„TOTAL_BANDWIDTH“"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Tai iš naujo sugeneruos raktų porą ir paleis tarnybą iš naujo."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr ""
+"Slenkstis, prisijungimo aukštutinės versijos/programos/įrangos į senesnę "
+"sugrąžinimas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr ""
+"Bendra duomenų siuntimo ir perdavimo srauto pralaidumo riba MB/s (0-is = "
+"numatytasis)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Atsekamumas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "„UDP“ gavimo buferis (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "„URL“ – Saitas turi prasidėti su – „http://“ arba „https://“"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Įspėjimas"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Taip"

--- a/applications/luci-app-rustdesk-server/po/pl/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/pl/rustdesk-server.po
@@ -1,0 +1,497 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-04 00:14+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ALWAYS_USE_RELAY"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Dodatkowe serwery połączeń. Dodaj jeden serwer na wpis (nazwa hosta lub "
+"nazwa_hosta:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr ""
+"Wszystkie istniejące klienty będą musiały zostać ponownie skonfigurowane."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+"Limit przepustowości na pojedyncze połączenie w MB/s (0 = wartość domyślna)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Binarny"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "Nie można wygenerować: klucz publiczny jeszcze nie istnieje."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"Nie można uruchomić usługi: najpierw włącz w konfiguracji „Serwer ID\" lub "
+"„Serwer pośredniczący”."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Zaznacz opcję „Włącz serwer ID” lub „Włącz serwer pośredniczący” poniżej i "
+"kliknij „Zapisz i zastosuj”."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Klient"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Komponent"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Konfiguracja"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Skonfiguruj w Sieć → Zapora → Reguły ruchu sieciowego."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "Kontynuować?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Kopiuj"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Debugowanie"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Domyślne"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Domyślne serwery pośredniczące. Dodaj jeden serwer na wpis (nazwa hosta lub "
+"nazwa_hosta:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "Sprawdź, czy połączenie pochodzi z sieci LAN. Użyj notacji CIDR."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Wyłącz"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Włącz"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "Najpierw włącz „Serwer ID” lub „Serwer pośredniczący”"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "Najpierw włącz „Serwer ID” lub „Serwer pośredniczący” w konfiguracji"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Włączone"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Błąd"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Błąd:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Nie udało się ponownie uruchomić usługi:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Nie udało się uruchomić usługi:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Nie udało się zatrzymać usługi:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Niepowodzenie:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Wymagana konfiguracja zapory"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Wymuś używanie serwerów pośredniczących przez wszystkie połączenia"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Znaleziono"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "Ogólne"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Przyznaj dostęp do konfiguracji serwera RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (serwer pośredniczący)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (serwer ID)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "Serwer ID (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Info"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Wykryto nieprawidłowe znaki"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Nieprawidłowe znaki."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Klucz (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Ponowne generowanie klucza nie powiodło się:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr ""
+"Klucze zostały usunięte. Rozpoczynam usługę generowania nowych kluczy..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "Maska LAN (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "LIMIT_SPEED"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Ładowanie..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Dziennik"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Poziom rejestrowania dla serwera ID"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Poziom rejestrowania dla serwera pośredniczącego"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "Nie"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "Nie znaleziono"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Jeszcze nie wygenerowano. Uruchom usługę"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Zezwalaj tylko klientom z tym samym kluczem. Jeśli puste, użyj klucza "
+"wygenerowanego automatycznie"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "Dozwolone są wyłącznie znaki alfanumeryczne i base64 (+/=)."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Port (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Przetwarzanie..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Klucz publiczny"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Wygeneruj ponownie klucz"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Wygeneruj ponownie parę kluczy (wymaga istniejącego klucza)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Wygeneruj ponownie parę kluczy (uruchomi ponownie usługę)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Ponowne generowanie..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Serwer pośredniczący (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Serwery pośredniczące (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Konfiguracja serwera oprogramowania pulpitu zdalnego."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Serwery połączeń (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+"Wymagane porty (przy użyciu ustawień domyślnych): TCP 21115-21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Restartuj"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Uruchomione"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "Serwer RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "Dziennik serwera RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "SINGLE_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Numer seryjny (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Serwer"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Kontrola usługi"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Status usługi"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Usługa wyłączona podczas rozruchu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Usługa włączona podczas rozruchu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr "Uruchomienie usługi mogło się nie powieść. Sprawdź status powyżej."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Usługa uruchomiona z nowym kluczem"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Ustawia rozmiar bufora odbioru UDP (0 = wartość domyślna systemu)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Ustawia konfigurację numeru seryjnego aktualizacji"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "Ustawia adres URL pobierania oprogramowania RustDesk dla klientów"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "Ustawia port nasłuchiwania dla serwerów ID i połączeń"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "Ustawia port nasłuchiwania dla serwera pośredniczącego"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "Adres URL pobierania oprogramowania (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Limit prędkości na połączenie w Mb/s (0 = wartość domyślna)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Uruchom"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Uruchom przy rozruchu"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "Uruchom sprawdzanie czasu obniżenia poziomu połączenia"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Uruchom usługę"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Najpierw uruchom usługę, aby wygenerować klucz początkowy"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Najpierw uruchom usługę, aby wygenerować klucz początkowy."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"Uruchomienie będzie działać tylko wtedy, gdy w sekcji Konfiguracja poniżej "
+"zaznaczona będzie opcja „Włącz serwer ID” lub „Włącz serwer pośredniczący”."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Zatrzymaj"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Zatrzymane"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "TOTAL_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Spowoduje to ponowne wygenerowanie pary kluczy i restart usługi."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "Próg obniżenia połączenia"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "Całkowity limit przepustowości w MB/s (0 = wartość domyślna)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Śledzenie"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "Bufor odbioru UDP (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "Adres URL musi zaczynać się od http:// lub https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Ostrzeżenie"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Tak"

--- a/applications/luci-app-rustdesk-server/po/pt_BR/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/pt_BR/rustdesk-server.po
@@ -1,0 +1,480 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-17 16:40+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationsrustdesk-server/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Cliente"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Padrão"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Desativado"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Ativar"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Ativado"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Informação (Info)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Aviso"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr ""

--- a/applications/luci-app-rustdesk-server/po/ru/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/ru/rustdesk-server.po
@@ -1,0 +1,499 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-25 12:14+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ALWAYS_USE_RELAY"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Дополнительные серверы координации. Добавляйте по одному серверу на запись "
+"(имя хоста или имя хоста:порт)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "Все существующие клиенты потребуют перенастройки."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+"Ограничение пропускной способности для одного соединения в МБ/с (0 = по "
+"умолчанию)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Бинарный файл"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "Невозможно пересоздать: публичный ключ ещё не существует."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"Невозможно запустить службу: сначала включите ID-сервер или сервер "
+"ретрансляции в настройках."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Отметьте «Включить ID-сервер» или «Включить сервер ретрансляции» ниже и "
+"нажмите «Сохранить и применить»."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Клиент"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Компонент"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Конфигурация"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Настройте в Сеть → Межсетевой экран → Правила для трафика."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "Продолжить?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Копировать"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Отладка"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "По умолчанию"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Серверы ретрансляции по умолчанию. Добавляйте по одному серверу на запись "
+"(имя хоста или имя хоста:порт)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr ""
+"Определяет, является ли подключение локальным. Используйте CIDR-нотацию."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Отключить"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Отключено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Включить"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "Сначала включите ID-сервер или сервер ретрансляции"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "Сначала включите ID-сервер или сервер ретрансляции в настройках"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Включено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Ошибка"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Ошибка:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Не удалось перезапустить службу:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Не удалось запустить службу:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Не удалось остановить службу:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Не удалось:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Требуется настройка межсетевого экрана"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Принудительно использовать серверы ретрансляции для всех подключений"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Найдено"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "Основные"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Предоставить доступ к настройкам сервера RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (сервер ретрансляции)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID-сервер)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID-сервер (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Информация"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Обнаружены недопустимые символы"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Недопустимые символы."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Ключ (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Пересоздание ключа не удалось:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "Ключи удалены. Запуск службы для создания новых ключей..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "Маска LAN (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "LIMIT_SPEED"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Загрузка..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Системный журнал"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Уровень журналирования для ID-сервера"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Уровень журналирования для сервера ретрансляции"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "Нет"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "Не найдено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Ещё не создан — запустите службу"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Разрешать только клиентам с таким же ключом. Если оставить пустым, "
+"используется автоматически сгенерированный ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "Допускаются только буквенно-цифровые символы и символы base64 (+/=)."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Порт (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Обработка..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Публичный ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Пересоздать ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Пересоздать пару ключей (требуется существующий ключ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Пересоздать пару ключей (служба будет перезапущена)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Пересоздание..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Сервер ретрансляции (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Серверы ретрансляции (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Конфигурация сервера ПО удалённого рабочего стола."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Серверы координации (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr ""
+"Необходимые порты (при использовании настроек по умолчанию): TCP 21115–"
+"21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Перезапустить"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Запущено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "Сервер RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "Журнал сервера RustDesk"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "SINGLE_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Серийный номер (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Сервер"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Управление службой"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Состояние службы"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Служба отключена при загрузке"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Служба включена при загрузке"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr "Возможно, служба не запустилась. Проверьте статус выше."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Служба запущена с новым ключом"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Размер буфера приёма UDP (0 = системное значение по умолчанию)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Задаёт серийный номер для обновления конфигурации"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "Задаёт URL-адрес для загрузки ПО RustDesk клиентами"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "Задаёт порт прослушивания для сервера ID/координации"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "Задаёт порт прослушивания для сервера ретрансляции"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "URL-адрес для загрузки ПО (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Ограничение скорости для одного соединения в Мбит/с (0 = по умолчанию)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Запустить"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Запускать при загрузке"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "Задержка перед началом проверки необходимости снижения качества"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Запустить службу"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Сначала запустите службу, чтобы сгенерировать начальный ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Сначала запустите службу, чтобы сгенерировать начальный ключ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"Запуск сработает только если ниже установлен флажок «Включить ID-сервер» или "
+"«Включить сервер ретрансляции»."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Остановить"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Остановлен"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "TOTAL_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Это приведёт к пересозданию пары ключей и перезапуску службы."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "Порог, при котором сервер начнёт снижать качество"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "Общее ограничение пропускной способности в МБ/с (0 = по умолчанию)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Трассировка"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "Буфер приёма UDP (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "URL-адрес должен начинаться с http:// или https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Предупреждение"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Да"

--- a/applications/luci-app-rustdesk-server/po/uk/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/uk/rustdesk-server.po
@@ -1,0 +1,494 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-21 05:04+0000\n"
+"Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsrustdesk-server/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ALWAYS_USE_RELAY"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"Додаткові Rendezvous-сервери. Додавайте по одному серверу на запис (hostname "
+"або hostname:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "Усі наявні клієнти доведеться переналаштувати."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr "Обмеження пропускної здатності на одне підключення в МБ/с (0 = типово)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "Двійковий файл"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "Неможливо перегенерувати: відкритого ключа ще не існує."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr ""
+"Неможливо запустити службу: спочатку увімкніть ID-сервер або Реле-сервер у "
+"конфігурації."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr ""
+"Позначте «Увімкнути ID-сервер» або «Увімкнути Реле-сервер» нижче та "
+"натисніть «Зберегти і застосувати»."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "Клієнт"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "Компонент"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "Конфігурація"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "Налаштуйте у Мережа → Брандмауер → Правила трафіку."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "Продовжити?"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "Копіювати"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "Налагодження"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "Типово"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr ""
+"Типові реле-сервери. Додавайте по одному серверу на запис (hostname або "
+"hostname:port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr ""
+"Визначає, чи підключення надходить із LAN. Використовуйте нотацію CIDR."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "Вимкнути"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "Увімкнути"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "Спочатку увімкніть ID-сервер або Реле-сервер"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "Спочатку увімкніть ID-сервер або Реле-сервер у Конфігурації"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "Помилка"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "Помилка:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "Не вдалося перезапустити службу:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "Не вдалося запустити службу:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "Не вдалося зупинити службу:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "Не вдалося:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "Потрібне налаштування брандмауера"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "Примушувати всі підключення використовувати реле-сервери"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "Знайдено"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "Загальне"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "Надати доступ до конфігурації RustDesk Server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (Реле-сервер)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID-сервер)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID-сервер (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "Інформація"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "Виявлено недійсні символи"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "Недійсні символи."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "Ключ (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "Не вдалося перегенерувати ключ:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "Ключі видалено. Запуск служби для генерації нових ключів…"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "Маска LAN (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "LIMIT_SPEED"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "Завантаження…"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "Журнал"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "Рівень журналу для ID-сервера"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "Рівень журналу для реле-сервера"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "Ні"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "Не знайдено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "Ще не згенеровано — запустіть службу"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+"Дозволяти лише клієнтів з тим самим ключем. Якщо порожнє, використовується "
+"автоматично згенерований ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "Дозволено лише алфавітно-цифрові та base64-символи (+/=)."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "Порт (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "Обробка…"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "Відкритий ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "Перегенерувати ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "Перегенерувати пару ключів (потрібен наявний ключ)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "Перегенерувати пару ключів (службу буде перезапущено)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "Перегенерація…"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "Реле-сервер (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "Реле-сервери (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "Конфігурація сервера програми віддаленого керування робочим столом."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "Rendezvous-сервери (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr "Необхідні порти (за типових налаштувань): TCP 21115-21119, UDP 21116."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "Перезапустити"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "Запущено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "RustDesk Server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "Журнал RustDesk Server"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "SINGLE_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "Серійний номер (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "Сервер"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "Керування службою"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "Стан служби"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "Службу вимкнено при завантаженні"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "Службу увімкнено при завантаженні"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr "Запуск служби міг не вдатися. Перевірте стан вище."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "Службу запущено з новим ключем"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "Встановлює розмір буфера прийому UDP (0 = системне типове значення)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "Встановлює серійний номер оновлення конфігурації"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "Встановлює URL для завантаження ПЗ RustDesk для клієнтів"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "Встановлює порт прослуховування для ID/Rendezvous-сервера"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "Встановлює порт прослуховування для реле-сервера"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "URL для завантаження ПЗ (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "Обмеження швидкості на одне підключення в Мбіт/с (0 = типово)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "Почати"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "Запускати при завантаженні"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "Час початку перевірки для зниження якості підключення"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "Запустити службу"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "Спочатку запустіть службу, щоб згенерувати початковий ключ"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "Спочатку запустіть службу, щоб згенерувати початковий ключ."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"Запуск спрацює лише якщо у розділі «Конфігурація» нижче позначено принаймні "
+"«Увімкнути ID-сервер» або «Увімкнути Реле-сервер»."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "Зупинити"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "Зупинено"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "TOTAL_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "Це перегенерує пару ключів та перезапустить службу."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "Поріг для зниження якості підключення"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "Загальне обмеження пропускної здатності в МБ/с (0 = типово)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "Трасування"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "Буфер прийому UDP (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "URL має починатися з http:// або https://"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "Попередження"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "Так"

--- a/applications/luci-app-rustdesk-server/po/zh_Hans/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/zh_Hans/rustdesk-server.po
@@ -1,0 +1,483 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-05 19:01+0000\n"
+"Last-Translator: 大王叫我来巡山 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsrustdesk-server/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "始终使用中继"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr "额外的交会服务器。每行输入一个服务器（主机名或主机名:端口）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "所有现有客户端都需要重新配置。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr "单条连接的带宽限制，单位 MB/s（0 为默认）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "可执行文件"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr "无法重新生成：尚不存在公钥。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr "无法启动服务：请先在配置中启用 ID 服务器或中继服务器。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr "勾选下方的“启用 ID 服务器”或“启用中继服务器”，然后点击“保存并应用”。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "客户端"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "组件"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "配置"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "请在“网络 → 防火墙 → 通信规则”中进行配置。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "确认继续？"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "复制"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "降级检测启动时间"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "降级阈值"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "调试"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "默认"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr "默认中继服务器。每行输入一个服务器（主机名或主机名:端口）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "判断连接是否来自局域网。使用 CIDR 格式（如 192.168.1.0/24）。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "禁用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "已禁用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "启用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "请先启用 ID 服务器或中继服务器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "请先在“配置”中启用 ID 服务器或中继服务器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "已启用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "错误"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "错误："
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "重启服务失败："
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "启动服务失败："
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "停止服务失败："
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr "失败："
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "需要配置防火墙"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "强制所有连接使用中继服务器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "已找到"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "常规"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "授予 RustDesk 服务器配置的访问权限"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (中继服务器)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID/注册服务器)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID 服务器 (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "信息"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "检测到无效字符"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "无效字符。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "秘钥 (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "重新生成秘钥失败："
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "秘钥已删除。正在启动服务以生成新秘钥..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "局域网掩码 (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "限速"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "正在加载..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "日志"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "ID 服务器的日志级别"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "中继服务器的日志级别"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "不"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "未找到"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr "尚未生成 - 请先启动服务"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr "仅允许拥有相同秘钥的客户端。如果为空，则使用自动生成的秘钥"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr "仅允许字母数字和 base64 字符 (+/=)。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "端口 (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "正在处理..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "公钥"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "Rust 日志级别 (RUST_LOG)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "重新生成秘钥"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr "重新生成密钥对（需要现有的秘钥）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "重新生成密钥对（将重启服务）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "正在重新生成..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "中继服务器 (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "中继服务器 (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "远程桌面软件服务器配置。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "交会服务器 (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr "所需端口（使用默认设置时）：TCP 21115-21119, UDP 21116。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "重启"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "运行中"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "RustDesk 服务器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "RustDesk 服务器日志"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "单连接带宽"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "序列号 (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "服务器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "服务控制"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "服务状态"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr "服务已禁用开机自启"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr "服务已开启开机自启"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr "服务启动可能失败。请检查上方状态。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr "服务已随新秘钥启动"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "设置 UDP 接收缓冲区大小（0 为系统默认）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr "设置配置更新序列号"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "设置客户端 RustDesk 软件的下载 URL"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr "设置 ID/交会服务器的监听端口"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "设置中继服务器的监听端口"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "软件下载 URL (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr "每个连接的限速，单位 Mb/s（0 为默认）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "启动"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "开机自启"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr "连接降级的启动检查时间"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "启动服务"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "请先启动服务以生成初始秘钥"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "请先启动服务以生成初始秘钥。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+"只有在下方“配置”部分至少勾选了“启用 ID 服务器”或“启用中继服务器”时，启动操作"
+"才会生效。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "停止"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "已停止"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "总带宽"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr "这将重新生成密钥对并重启服务。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "连接降级的阈值"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr "总带宽限制，单位 MB/s（0 为默认）"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "追踪"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "UDP 接收缓冲区 (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "URL 必须以 http:// 或 https:// 开头"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "警告"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "是"

--- a/applications/luci-app-rustdesk-server/po/zh_Hant/rustdesk-server.po
+++ b/applications/luci-app-rustdesk-server/po/zh_Hant/rustdesk-server.po
@@ -1,0 +1,481 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-20 17:02+0000\n"
+"Last-Translator: 為什麼不加空格 <c++23@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsrustdesk-server/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:541
+msgid "ALWAYS_USE_RELAY"
+msgstr "ALWAYS_USE_RELAY"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:518
+msgid ""
+"Additional rendezvous servers. Add one server per entry (hostname or "
+"hostname:port)"
+msgstr ""
+"額外會合伺服器。每個條目新增一個伺服器 (「主機名稱」或「主機名稱:連接埠」)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "All existing clients will need to be reconfigured."
+msgstr "所有現存用戶端都將需要被重新配置。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:586
+msgid "Bandwidth limit per single connection in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:190
+msgid "Binary"
+msgstr "二進位"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Cannot regenerate: No public key exists yet."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Cannot start service: Enable the ID Server or Relay Server in the "
+"configuration first."
+msgstr "無法啟動服務: 請先在配置中啟用 ID 伺服器或中繼伺服器。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:315
+msgid ""
+"Check \"Enable ID Server\" or \"Enable Relay Server\" below and click \"Save "
+"& Apply\"."
+msgstr "檢查下方的「啟用 ID 伺服器」或「啟用中繼伺服器」並點選「儲存並套用」。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:165
+msgid "Client"
+msgstr "用戶端"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:188
+msgid "Component"
+msgstr "組件"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:493
+msgid "Configuration"
+msgstr "配置"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:174
+msgid "Configure in Network → Firewall → Traffic Rules."
+msgstr "在網路 → 防火牆 → 流量規則中配置。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "Continue?"
+msgstr "繼續？"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:449
+msgid "Copy"
+msgstr "複製"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:598
+msgid "DOWNGRADE_START_CHECK"
+msgstr "DOWNGRADE_START_CHECK"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:594
+msgid "DOWNGRADE_THRESHOLD"
+msgstr "DOWNGRADE_THRESHOLD"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:551
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:575
+msgid "Debug"
+msgstr "除錯"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:547
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:571
+msgid "Default"
+msgstr "預設"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:514
+msgid ""
+"Default relay servers. Add one server per entry (hostname or hostname:port)"
+msgstr "預設中繼伺服器。每個條目新增一個伺服器 (主機名稱 或 主機名稱:連接埠)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:522
+msgid "Determine if the connection comes from LAN. Use CIDR notation."
+msgstr "確定連線是否來自 LAN。使用 CIDR 表示法。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+msgid "Disable"
+msgstr "停用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Disabled"
+msgstr "已停用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:292
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:485
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:501
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:556
+msgid "Enable"
+msgstr "啟用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:312
+msgid "Enable ID Server or Relay Server first"
+msgstr "請先啟用 ID 伺服器或中繼伺服器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:471
+msgid "Enable ID Server or Relay Server in Configuration first"
+msgstr "請先在配置中啟用 ID 伺服器或中繼伺服器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:191
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:295
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:482
+msgid "Enabled"
+msgstr "已啟用"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:548
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:572
+msgid "Error"
+msgstr "錯誤"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:248
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:286
+msgid "Error:"
+msgstr "錯誤:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:349
+msgid "Failed to restart service:"
+msgstr "無法重啟服務:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:323
+msgid "Failed to start service:"
+msgstr "無法啟動服務:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:336
+msgid "Failed to stop service:"
+msgstr "無法停止服務:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:283
+msgid "Failed:"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:172
+msgid "Firewall Configuration Required"
+msgstr "需要防火牆配置"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:542
+msgid "Force all connections to use relay servers"
+msgstr "強制所有連線使用中繼伺服器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Found"
+msgstr "已找到"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:18
+msgid "General"
+msgstr "一般"
+
+#: applications/luci-app-rustdesk-server/root/usr/share/rpcd/acl.d/luci-app-rustdesk-server.json:3
+msgid "Grant access to RustDesk Server configuration"
+msgstr "授予存取 RustDesk 伺服器配置的權限"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:200
+msgid "HBBR (Relay Server)"
+msgstr "HBBR (中繼伺服器)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:194
+msgid "HBBS (ID Server)"
+msgstr "HBBS (ID 伺服器)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:497
+msgid "ID Server (hbbs)"
+msgstr "ID 伺服器 (hbbs)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:550
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:574
+msgid "Info"
+msgstr "資訊"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:80
+msgid "Invalid characters detected"
+msgstr "偵測到無效字元"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Invalid characters."
+msgstr "無效字元。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:509
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:564
+msgid "Key (-k, --key)"
+msgstr "金鑰 (-k, --key)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:237
+msgid "Key regeneration failed:"
+msgstr "金鑰重新產生失敗:"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:230
+msgid "Keys deleted. Starting service to generate new keys..."
+msgstr "金鑰已刪除。啟動服務以產生新金鑰..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:521
+msgid "LAN Mask (--mask)"
+msgstr "LAN 遮罩 (--mask)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:579
+msgid "LIMIT_SPEED"
+msgstr "LIMIT_SPEED"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:299
+msgid "Loading..."
+msgstr "載入中..."
+
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:26
+msgid "Log"
+msgstr "紀錄"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:546
+msgid "Logging level for the ID server"
+msgstr "ID 伺服器記錄等級"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:570
+msgid "Logging level for the relay server"
+msgstr "中繼伺服器記錄等級"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "No"
+msgstr "否"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:405
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:430
+msgid "Not Found"
+msgstr "未找到"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:451
+msgid "Not generated yet - start the service"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:510
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:565
+msgid "Only allow clients with the same key. If empty, uses auto-generated key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:94
+msgid "Only alphanumeric and base64 characters (+/=) allowed."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:504
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:559
+msgid "Port (-p, --port)"
+msgstr "連接埠 (-p, --port)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:273
+msgid "Processing..."
+msgstr "處理中..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:209
+msgid "Public Key"
+msgstr "公鑰"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:545
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:569
+msgid "RUST_LOG"
+msgstr "RUST_LOG"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:254
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:258
+msgid "Regenerate Key"
+msgstr "重新產生金鑰"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:216
+msgid "Regenerate the key pair (requires existing key)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:461
+msgid "Regenerate the key pair (will restart service)"
+msgstr "重新產生金鑰對 (將會重新啟動服務)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:226
+msgid "Regenerating..."
+msgstr "重新產生中..."
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:498
+msgid "Relay Server (hbbr)"
+msgstr "中繼伺服器 (hbbr)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:513
+msgid "Relay Servers (-r, --relay-servers)"
+msgstr "中繼伺服器 (-r, --relay-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:163
+msgid "Remote Desktop Software Server configuration."
+msgstr "遠端桌面軟體伺服器配置。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:517
+msgid "Rendezvous Servers (-R, --rendezvous-servers)"
+msgstr "會合伺服器 (-R, --rendezvous-servers)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:173
+msgid ""
+"Required ports (when using default settings): TCP 21115-21119, UDP 21116."
+msgstr "需要的連接埠 (使用預設設定時): TCP 21115-21119、UDP 21116。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:353
+msgid "Restart"
+msgstr "重新啟動"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Running"
+msgstr "執行中"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:162
+#: applications/luci-app-rustdesk-server/root/usr/share/luci/menu.d/luci-app-rustdesk-server.json:3
+msgid "RustDesk Server"
+msgstr "RustDesk 伺服器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/logs.js:4
+msgid "RustDesk Server Log"
+msgstr "RustDesk 伺服器紀錄"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:584
+msgid "SINGLE_BANDWIDTH"
+msgstr "SINGLE_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:531
+msgid "Serial Number (-s, --serial)"
+msgstr "序號 (-s, --serial)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:164
+msgid "Server"
+msgstr "伺服器"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:305
+msgid "Service Control"
+msgstr "服務控制"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:183
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:189
+msgid "Service Status"
+msgstr "服務狀態"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service disabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:279
+msgid "Service enabled at boot"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:244
+msgid "Service start may have failed. Check status above."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:242
+msgid "Service started with new key"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:529
+msgid "Sets UDP receive buffer size (0 = system default)"
+msgstr "設定 UDP 接收緩衝區大小 (0 = 系統預設)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:534
+msgid "Sets configure update serial number"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:537
+msgid "Sets the download URL of RustDesk software for clients"
+msgstr "設定用戶端下載 RustDesk 軟體的 URL"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:507
+msgid "Sets the listening port for the ID/Rendezvous server"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:562
+msgid "Sets the listening port for the relay server"
+msgstr "設定中繼伺服器的監聽連接埠"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:536
+msgid "Software Download URL (-u, --software-url)"
+msgstr "軟體下載 URL (-u, --software-url)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:581
+msgid "Speed limit per connection in Mb/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:327
+msgid "Start"
+msgstr "啟動"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:264
+msgid "Start at Boot"
+msgstr "跟著系統啟動"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:600
+msgid "Start check time for connection downgrade"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:473
+msgid "Start the service"
+msgstr "啟動服務"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:459
+msgid "Start the service first to generate the initial key"
+msgstr "請先啟動服務以產生初始金鑰"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:219
+msgid "Start the service first to generate the initial key."
+msgstr "請先啟動服務以產生初始金鑰。"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:361
+msgid ""
+"Start will only work if at least \"Enable ID Server\" or \"Enable Relay "
+"Server\" is checked in the Configuration section below."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:340
+msgid "Stop"
+msgstr "停止"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:398
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:423
+msgid "Stopped"
+msgstr "已停止"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:589
+msgid "TOTAL_BANDWIDTH"
+msgstr "TOTAL_BANDWIDTH"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:222
+msgid "This will regenerate the key pair and restart the service."
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:596
+msgid "Threshold for connection downgrade"
+msgstr "連線降級閾值"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:591
+msgid "Total bandwidth limit in MB/s (0 = default)"
+msgstr ""
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:552
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:576
+msgid "Trace"
+msgstr "追溯"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:526
+msgid "UDP Recv Buffer (-M, --rmem)"
+msgstr "UDP 接收緩衝區 (-M, --rmem)"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:111
+msgid "URL must start with http:// or https://"
+msgstr "URL 必須以 http:// 或 https:// 作為開頭"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:549
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:573
+msgid "Warning"
+msgstr "警告"
+
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:411
+#: applications/luci-app-rustdesk-server/htdocs/luci-static/resources/view/rustdesk-server/general.js:436
+msgid "Yes"
+msgstr "是"

--- a/applications/luci-app-softether/po/cs/softether.po
+++ b/applications/luci-app-softether/po/cs/softether.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-07 11:16+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Udělit přístup ke správě softether"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Načítání informací o účtu…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Nenastaven žádný VPN účet."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "Stav softether"

--- a/applications/luci-app-softether/po/de/softether.po
+++ b/applications/luci-app-softether/po/de/softether.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-02 19:29+0000\n"
+"Last-Translator: ssantos <ssantos@web.de>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/de/>\n"
+"Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Zugriff auf Verwaltung von softether gewähren"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Kontoinformationen laden…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Kein VPN-Konto konfiguriert."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "SoftEther-Zustand"

--- a/applications/luci-app-softether/po/es/softether.po
+++ b/applications/luci-app-softether/po/es/softether.po
@@ -1,0 +1,31 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Conceder acceso a la gestión de Softether"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Cargando información de la cuenta…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "No hay ninguna cuenta VPN configurada."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "Estado de SoftEther"

--- a/applications/luci-app-softether/po/ga/softether.po
+++ b/applications/luci-app-softether/po/ga/softether.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-23 10:15+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Deonaigh rochtain ar bhainistíocht softether"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Ag lódáil faisnéis chuntais…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Níl aon chuntas VPN cumraithe."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "Stádas SoftEther"

--- a/applications/luci-app-softether/po/ko/softether.po
+++ b/applications/luci-app-softether/po/ko/softether.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 12:32+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "softether 관리에 접근 권한 부여"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "계정 정보를 불러오는 중…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "설정된 VPN 계정이 없습니다."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "SoftEther 상태"

--- a/applications/luci-app-softether/po/lo/softether.po
+++ b/applications/luci-app-softether/po/lo/softether.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "ອະນຸຍາດໃຫ້ເຂົ້າເຖິງການຈັດການ SoftEther"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "ກຳລັງໂຫຼດຂໍ້ມູນບັນຊີ…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "ບໍ່ມີການຕັ້ງຄ່າບັນຊີ VPN."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "ສະຖານະ SoftEther"

--- a/applications/luci-app-softether/po/lt/softether.po
+++ b/applications/luci-app-softether/po/lt/softether.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-03-03 18:00+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Suteikti prieigą prie „softether“ valdymo"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Kraunama paskyros informaciją…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Nėra konfigūruotos „VPN“ paskyros."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "„SoftEther“ būklę/būseną"

--- a/applications/luci-app-softether/po/lv/softether.po
+++ b/applications/luci-app-softether/po/lv/softether.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-12 16:46+0000\n"
+"Last-Translator: \"ℂ𝕠𝕠𝕠𝕝 (𝕘𝕚𝕥𝕙𝕦𝕓.𝕔𝕠𝕞/ℂ𝕠𝕠𝕠𝕝)\" <coool@mail.lv>\n"
+"Language-Team: Latvian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/lv/>\n"
+"Language: lv\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= "
+"19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Piešķirt piekļuvi SoftEther pārvaldībai"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Ielādē konta informāciju…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Nav konfigurēts neviens VPN konts."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "SoftEther statuss"

--- a/applications/luci-app-softether/po/pl/softether.po
+++ b/applications/luci-app-softether/po/pl/softether.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-02-25 15:43+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Przyznaj dostęp do zarządzania SoftEther"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Ładowanie informacji o koncie…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Nie skonfigurowano konta VPN."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "Status SoftEther"

--- a/applications/luci-app-softether/po/ru/softether.po
+++ b/applications/luci-app-softether/po/ru/softether.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-24 00:23+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Предоставить доступ к управлению SoftEther"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Загрузка информации об учётной записи…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Учётная запись VPN не настроена."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "Статус SoftEther"

--- a/applications/luci-app-softether/po/templates/softether.pot
+++ b/applications/luci-app-softether/po/templates/softether.pot
@@ -1,0 +1,19 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr ""
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr ""
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr ""
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr ""

--- a/applications/luci-app-softether/po/uk/softether.po
+++ b/applications/luci-app-softether/po/uk/softether.po
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-15 10:43+0000\n"
+"Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationssoftether/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5.dev0\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "Надати доступ до керування SoftEther"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "Завантаження інформації про обліковий запис…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "Обліковий запис VPN не налаштовано."
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "Стан SoftEther"

--- a/applications/luci-app-softether/po/zh_Hans/softether.po
+++ b/applications/luci-app-softether/po/zh_Hans/softether.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-04 04:16+0000\n"
+"Last-Translator: konno_he <h3114931694@gmail.com>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationssoftether/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "授予softether访问权限"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "正在加载账号信息…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "没有 VPN 账户配置信息。"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "SoftEther 状态"

--- a/applications/luci-app-softether/po/zh_Hant/softether.po
+++ b/applications/luci-app-softether/po/zh_Hant/softether.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-16 07:27+0000\n"
+"Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationssoftether/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-softether/root/usr/share/rpcd/acl.d/luci-app-softether.json:3
+msgid "Grant access to softether management"
+msgstr "授予存取 softether 管理的權限"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:108
+msgid "Loading account information…"
+msgstr "載入帳號資訊中…"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:109
+msgid "No VPN account configured."
+msgstr "無 VPN 帳號被配置。"
+
+#: applications/luci-app-softether/htdocs/luci-static/resources/view/softether-status.js:102
+#: applications/luci-app-softether/root/usr/share/luci/menu.d/luci-app-softether.json:3
+msgid "SoftEther Status"
+msgstr "SoftEther 狀態"

--- a/applications/luci-app-strongswan-swanctl/po/cs/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/cs/strongswan-swanctl.po
@@ -1,0 +1,645 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-07-01 20:06+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/cs/>\n"
+"Language: cs\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Akce při počátečním načtení nastavení"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Akce při zavření CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Akce pokud nastane překročení časového limitu DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "Aktivní IKE_SAs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Algoritmy označené znakem * (hvězdička) jsou považovány za nebezpečné"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Ověřování se"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Metoda ověřování se"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Bajtů do"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Bajtů ven"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "Certifikát cert. autority"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"Certifikát cert. autority které potřebuje lhát v řetězci důvěry certifikátu "
+"na vzdáleném protějšku"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SAs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "Popis umístění certifikátu který použít pro ověřování se"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Zavřít"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Akce zavřít"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "Nastavení je zapnuté nebo ne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Nastavit sadu šifer pro definování návrhů IKE (fáze 1) nebo ESP (fáze 2)."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Nastavit strongSwan pro zabezpečená VPN spojení."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Návrh šifrování"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Návrh šifrování (fáze 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "DPD akce"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "DPD prodleva"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Proces služby"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "Den"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "Dnů"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Stupeň podrobnosti ladících informací"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+"Definovat podřízené spojení které použít jako tunely ve vzdáleném nastavení."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Definovat nastavení vzdáleného IKE."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "Podrobnosti"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Diffie-Hellman skupina"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "Doba trvání CHILD_SA před znovuopatřením klíči"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "ESP návrh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Povolit předávání zpracovávání do hardware"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Povolit ipcomp compresi"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Povoleno"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Šifrovací algoritmus"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Délka šifrovacího klíče"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Návrhy šifrování"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Navázáno pro"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "Zóna brány firewall u které je třeba shoda s definovanou zónou"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Brána (vzdálený koncový bod)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "Obecné"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Obecná nastavení"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Udělit přístup k luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Předávání na hardware"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "Polootevřená IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "Algoritmus vytváření otisků"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "Hodina"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "Hodiny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "IKE fragmentace"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "Verze IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "IKE ověřování se (fáze 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"IKEv2 interval pro obnovení materiálu klíčů (také použito pro spočítání "
+"životnosti)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "IP adresa nebo FQDN název vzdáleného koncového bodu tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "IP adresa nebo FQDN lokálního koncového bodu tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Neaktivita"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Čas instalace"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Rozhraní která dovolují VPN provoz"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Interval před zavřením neaktivního CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Interval pro kontrolu toho, zda je protějšek aktivní"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Výměna klíčů"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Opakovaných pokusů o opatření klíči"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Životnost"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Životnost"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "Omezit dobu pro úplné znovuopatření klíči / opětovné ověření se"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"Seznam ESP (fáze dva) návrhů. Vybrat je možné pouze návrhy, u kterých je "
+"zaškrtnutý příznak ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "Seznam IKE (fáze 1) návrhů které použít pro ověření se"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Rozhraní na kterých očekávat spojení"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Lokální certifikát"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Lokální brána"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "Lokální IP adresa"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Lokální identifikátor"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Lokální klíč"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "Lokální NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "Lokální zdrojová IP adresa"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Lokální podsíť"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Výběry lokálního provozu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Lokální adresa/adresy které použít při IKE vyjednávání"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Lokální identifikátor pro IKE (fáze 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Lokální síť(e)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Nejdelší doba trvání CHILD_SA před zavřením"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "Minuta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "Minuty"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Režim"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "NAT rozsah pro tunely s překrývajícími se IP adresami"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Název"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "Délka názvu by neměla překročit 15 znaků"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "Je třeba, aby číslo mělo příponu s, m, h nebo d"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Počet pokusů o opakované přenosy při úvodním vyjednávání"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Přesčas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "PRF algoritmus"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"Při používání algoritmu ověřeného se šifrování je třeba, aby byl nastavený "
+"PRF algoritmus"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+"Popis umístění skriptu který spouštět při událostech CHILD_SA nahoře/dole"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Nejprve vytvořte návrh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "Nejprve vytvořte tunel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Nejprve vytvořte ESP návrh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Předsdílený klíč"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Priorita"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Priorita CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+"Popis umístění soukromého klíče který použít společně s výše uvedeným "
+"certifikátem"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Protokol"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "Dotazování se strongSwan se nezdařilo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Znovuověření se za"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Čas znovuopatření klíči"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Znovuopatření klíči za"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Vzdálené"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Nastavení vzdáleného"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Vzdálený identifikátor"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Vzdálená podsíť"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Výběry vzdáleného provozu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Vzdálený identifikátor pro IKE (fáze 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Vzdálené sítě"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr "Vzdálené, návrhy šifrování a tunely nemohou být nazvány stejně."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Okno opětovného použití"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Okno opětovného použití pro CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "SPI dovnitř"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "SPI ven"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "Sekund"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "Sekund"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Asociace zabezpečení (SA)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "Vyberte rozhraní nebo nevyplňujte (pokud pro všechna)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Zobrazit podrobnosti"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Spustit akci"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Stav"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Statistiky"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "Tunel obsahující ESP sekci (fáze 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "Předsdílený klíč pro tunel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "Stupeň trace: 0 pro nejmenší výřečnost, 4 pro největší"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "Tunel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "Nastavení tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Popis umístění skriptu pro nahoře/dole"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Doba chodu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Použít IKE fragmentaci"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+"Použijte kombinace jako například tunel_faze1, které nejsou delší než 15 "
+"znaků."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "Hodnoty vyšší než 32 jsou podporovány pouze podpůrnou vrstvou Netlink"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Verze"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "Verze IKE pro vyjednání"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr "Virtuální IP adresa/adresy které vyžádat v požadavcích IKEv2 nastavení"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Zda toto je ESP návrh (fáze 2) nebo ne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+"Nastavit identifikátor XFRM rozhraní na vstupních a výstupních rozhraních"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Zóna"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "obojí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "zastaralé"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "Nastavení pro strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "Stav strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/de/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/de/strongswan-swanctl.po
@@ -1,0 +1,629 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-22 19:35+0000\n"
+"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/de/>\n"
+"Language: de\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Version"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Zone"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "beide"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "veraltet"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "strongSwan-Konfiguration"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "strongSwan-Status"

--- a/applications/luci-app-strongswan-swanctl/po/es/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/es/strongswan-swanctl.po
@@ -1,0 +1,650 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Acción en carga de configuración inicial"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Acción cuando CHILD_SA está cerrado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Acción al suceder vencimiento DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "IKE_SA activo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Algoritmo marcado con * es considerado inseguro"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Autenticación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Método de Autenticación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Bytes en"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Bytes salientes"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "Certificado AC"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"Certificado de CA que debe estar en la ruta de confianza del certificado de "
+"par remoto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SAs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "Nombre de ruta del certificado que se utiliza para autenticación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Cerrar"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Cerrar acción"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "Si está activada o no la configuración"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Configure Suites de Cifrado para definir Propuestas IKE (Fase 1) o ESP (Fase "
+"2)."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Configure strongSwan para conexión VPN segura."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Cripto propuesta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Cripto propuesta (Fase 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "Acción DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "Retraso DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Demonio"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "Día"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "Días"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Nivel de depuración"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+"Define los elementos de conexión que se utilizarán como túneles en "
+"configuraciones remotas."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Definir configuraciones IKE remotas."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "Detalles"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Grupo Diffie-Hellman"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "Duración de la CHILD_SA antes de re-introducción de claves"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "Propuesta ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Activar descarga de hardware"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Activar compresión ipcomp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Activado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Algoritmo de cifrado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Tamaño de clave de cifrado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Propuestas de cifrado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Establecido para"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+"Zona cortafuego que tiene que coincidir con la zona de cortafuego definida"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Puerta de enlace (Punto final remoto)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "General"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Ajustes generales"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Conceder acceso a luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Descargar A/L"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "IKE_SAs Medio-Abierta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "Algoritmo Hash"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "Hora"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "Horas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "Fragmentación IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "Versión IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "Autenticación IKE (fase 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"Intervalo IKEv2 para refrescar material de anillo; además utilizado para "
+"calcular tiempo de vida"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "Dirección IP o nombre FQDN del túnel de punto final remoto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "Dirección IP o FQDN del punto final de túnel local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Inactividad"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Tiempo de instalación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Interfaces que aceptan tráfico VPN"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Intervalo antes de cerrar un CHILD_SA inactivo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Intervalo para comprobar la vida de un par"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Keyexchange"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Reintentos de anillo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Tiempo de vida"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Vida"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "Límite en tiempo para completar re-clave/re-autenticación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"Listado de propuestas ESP (fase dos). Solo Propuestas con indicador de ESP "
+"marcado son seleccionables"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "Listado de propuestas IKE (fase 1) para utilizar para autenticación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Listado de interfaces"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Certificado local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Puerta de enlace local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "IP local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Identificador local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Clave Local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "NAT local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "IP de origen local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Subred local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Selectores de tráfico local"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Dirección(es) local(es) para utilizar en negociación IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Identificador local para IKE (fase 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Red(es) local(es)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (Protocolo IKEv2 de Movilidad y Multihogar)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Duración máxima del CHILD_SA antes de cerrar"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "Minuto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "Minutos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Modo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "Intervalo de NAT para túneles con sobrecarga de direcciones IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Nombre"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "La longitud del nombre no debe exceder los 15 caracteres"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "El número debe tener sufijo s, m, h o d"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Número de retransmisiones intentadas durante negociación inicial"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Fuera de hora"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "Algoritmo PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"Algoritmo PRF debe ser configurado cuando utilice un Algoritmo de cifrado "
+"autenticado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr "Ruta para script a ejecutar en CHILD_SA para subir/bajar eventos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Cree primero una propuesta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "Cree un túnel primero"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Cree primero una propuesta ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Clave pre-compartida"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Prioridad"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Prioridad del CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "Nombre de ruta de clave privada a utilizar con certificado de arriba"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "La consulta a strongSwan falló"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Reautenticación en"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Tiempo de re-clave"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Re-clave en"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Remoto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Configuración remota"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Identificador remoto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Subred remota"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Selectores de tráfico remoto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Identificador remoto para IKE (fase 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Red(es) remota(s)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+"Remotos, Propuestas de cifrado y Túneles pueden no compartir los mismos "
+"nombres."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Ventana de reproducción"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Ventana de reproducción del CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "Entrada SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "Salida SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "Segundo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "Segundos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Asociaciones de seguridad (AS)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "Seleccione un interfaz o déjelo vacío para todos los interfaces"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Mostrar detalles"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Iniciar acción"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Estado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Estados"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "El túnel conteniendo la sección del ESP (fase 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "La clave pre-compartida para el túnel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "Nivel de seguimiento: 0 es el de menor detallado, 5 es el de más"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "Túnel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "Configuración del túnel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Subir/Bajar ruta de script"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Tiempo de actividad"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Utiliza fragmentación de IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr "Utiliza combinaciones como tunnel1_phase1 que no supere 15 caracteres."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr ""
+"Valores más grandes que 32 están admitidos solo por el backend de Netlink"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Versión"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "Versión de IKE para negociación"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+"IP(s) virtual(es) para solicitar en configuración de cargas IKEv2 útiles "
+"solicitadas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Si esto es un ESP (fase 2) propuesto o no"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr "ID de interfaz XFRM fijado sobre interfaces de entrada y salida"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Zona"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "ambos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "obsoleto"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "Configuración de strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "IPSec de strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "Estado de strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/ga/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ga/strongswan-swanctl.po
@@ -1,0 +1,643 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/ga/>\n"
+"Language: ga\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=5; plural=n==1 ? 0 : n==2 ? 1 : (n>2 && n<7) ? 2 :"
+"(n>6 && n<11) ? 3 : 4;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Gníomh ar an ualach cumraíochta tosaigh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Gníomh nuair a bhíonn CHILD_SA dúnta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Gníomh nuair a tharlaíonn teorainn ama DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "IKE_SAanna gníomhacha"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Ardleibhéil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Meastar go bhfuil halgartaim atá marcáilte le * neamhshábháilte"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Fíordheimhniú"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Modh Fíordheimhnithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Bearta isteach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Bearta amach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "Teastas CA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"Teastas CA a chaithfidh a bheith i gcosán muiníne deimhnithe piaraí iargúlta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SAs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "Ainm cosáin an deimhnithe le húsáid le haghaidh fíordheimhnithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Dún"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Dún Gníomh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "An bhfuil an chumraíocht cumasaithe nó nach bhfuil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Cumraigh Sraith Cipher chun Tograí IKE (Céim 1) nó ESP (Céim 2) a shainiú."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Cumraigh strongSwan le haghaidh naisc VPN slána."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Togra Cripte"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Togra Cripte (Céim 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "Gníomh DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "Moill DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Daemon"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "Lá"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "Laethanta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Leibhéal Dífhabhtaithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr "Sainmhínigh Leanaí Nasc le húsáid mar Tholláin i gCumraíochtaí Cianda."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Sainmhínigh Cumraíochtaí IKE Cianda."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "Sonraí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Grúpa Diffie-Hellman"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "Fad an CHILD_SA roimh ath-eochrú"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "Togra ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Cumasaigh díluchtú crua-earraí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Cumasaigh comhbhrú ipcomp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Cumasaithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Algartam Criptithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Méid Eochrach Criptithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Tograí Criptithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Bunaithe do"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+"Crios balla dóiteáin a chaithfidh a bheith mar an gcéanna leis an gcrios "
+"balla dóiteáin atá sainithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Geata (Críochphointe Iargúlta)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "Ginearálta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Socruithe Ginearálta"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Deonaigh rochtain ar luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Díluchtú Crua-earraí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "IKE_SAanna Leath-Oscailte"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "Algartam Hais"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "Uair an chloig"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "Uaireanta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "Ilroinnt IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "Leagan IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "Fíordheimhniú IKE (céim 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"Eatramh IKEv2 chun ábhar eochrach a athnuachan; úsáidtear é freisin chun "
+"saolré a ríomh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "Seoladh IP nó ainm FQDN chríochphointe iargúlta an tolláin"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "Seoladh IP nó FQDN chríochphointe áitiúil an tolláin"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Neamhghníomhaíocht"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Am Suiteála"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Comhéadain a ghlacann le trácht VPN"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Eatramh roimh dhúnadh CHILD_SA neamhghníomhach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Eatramh chun beochan piara a sheiceáil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Malartú Eochrach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Ath-Iarrachtaí Eochracha"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Am Saoil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Saolré"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "Teorainn ama chun ath-eochrú/athfhíordheimhniú a chríochnú"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"Liosta de thograí ESP (céim a dó). Ní féidir ach tograí a roghnú a bhfuil "
+"bratach ESP ticáilte orthu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "Liosta de mholtaí IKE (céim 1) le húsáid le haghaidh fíordheimhnithe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Comhéadain Éisteachta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Teastas Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Geata Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "IP Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Aitheantóir Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Eochair Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "NAT Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "IP Foinse Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Fo-líonra Áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Roghnóirí Tráchta Áitiúla"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Seoladh(anna) áitiúil le húsáid in idirbheartaíocht IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Aitheantóir áitiúil le haghaidh IKE (céim 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Líonra(í) áitiúil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (Prótacal Soghluaisteachta agus Il-Tíre IKEv2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Uasfhad an CHILD_SA roimh dhúnadh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "Nóiméad"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "Nóiméid"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Mód"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "Raon NAT do tholláin le seoltaí IP forluiteacha"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Ainm"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "Ní fhéadfaidh fad an ainm a bheith níos mó ná 15 charachtar"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "Ní mór iarmhír s, m, h nó d a bheith ag an uimhir"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Líon na n-iarrachtaí athchraolta le linn na caibidlíochta tosaigh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Am breise"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "Algartam PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"Ní mór Algartam PRF a chumrú agus Algartam Criptithe Fíordheimhnithe á úsáid"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr "Cosán chuig an script le rith ar imeachtaí suas/síos CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Cruthaigh Togra ar dtús le do thoil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "Cruthaigh Tollán ar dtús le do thoil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Cruthaigh Togra ESP ar dtús le do thoil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Eochair Réamh-Roinnte"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Tosaíocht"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Tosaíocht an CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "Ainm cosáin eochrach phríobháideach le húsáid leis an teastas thuas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Prótacal"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "Theip ar an gceistiú strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Athfhíordheimhniú i"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Am Atheochrach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Ath-eochair isteach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Cianda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Cumraíocht Chianda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Aitheantóir Cianda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Fo-líonra cianda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Roghnóirí Tráchta Cianda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Aitheantóir cianda le haghaidh IKE (céim 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Líonra(í) iargúlta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+"B’fhéidir nach mbeadh na hainmneacha céanna ar Chianrialtáin, ar Thograí "
+"Criptithe agus ar Tolláin."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Fuinneog Athsheinm"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Fuinneog Athsheinm an CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "SPI isteach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "SPI amach"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "Soicind"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "Soicindí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Cumainn Slándála (SAanna)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "Roghnaigh comhéadan nó fág folamh do gach comhéadan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Taispeáin Sonraí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Tosaigh Gníomh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Stát"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Staitisticí"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "An Tollán ina bhfuil an chuid ESP (céim 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "An eochair réamhroinnte don tollán"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "Leibhéal rianaithe: 0 is lú focal, 4 is mó"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "Tollán"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "Cumraíocht Tolláin"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Cosán Scripte Suas/Síos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Am ar Fáil"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Úsáid ilroinnt IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+"Bain úsáid as teaglaim cosúil le tunnel1_phase1 nach bhfuil níos mó ná 15 "
+"charachtar."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "Ní thacaíonn ach cúltaca Netlink le luachanna níos mó ná 32"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Leagan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "Leagan de IKE le haghaidh caibidlíochta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr "IP(anna) fíorúla le hiarraidh in iarratais ar ualaí cumraíochta IKEv2"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Cibé acu togra ESP (céim 2) atá ann nó nach ea"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr "Socraíodh ID comhéadain XFRM ar chomhéadain ionchuir agus aschuir"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Crios"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "an dá cheann"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "as feidhm"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "Cumraíocht strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "IPsec strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "Stádas strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/ko/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ko/strongswan-swanctl.po
@@ -1,0 +1,629 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-05 19:02+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/ko/>\n"
+"Language: ko\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "활성 IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "고급"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "* 표시가 된 알고리즘은 안전하지 않은 것으로 간주됩니다"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "인증"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "인증 방식"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "수신 바이트"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "송신 바이트"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "CA 인증서"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "닫기"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "DPD 동작"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "DPD 확인 주기"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "데몬"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "일"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "일"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "디버그 수준"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "활성화"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "암호화 알고리즘"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "게이트웨이 (원격 엔드포인트)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "일반"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "일반 설정"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "luci-app-strongswan-swanctl에 접근 권한 부여"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "반개방 IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "해시 알고리즘"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "시간"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "시간"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "IKE 버전"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "유효 수명"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "로컬 인증서"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "로컬 게이트웨이"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "로컬 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "로컬 식별자"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "로컬 NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "로컬 출발지 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "로컬 서브넷"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "로컬 트래픽 선택자"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "로컬 네트워크"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (IKEv2 이동성 및 멀티호밍 프로토콜)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "분"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "분"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "모드"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "이름"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "이름은 최대 15자까지만 입력 가능"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "PRF 알고리즘"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "먼저 터널을 생성하세요"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "사전 공유 키(PSK)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "우선순위"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "프로토콜"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "원격"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "원격 설정"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "원격 식별자"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "원격 서브넷"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "원격 트래픽 선택자"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "원격 네트워크"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "수신 SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "송신 SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "초"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "초"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "상태"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "통계"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "터널"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "터널 설정"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "가동 시간"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "버전"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "영역(Zone)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "strongSwan 설정"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "strongSwan 상태"

--- a/applications/luci-app-strongswan-swanctl/po/lo/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/lo/strongswan-swanctl.po
@@ -1,0 +1,629 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-03 08:19+0000\n"
+"Last-Translator: BoneNI <bounkirdni@gmail.com>\n"
+"Language-Team: Lao <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/lo/>\n"
+"Language: lo\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "ການກະທຳເມື່ອໂຫຼດການຕັ້ງຄ່າເລີ່ມຕົ້ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "ການກະທຳເມື່ອ CHILD_SA ຖືກປິດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "ການກະທຳເມື່ອ DPD ໝົດເວລາ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "IKE_SAs ທີ່ກຳລັງເຮັດວຽກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "ຂັ້ນສູງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "ອະລະກໍລິດທີ່ໝາຍດ້ວຍ * ຖືວ່າບໍ່ປອດໄພ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "ການຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "ວິທີການຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "ຈຳນວນຂໍ້ມູນເຂົ້າ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "ຈຳນວນຂໍ້ມູນອອກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "ໃບຢັ້ງຢືນ CA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr "ໃບຢັ້ງຢືນ CA ທີ່ຕ້ອງຢູ່ໃນເສັ້ນທາງຄວາມເຊື່ອຖືຂອງໃບຢັ້ງຢືນຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SAs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "ເສັ້ນທາງໄຟລ໌ໃບຢັ້ງຢືນສຳລັບໃຊ້ຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "ປິດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "ການກະທຳເມື່ອປິດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "ເປີດໃຊ້ງານການຕັ້ງຄ່ານີ້ຫຼືບໍ່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr "ຕັ້ງຄ່າ Cipher Suites ເພື່ອກຳນົດຂໍ້ສະເໜີ IKE (ໄລຍະ 1) ຫຼື ESP (ໄລຍະ 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "ຕັ້ງຄ່າ strongSwan ສຳລັບການເຊື່ອມຕໍ່ VPN ທີ່ປອດໄພ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ (ໄລຍະ 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "ການກະທຳ DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "ຄວາມຊັກຊ້າ DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Daemon"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "ມື້"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "ມື້"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "ລະດັບການດີບັກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr "ກຳນົດ Connection Children ເພື່ອໃຊ້ເປັນອຸໂມງໃນການຕັ້ງຄ່າຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "ກຳນົດການຕັ້ງຄ່າ IKE ຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "ລາຍລະອຽດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "ກຸ່ມ Diffie-Hellman"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "ໄລຍະເວລາຂອງ CHILD_SA ກ່ອນຈະມີການສ້າງຄີໃໝ່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "ຂໍ້ສະເໜີ ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "ເປີດໃຊ້ງານ Hardware offload"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "ເປີດໃຊ້ງານການບີບອັດ ipcomp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "ເປີດໃຊ້ງານ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "ອະລະກໍລິດການເຂົ້າລະຫັດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "ຂະໜາດຄີການເຂົ້າລະຫັດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "ເຊື່ອມຕໍ່ມາເປັນເວລາ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "ໂຊນໄຟວໍທີ່ຕ້ອງກົງກັບໂຊນໄຟວໍທີ່ກຳນົດໄວ້"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "ເກດເວ (ຈຸດໝາຍປາຍທາງທາງໄກ)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "ທົ່ວໄປ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "ໃຫ້ສິດເຂົ້າເຖິງ luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "H/W Offload"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "IKE_SAs ທີ່ເປີດຢູ່ເຄິ່ງໜຶ່ງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "ອະລະກໍລິດ Hash"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "ຊົ່ວໂມງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "ຊົ່ວໂມງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "ການແຍກສ່ວນ IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "ເວີຊັນ IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "ການຢືນຢັນຕົວຕົນ IKE (ໄລຍະ 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr "ໄລຍະເວລາ IKEv2 ສຳລັບການປັບປຸງວັດຖຸຄີ; ໃຊ້ສຳລັບຄຳນວນໄລຍະເວລາການໃຊ້ງານນຳ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "ທີ່ຢູ່ IP ຫຼື ຊື່ FQDN ຂອງຈຸດໝາຍປາຍທາງອຸໂມງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "ທີ່ຢູ່ IP ຫຼື FQDN ຂອງຈຸດໝາຍປາຍທາງອຸໂມງພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "ບໍ່ມີການເຄື່ອນໄຫວ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "ເວລາຕິດຕັ້ງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "ອິນເຕີເຟສທີ່ຍອມຮັບການຈະລາຈອນ VPN"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "ໄລຍະເວລາກ່ອນປິດ CHILD_SA ທີ່ບໍ່ມີການເຄື່ອນໄຫວ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "ໄລຍະເວລາໃນການກວດສອບສະຖານະຂອງເພຍ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "ການແລກປ່ຽນຄີ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "ຈຳນວນຄັ້ງການລອງໃໝ່ໃນການສ້າງຄີ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "ໄລຍະເວລາການໃຊ້ງານ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "ໄລຍະເວລາການໃຊ້ງານ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "ຈຳກັດເວລາໃນການສ້າງຄີ/ຢືນຢັນຕົວຕົນໃໝ່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr "ລາຍການຂໍ້ສະເໜີ ESP (ໄລຍະ 2). ສາມາດເລືອກໄດ້ສະເພາະຂໍ້ສະເໜີທີ່ໝາຍຕິກ ESP ໄວ້ເທົ່ານັ້ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "ລາຍການຂໍ້ສະເໜີ IKE (ໄລຍະ 1) ສຳລັບໃຊ້ຢືນຢັນຕົວຕົນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "ອິນເຕີເຟສທີ່ກຳລັງຟັງຢູ່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "ໃບຢັ້ງຢືນພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "ເກດເວພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "IP ພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "ຕົວລະບຸພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "ຄີພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "NAT ພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "IP ແຫຼ່ງຂໍ້ມູນທ້ອງຖິ່ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Subnet ທ້ອງຖິ່ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "ຕົວເລືອກການຈະລາຈອນພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "ທີ່ຢູ່ພາຍໃນສຳລັບໃຊ້ໃນການຕໍ່ລອງ IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "ຕົວລະບຸພາຍໃນສຳລັບ IKE (ໄລຍະ 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "ເຄືອຂ່າຍພາຍໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (ໂປຣໂຕຄອນການເຄື່ອນທີ່ແລະຫຼາຍເສັ້ນທາງຂອງ IKEv2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "ໄລຍະເວລາສູງສຸດຂອງ CHILD_SA ກ່ອນຈະປິດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "ນາທີ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "ນາທີ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "ໂໝດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "ຊ່ວງ NAT ສຳລັບອຸໂມງທີ່ມີທີ່ຢູ່ IP ຊ້ຳກັນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "ຊື່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "ຄວາມຍາວຂອງຊື່ຕ້ອງບໍ່ເກີນ 15 ຕົວອັກສອນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "ຕົວເລກຕ້ອງມີຫົວໜ່ວຍຕໍ່ທ້າຍ s, m, h ຫຼື d"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "ຈຳນວນຄັ້ງທີ່ພະຍາຍາມສົ່ງຂໍ້ມູນໃໝ່ໃນລະຫວ່າງການຕໍ່ລອງເບື້ອງຕົ້ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "ເວລາເກີນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "ອະລະກໍລິດ PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr "ຕ້ອງຕັ້ງຄ່າອະລະກໍລິດ PRF ເມື່ອໃຊ້ການເຂົ້າລະຫັດແບບ Authenticated"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr "ເສັ້ນທາງໄຟລ໌ສະຄຣິບທີ່ຈະໃຫ້ເຮັດວຽກເມື່ອເກີດເຫດການ CHILD_SA up/down"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "ກະລຸນາສ້າງຂໍ້ສະເໜີກ່ອນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "ກະລຸນາສ້າງອຸໂມງກ່ອນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "ກະລຸນາສ້າງຂໍ້ສະເໜີ ESP ກ່ອນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "ຄີທີ່ແບ່ງປັນກັນ (Pre-Shared Key)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "ບູລິມະສິດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Priority of the CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "ເສັ້ນທາງໄຟລ໌ Private key ສຳລັບໃຊ້ກັບໃບຢັ້ງຢືນຂ້າງເທິງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "ໂປຣໂຕຄອນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "ການຮ້ອງຂໍຂໍ້ມູນຈາກ strongSwan ລົ້ມເຫຼວ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "ຈະຢືນຢັນຕົວຕົນໃໝ່ໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "ເວລາສ້າງຄີໃໝ່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "ຈະສ້າງຄີໃໝ່ໃນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "ໄລຍະໄກ (Remote)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "ການຕັ້ງຄ່າຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "ຕົວລະບຸຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Subnet ຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "ຕົວເລືອກການຈະລາຈອນຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "ຕົວລະບຸຝັ່ງທາງໄກສຳລັບ IKE (ໄລຍະ 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "ເຄືອຂ່າຍຝັ່ງທາງໄກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr "Remotes, Encryption Proposals ແລະ Tunnels ບໍ່ຄວນໃຊ້ຊື່ດຽວກັນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Replay Window"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Replay Window ຂອງ CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "SPI ເຂົ້າ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "SPI ອອກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "ວິນາທີ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "ວິນາທີ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Security Associations (SAs)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "ເລືອກອິນເຕີເຟສ ຫຼື ປະຫວ່າງໄວ້ເພື່ອໃຊ້ທຸກອິນເຕີເຟສ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "ສະແດງລາຍລະອຽດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "ການກະທຳເມື່ອເລີ່ມຕົ້ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "ສະຖານະ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "ສະຖິຕິ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "ອຸໂມງທີ່ມີສ່ວນຂອງ ESP (ໄລຍະ 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "ຄີທີ່ແບ່ງປັນກັນສຳລັບອຸໂມງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "ລະດັບການແກ້ບັກ: 0 ແມ່ນລະອຽດນ້ອຍສຸດ, 4 ແມ່ນລະອຽດຫຼາຍສຸດ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "ອຸໂມງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "ການຕັ້ງຄ່າອຸໂມງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "ເສັ້ນທາງໄຟລ໌ສະຄຣິບ Up/Down"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "ເວລາທີ່ເຮັດວຽກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "ໃຊ້ການແຍກສ່ວນ IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr "ໃຊ້ການປະສົມຊື່ເຊັ່ນ tunnel1_phase1 ທີ່ບໍ່ເກີນ 15 ຕົວອັກສອນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "ຄ່າທີ່ໃຫຍ່ກວ່າ 32 ຮອງຮັບໂດຍ Netlink backend ເທົ່ານັ້ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "ເວີຊັນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "ເວີຊັນ IKE ສຳລັບການຕໍ່ລອງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr "Virtual IP ທີ່ຈະຮ້ອງຂໍໃນການຮ້ອງຂໍ configuration payloads ຂອງ IKEv2"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "ນີ້ແມ່ນຂໍ້ສະເໜີ ESP (ໄລຍະ 2) ຫຼືບໍ່"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr "ID ຂອງອິນເຕີເຟສ XFRM ທີ່ຕັ້ງໄວ້ເທິງອິນເຕີເຟສຂາເຂົ້າ ແລະ ຂາອອກ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "ໂຊນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "ທັງສອງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "ບໍ່ແນະນຳໃຫ້ໃຊ້ແລ້ວ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "ການຕັ້ງຄ່າ strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "ສະຖານະ strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/lt/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/lt/strongswan-swanctl.po
@@ -1,0 +1,675 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-22 21:11+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/lt/>\n"
+"Language: lt\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Veiksmas įkeliant pradinę konfigūraciją"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Veiksmas, kai „CHILD_SA“ yra uždarytas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Veiksmas, kai sueina „DPD“ pasibaigusios užklausos laikas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "Aktyvūs „IKE_SA“ (dgs.)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Pažangūs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Algoritmai pažymėti su „*“ yra laikomi nesaugiais"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Autentifikavimas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Autentifikavimo būdas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Gauti baitai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Perduoti baitai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "„CA“ sertifikatas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"„CA“ sertifikatas, kuris turi būti nuotolinio lygiarangio sertifikato "
+"patikimo kelio sudėtyje"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "„CHILD_SA“ (dgs.)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "Sertifikato kelio pavadinimas, naudojamas autentifikavimui"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Uždaryti/Užverti"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Uždaryti veiksma"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "Konfigūraciją yra įjungtą/įgalinta arba ne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Konfigūruokite šifravimo komplektus, kad apibrėžtumėte „IKE“ (1-osios fazės) "
+"arba „ESP“ (2-osios fazės) pasiūlymus."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Konfigūruokite „strongSwan“ saugiems „VPN“ ryšiams."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Kripto pasiūlymas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Kripto pasiūlymas (2-oji fazė)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "„DPD“ veiksmas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "„DPD“ atidėjimas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Paslaugų teikimo sistema"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "Diena"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "Dienos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Derinimo/Trukdžių šalinimo lygis"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+"Apibrėžti ryšio „vaikus“, kurie bus naudojami kaip „tuneliai“ – tinklo "
+"protokole, skirti šifruoti/pereiti į kitą tinklą nuotolinėse konfigūracijose."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Apibrėžti nuotolines „IKE“ konfigūracijas."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "išsamesnės informacijos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Difio-Helmano grupė"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "„CHILD_SA“ trukmė prieš pakartotinio rakto įvedimo"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "„ESP“ pasiūlymas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Įjungti/Įgalinti aparatinės įrangos iškrovimo/apkrovos perkėlimą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Įjungti/Įgalinti „IPcomp“ suspaudimą/suglaudi(ni)mą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Įjungta/Įgalinta (-s/-i)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Šifravimo algoritmas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Šifravimo rakto dydis"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Šifravimo pasiūlymai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Įkurta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "Užkardos zona, kuri turi atitikti apibrėžtą užkardos zoną"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Tinklo tarpuvartė (nuotolinis galutinis taškas)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "Bendra/-i/-ai/-s"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Bendri nustatymai"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Duoti prieigą prie – „luci-app-strongswan-swanctl“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Aparatinės įrangos iškrovimo/apkrovos perkėlimas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "Pusiau atidaryti „IKEA_SA“ (dgs.)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "maišos algoritmas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "Valanda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "Valandos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "„IKE“ fragmentavimas/-cija"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "„IKE“ versija"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "„IKE“ autentifikavimas (1-oji fazė)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"„IKEv2“ intervalas, skirtas atnaujinti raktų medžiagą; taip pat naudojamas "
+"gyvavimo laikui apskaičiuoti"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr ""
+"„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą "
+"nuotolinio galutinio taško IP adresas arba „FQDN“ pavadinimas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr ""
+"„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą "
+"vietinio galutinio taško IP adresas arba „FQDN“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "„IPComp“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Neaktyvumas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Įdiegimo laikas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Sąsajos ir/arba Sietuvai, kurios/-ie priima „VPN“ srauta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Intervalas prieš uždarant neaktyvų „CHILD_SA“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Intervalas, skirtas patikrinti lygiarangio gyvumą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Raktų mainų protokolas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Raktų keitimo bandymai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Gyvavimo laikas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Gyvavimo laikas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "Laiko apribojimas, atliekant pakartotinį raktų keitimą/autentifikavimą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"„ESP“ (2-osios fazės) pasiūlymų sąrašas. Galima pasirinkti tik pasiūlymus, "
+"pažymėtus su „ESP“ vėliavėle"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr ""
+"„IKE“ (1-os fazės) pasiūlymų sąrašas, kuriuos galima naudoti autentifikavimui"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Laukiamos/-i prisijungimo/jungties ryšio sąsajos ir/arba sietuvai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Vietinis sertifikatas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Vietinė tinklo tarpuvartė"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "Vietinis IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Vietinis identifikatorius"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Vietinis raktas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "Vietinis „NAT“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "Vietinis šaltinio IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Vietinis potinklis"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Vietiniai srauto parinkikliai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Vietinis(-iai) adresas(-ai), naudojamas(-i) „IKE“ derybose"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Vietinis identifikatorius, skirtas – „IKE“ (1-oji fazė)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Vietinis/-iai tinklas/-ai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "„MOBIKE“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "„MOBIKE“ („IKEv2“ mobilumo ir daugiafunkcinis protokolas)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Maksimali „CHILD_SA“ trukmė prieš uždarymą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "Minutė"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "Minutės"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Veiksena"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr ""
+"„NAT“ diapazonas „tuneliams“ – tinklo protokolams, skirtiems šifruoti/"
+"pereiti į kitą tinklą su persidengiančiais IP adresais"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Pavadinimas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "Pavadinimo ilgis neturi viršyti 15-ą rašmenų"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr ""
+"Numeriai turi turėti priesagas s (sek), m (min), h (val) arba d (diena)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Retransliavimo bandymų skaičius, pradines derybos metu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Viršvalandžiai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "„PRF“ algoritmas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"Naudojant autentifikuotą šifravimo algoritmą, reikia sukonfigūruoti „PRF“ "
+"algoritmą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+"Kelias į skriptą, kuris bus vykdomas ant – „CHILD_SA“ įvykių metu (įjungti/"
+"išgalinti┃išjungti/išgalinti)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Prašome sukurti pasiūlymą pirmą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr ""
+"Prašome pirmą sukurti „tunelį“ – Tinklo protokolą, skirtą šifruoti/pereiti į "
+"kitą tinklą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Prašome pirmą sukurti „ESP“ pasiūlymą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Išankstinis bendras raktas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Pirmenybė"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "„CHILD_SA“ pirmenybė"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+"Privataus rakto kelio pavadinimas, naudojamas su aukščiau nurodytu "
+"sertifikatu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Protokolas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "Nepavyko atlikti užklausos „strongSwan“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Pakartotinis autentifikavimas per"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Pakartotinio rakto įvedimo laikas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Pakartoti rakto įvedimą per"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Nuotolinis"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Nuotolinė konfigūracija"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Nuotolinis identifikatorius"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Nuotolinis potinklis"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Nuotoliniai srauto parinkikliai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Nuotolinis parinkiklis, skirtas – „IKE“ (1-oji fazė)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Nuotolinis/-iai tinklas/-ai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+"Nuotoliniai, šifravimo pasiūlymai ir „tuneliai“ – tinklo protokolai, skirti "
+"šifruoti/pereiti į kitus tinklus negali turėti tų pačių pavadinimų."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Pakartojimo langas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "„CHILD_SA“ pakartojimo langas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "„SPI“ (gaunamas)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "„SPI“ (išeinamas)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "Sekundė"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "Sekundės"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Apsaugos asociacijos („SA“)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr ""
+"Pasirinkite sąsają ir/arba sietuvą arba palikite tuščią visoms-/iems "
+"sąsajoms ir/arba sietuvams"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Rodyti išsamesnę informaciją"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Pradėti veiksmą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Būklę/Būseną"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Statistika"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr ""
+"„Tunelis“ – tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą, "
+"kuriame yra „ESP“ (2-osios fazės) skyrius"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr ""
+"Išankstinis bendras „tunelio“ – tinklo protokolo, skirtas šifruoti/pereiti į "
+"kitą tinklą raktas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+"Atsekamumo lygis: 0-is yra mažiausiai platus/išsamus/daugiažodiškas, 4-i yra "
+"daugiausiai"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "„Tunelis“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr ""
+"„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kito tinklo "
+"konfigūracija"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Įjungimo/Įgalinimo┃/Išjungimo/Išgalinimo skripto kelias"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Aktyvumo laikas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Naudoti „IKE“ fragmentavimą/-ciją"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+"Naudokite tokias kombinacijas kaip – „tunnel1_phase1“, kurios neviršija 15-"
+"os rašmenų."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr ""
+"Reikšmes didesnės nei 32-i yra palaikomos tik „Netlink“ uždaros sąsajos"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Versija"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "„IKE“ versija, skirta deryboms"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+"Virtualūs IP (dgs.), kurių reikia prašyti – „IKEv2“ konfigūracijos "
+"naudingosios apkrovos užklausose"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Ar tai yra „ESP“ (2-sios fazės) pasiūlymas, ar ne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+"„XFRM“ sąsajos ir/arba sietuvo ID, nustatytas įvesties ir išvesties sąsajose "
+"ir/arba sietuvuose"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Zona"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "abi/abu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "nebenaudojamas/-a"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "„strongSwan“ konfigūracija"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "„strongSwan IPsec“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "„strongSwan“ būklę/būseną"

--- a/applications/luci-app-strongswan-swanctl/po/pl/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/pl/strongswan-swanctl.po
@@ -1,0 +1,652 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-26 11:19+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/pl/>\n"
+"Language: pl\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Akcja po załadowaniu konfiguracji początkowej"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Akcja, gdy CHILD_SA jest zamknięte"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Akcja przy przekroczeniu limitu czasu DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "Aktywne IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Algorytmy oznaczone * są uważane za niebezpieczne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Uwierzytelnienie"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Metoda uwierzytelnienia"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Bajty odebrane"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Bajty wysłane"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "Certyfikat CA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"Certyfikat CA, który musi znajdować się w zdalnej ścieżce zaufania "
+"certyfikatu peera"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "Powiązania CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr ""
+"Ścieżka dostępu do certyfikatu, która ma być używana do uwierzytelniania"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Zamknij"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Zamknij akcję"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "Konfiguracja jest włączona lub nie"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Skonfiguruj zestawy szyfrów, aby określić propozycje IKE (Faza 1) lub ESP "
+"(Faza 2)."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Skonfiguruj strongSwan w celu zapewnienia bezpiecznych połączeń VPN."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Propozycja kryptograficzna"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Propozycja kryptograficzna (Faza 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "Akcja DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "Opóźnienie DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Demon"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "Dzień"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "Dni"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Poziom debugowania"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+"Określ elementy podrzędne połączenia, które będą używane jako tunele w "
+"konfiguracjach zdalnych."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Określ zdalne konfiguracje IKE."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "Szczegóły"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Grupa Diffiego-Hellmana"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "Czas trwania CHILD_SA przed wznawianiem klucza"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "Propozycja ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Włącz odciążanie sprzętowe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Włącz kompresję ipcomp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Włączone"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Algorytm szyfrowania"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Rozmiar klucza szyfrującego"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Propozycje szyfrowania"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Utworzono dla"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "Strefa zapory, która musi odpowiadać zdefiniowanej strefie zapory"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Brama (zdalny punkt końcowy)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "Ogólne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Ustawienia główne"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Udziel dostępu do luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Odciążenie sprzętowe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "Półotwarte IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "Algorytm haszujący"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "Godzina"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "Godziny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "Fragmentacja IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "Wersja IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "Uwierzytelnienie IKE (Faza 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"Interwał IKEv2 do odświeżenia materiału wznawiania klucza; używany również "
+"do obliczania czasu życia"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "Adres IP lub nazwa FQDN zdalnego punktu końcowego tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "Adres IP lub nazwaFQDN lokalnego punktu końcowego tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Bezczynność"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Czas instalacji"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Interfejsy akceptujące ruch VPN"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Interwał przed zamknięciem nieaktywnego CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Interwał sprawdzania żywotności peera"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Wymiana kluczy"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Ponowne próby wznawiania klucza"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Czas życia"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Życie"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "Ograniczenie czasu na wznowienie klucza / ponowne uwierzytelnienie"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"Lista propozycji ESP (Faza 2). Można wybrać tylko propozycje z zaznaczoną "
+"flagą ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "Lista propozycji IKE (Faza 1) do wykorzystania w uwierzytelnianiu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Interfejsy nasłuchujące"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Certyfikat lokalny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Brama lokalna"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "Lokalny IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Identyfikator lokalny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Klucz lokalny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "Lokalny NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "Lokalny źródłowy adres IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Lokalna podsieć"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Selektory ruchu lokalnego"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Adresy lokalne do wykorzystania w negocjacjach IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Identyfikator lokalny dla IKE (Faza 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Sieci lokalne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (protokół mobilności i wielodostępności IKEv2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Maksymalny czas trwania CHILD_SA przed zamknięciem"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "Minuta"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "Minuty"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Tryb"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "Zakres NAT dla tuneli z nakładającymi się adresami IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Nazwa"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "Długość nazwy nie może przekraczać 15 znaków"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "Liczba musi mieć sufiks s, m, h lub d"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Liczba prób retransmisji podczas początkowych negocjacji"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Czas nadliczbowy"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "Algorytm PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"Algorytm PRF musi być skonfigurowany w przypadku korzystania z algorytmu "
+"szyfrowania uwierzytelnionego"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+"Ścieżka do skryptu uruchamianego w przypadku zdarzeń przesyłania/pobierania "
+"CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Najpierw utwórz propozycję"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "Najpierw utwórz tunel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Najpierw utwórz propozycję ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Klucz wstępnie udostępniony"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Priorytet"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Priorytet CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "Ścieżka do klucza prywatnego do użycia z powyższym certyfikatem"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Protokół"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "Nie powiodło się zapytanie strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Ponowne uwierzytelnienie za"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Czas wznawiania klucza"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Wznawianie klucza za"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Zdalny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Konfiguracja zdalna"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Identyfikator zdalny"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Zdalna podsieć"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Selektory ruchu zdalnego"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Identyfikator zdalny dla IKE (Faza 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Sieci zdalne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+"Zdalne, propozycje szyfrowania i tunele nie mogą mieć tych samych nazw."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Okno powtórzenia"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Okno powtórzenia CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "SPI odebrane"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "SPI wysłane"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "Sekunda"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "Sekundy"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Powiązania bezpieczeństwa (SA)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "Wybierz interfejs lub pozostaw puste dla wszystkich interfejsów"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Pokaż szczegóły"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Rozpocznij akcję"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Stan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Statystyki"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "Tunel zawierający sekcję ESP (Faza 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "Klucz wstępnie udostępniony dla tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+"Poziom śledzenia: 0 oznacza najmniej szczegółowy, 4 oznacza najbardziej "
+"szczegółowy"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "Tunel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "Konfiguracja tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Ścieżka skryptu przesyłania/pobierania"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Czas pracy"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Użyj fragmentacji IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+"Należy używać kombinacji takich jak tunel1_faza1, które nie przekraczają 15 "
+"znaków."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "Wartości większe niż 32 są obsługiwane tylko przez backend Netlink"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Wersja"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "Wersja IKE do negocjacji"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr "Wirtualne adresy IP do żądania w konfiguracji ładunku IKEv2"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Czy jest to propozycja ESP (Faza 2), czy nie"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+"Identyfikator interfejsu XFRM ustawiony na interfejsach wejściowych i "
+"wyjściowych"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Strefa"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "oba"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "przestarzałe"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "Konfiguracja strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "Status strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/pt_BR/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/pt_BR/strongswan-swanctl.po
@@ -1,0 +1,629 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-26 08:43+0000\n"
+"Last-Translator: Volenski <volenski@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
+"openwrt/luciapplicationsstrongswan-swanctl/pt_BR/>\n"
+"Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Daemon"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Ativado"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Configurações gerais"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Tempo de atividade"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr ""

--- a/applications/luci-app-strongswan-swanctl/po/ru/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ru/strongswan-swanctl.po
@@ -1,0 +1,649 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-04-25 12:14+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/ru/>\n"
+"Language: ru\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Действие при начальной загрузке конфигурации"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Действие при закрытии CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Действие при тайм-ауте DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "Активные KE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Дополнительно"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Алгоритмы, отмеченные *, считаются небезопасными"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Аутентификация"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Метод аутентификации"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Байт получено"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Байт передано"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "CA-сертификат"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"CA-сертификат, который должен находиться в цепочке доверия сертификата "
+"удалённого узла"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "Путь к файлу сертификата для аутентификации"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Закрыть"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Действие при закрытии"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "Конфигурация включена"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Настройка наборов шифрования для определения профилей IKE (фаза 1) или ESP "
+"(фаза 2)."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Настройка strongSwan для защищённых VPN-соединений."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Криптографический профиль"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Криптографический профиль (фаза 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "Действие DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "Интервал проверки DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Демон"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "День"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "Дней"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Уровень отладки"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+"Настройка дочерних соединений, используемых в качестве туннелей в удалённых "
+"конфигурациях."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Настройка удалённых конфигураций IKE."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "Подробности"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Наборы Диффи-Хеллмана"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "Время жизни CHILD_SA до обновления ключей"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "Профиль ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Включить аппаратное ускорение"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Включить сжатие IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Включено"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Алгоритм шифрования"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Размер ключа шифрования"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Профили шифрования"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Установлено"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "Зона межсетевого экрана должна соответствовать указанной"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Шлюз (удалённая точка)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "Основные"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Основные настройки"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Предоставить доступ к luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Аппаратное ускорение"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "Полуоткрытые IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "Алгоритм хеширования"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "Час"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "Часов"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "Фрагментация IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "Версия IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "Аутентификация IKE (фаза 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"Интервал для обновления ключей IKEv2; используется для расчёта времени жизни"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "IP-адрес или FQDN удалённой точки туннеля"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "IP-адрес или FQDN локальной точки туннеля"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "Сжатие IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Тайм-аут неактивности"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Время установки"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Интерфейсы, принимающие VPN-трафик"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Интервал до закрытия неактивного CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Интервал проверки работоспособности узла"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Протокол обмена ключами"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Повторные попытки обмена ключами"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Время жизни"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Время жизни"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+"Максимальное время на завершение обновления ключей/повторной аутентификации"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"Список профилей ESP (фаза 2). Доступны только профили с установленным флагом "
+"ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "Список профилей IKE (фаза 1) для аутентификации"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Прослушиваемые интерфейсы"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Локальный сертификат"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Локальный шлюз"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "Локальный IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Локальный идентификатор"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Локальный ключ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "Локальный NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "Локальный IP-адрес источника"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Локальная подсеть"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Локальные селекторы трафика"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Локальные адреса для использования в согласовании IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Локальный идентификатор для IKE (фаза 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Локальные сети"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (протокол мобильности и множественной адресации IKEv2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Максимальное время жизни CHILD_SA до закрытия"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "Минута"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "Минут"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Режим работы"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "Диапазон NAT для туннелей с пересекающимися IP-адресами"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Название"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "Длина имени не должна превышать 15 символов"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "Число должно содержать суффикс s (сек.), m (мин.), h (ч.) или d (дн.)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Количество попыток повторной передачи при первоначальном согласовании"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Запас по времени"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "Алгоритм PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"При использовании аутентифицированного шифрования необходимо настроить "
+"алгоритм PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+"Путь к скрипту, выполняемому при событиях CHILD_SA (включение/отключение)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Сначала создайте профиль"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "Сначала создайте туннель"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Сначала создайте профиль ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Предварительный общий ключ (PSK)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Приоритет"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Приоритет CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "Путь к приватному ключу для указанного сертификата"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Протокол"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "Не удалось запросить данные у strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Повторная аутентификация через"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Интервал обновления ключей"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Время обновления ключей"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Удалённый узел"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Удалённая конфигурация"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Удалённый идентификатор"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Удалённая подсеть"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Удалённые селекторы трафика"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Удалённый идентификатор для IKE (фаза 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Удалённые сети"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+"Имена удалённых конфигураций, профилей шифрования и туннелей не должны "
+"совпадать."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Окно защиты от повторов"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Окно защиты от повторов CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "SPI (входящий)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "SPI (исходящий)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "Секунда"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "Секунд"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Безопасные ассоциации (SA)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "Выберите интерфейс или оставьте пустым для всех интерфейсов"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Показать подробности"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Действие при запуске"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Состояние"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Статистика"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "Туннель, содержащий раздел ESP (фаза 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "Предварительный общий ключ для туннеля"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "Уровень трассировки: 0 — минимум сообщений, 4 — максимум"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "Туннель"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "Конфигурация туннеля"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Путь к скрипту включения/отключения"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Время работы"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Использовать фрагментацию IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+"Используйте комбинации вида tunnel1_phase1, не превышающие 15 символов."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "Значения больше 32 поддерживаются только ядром Linux (Netlink)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Версия"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "Версии IKE для согласования"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+"Виртуальные IP-адреса, запрашиваемые в запросах полезной нагрузки "
+"конфигурации IKEv2"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Указывает, является ли это профилем ESP (фаза 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr "ID интерфейса XFRM, устанавливаемый на входных и выходных интерфейсах"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Зона"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "обе"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "устаревшая опция"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "Конфигурация strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "Статус strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/templates/strongswan-swanctl.pot
+++ b/applications/luci-app-strongswan-swanctl/po/templates/strongswan-swanctl.pot
@@ -1,0 +1,620 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr ""

--- a/applications/luci-app-strongswan-swanctl/po/uk/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/uk/strongswan-swanctl.po
@@ -1,0 +1,649 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-21 05:04+0000\n"
+"Last-Translator: Dan <jonweblin2205@protonmail.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationsstrongswan-swanctl/uk/>\n"
+"Language: uk\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "Дія при початковому завантаженні конфігурації"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "Дія при закритті CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "Дія при тайм-ауті DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "Активні IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "Розширені"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "Алгоритми, позначені *, вважаються небезпечними"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "Автентифікація"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "Метод автентифікації"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "Байтів отримано"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "Байтів надіслано"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "Сертифікат CA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+"Сертифікат CA, що має бути у ланцюжку довіри сертифіката віддаленого "
+"однорангового вузла"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "Шлях до сертифіката для автентифікації"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "Закрити"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "Дія при закритті"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "Чи увімкнено конфігурацію"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+"Налаштуйте набори шифрів, щоб визначити пропозиції IKE (фаза 1) або ESP "
+"(фаза 2)."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "Налаштуйте strongSwan для безпечних зʼєднань VPN."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "Криптопропозиція"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "Криптопропозиція (фаза 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "Дія DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "Затримка DPD"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "Служба"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "день"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "днів"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "Рівень налагодження"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+"Визначте дочірні зʼєднання для використання як тунелі у віддалених "
+"конфігураціях."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "Визначте віддалені конфігурації IKE."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "Подробиці"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Група Діффі-Геллмана"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "Тривалість CHILD_SA до перегенерації ключів"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "Пропозиція ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "Увімкнути апаратне розвантаження"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "Увімкнути стиснення ipcomp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "Алгоритм шифрування"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "Розмір ключа шифрування"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "Пропозиції шифрування"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "Встановлено вже"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "Зона брандмауера, що має збігатися з визначеною зоною брандмауера"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "Шлюз (віддалена кінцева точка)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "Загальне"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "Загальні налаштування"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "Надати доступ до luci-app-strongswan-swanctl"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "Апаратне розвантаження"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "Напіввідкриті IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "Алгоритм хешування"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "година"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "годин"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "Фрагментація IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "Версія IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "Автентифікація IKE (фаза 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+"Інтервал IKEv2 для оновлення ключового матеріалу; також використовується для "
+"обчислення часу життя"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "IP-адреса або FQDN віддаленої кінцевої точки тунелю"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "IP-адреса або FQDN локальної кінцевої точки тунелю"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "Неактивність"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "Час встановлення"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "Інтерфейси, що приймають трафік VPN"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "Інтервал до закриття неактивного CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "Інтервал перевірки активності однорангового вузла"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "Обмін ключами"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "Спроби обміну ключами"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "Час життя"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "Час життя"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+"Обмеження часу на завершення перегенерації ключів/повторної автентифікації"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+"Список пропозицій ESP (фаза 2). Можна обрати лише пропозиції з позначеним "
+"прапором ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "Список пропозицій IKE (фаза 1) для використання при автентифікації"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "Інтерфейси прослуховування"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "Локальний сертифікат"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "Локальний шлюз"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "Локальна IP-адреса"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "Локальний ідентифікатор"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "Локальний ключ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "Локальний NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "Локальна IP-адреса джерела"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "Локальна підмережа"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "Локальні селектори трафіку"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "Локальна(і) адреса(и) для узгодження IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "Локальний ідентифікатор для IKE (фаза 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "Локальна(і) мережа(і)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (протокол мобільності та мультихостингу IKEv2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "Максимальна тривалість CHILD_SA до закриття"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "хвилина"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "хвилин"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "Режим"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "Діапазон NAT для тунелів із перекриттям IP-адрес"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "Імʼя"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "Довжина імені не повинна перевищувати 15 символів"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "Число має мати суфікс s, m, h або d"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "Кількість спроб повторної передачі під час початкового узгодження"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "Перевищення часу"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "Алгоритм PRF"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+"Алгоритм PRF необхідно налаштувати при використанні алгоритму "
+"автентифікованого шифрування"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr "Шлях до сценарію, що виконується при подіях up/down CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "Спочатку створіть пропозицію"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "Спочатку створіть тунель"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "Спочатку створіть пропозицію ESP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "Спільний ключ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "Пріоритет"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "Пріоритет CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "Шлях до приватного ключа для використання з наведеним сертифікатом"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "Протокол"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "Не вдалося опитати strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "Повторна автентифікація через"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "Час перегенерації ключів"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "Перегенерація ключів через"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "Віддалений вузол"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "Віддалена конфігурація"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "Віддалений ідентифікатор"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "Віддалена підмережа"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "Віддалені селектори трафіку"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "Віддалений ідентифікатор для IKE (фаза 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "Віддалена(і) мережа(і)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+"Віддалені вузли, пропозиції шифрування та тунелі не можуть мати однакових "
+"імен."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "Вікно повторного відтворення"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "Вікно повторного відтворення CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "SPI вх."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "SPI вих."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "секунда"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "секунд"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "Контексти безпеки (SA)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "Виберіть інтерфейс або залиште порожнім для всіх інтерфейсів"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "Показати подробиці"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "Дія при запуску"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "Стан"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "Статистика"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "Тунель, що містить секцію ESP (фаза 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "Спільний ключ для тунелю"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "Рівень трасування: 0 — найменш докладно, 4 — найдокладніше"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "Тунель"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "Конфігурація тунелю"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "Шлях до сценарію Up/Down"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "Час безперервної роботи"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "Використовувати фрагментацію IKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr ""
+"Використовуйте комбінації на кшталт tunnel1_phase1, що не перевищують 15 "
+"символів."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "Значення більше 32 підтримуються лише бекендом Netlink"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "Версія"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "Версія IKE для узгодження"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+"Віртуальна(і) IP-адреса(и) для запиту в конфігураційних повідомленнях IKEv2"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "Чи є це пропозиція ESP (фаза 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr ""
+"Ідентифікатор інтерфейсу XFRM, призначений вхідним та вихідним інтерфейсам"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "Зона"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "обидва"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "застаріле"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "Конфігурація strongSwan"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "Стан strongSwan"

--- a/applications/luci-app-strongswan-swanctl/po/zh_Hans/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/zh_Hans/strongswan-swanctl.po
@@ -1,0 +1,630 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-06-26 11:19+0000\n"
+"Last-Translator: Hosted Weblate user 54392 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsstrongswan-swanctl/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "初始配置加载时的动作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr "CHILD_SA 关闭时的动作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr "DPD 超时时的动作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr "活动的 IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "高级"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "带有 * 标记的算法被视为不安全"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "认证"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "认证方式"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "入站字节"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "出站字节"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "CA 证书"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr "位于对端证书信任链路径中的 CA 证书"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "子安全联盟 (CHILD_SA)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "用于认证的证书文件路径"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "关闭"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "关闭动作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "是否启用此配置"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr "配置密码套件以定义 IKE（阶段 1）或 ESP（阶段 2）提议。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "配置 strongSwan 以实现安全的 VPN 连接。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "加密提议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "加密提议 (阶段 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "DPD 动作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "DPD 延迟"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "守护进程"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "天"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "天"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "调试级别"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr "定义在对端配置中作为隧道使用的子连接。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "定义对端 IKE 配置。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "详情"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "DH 组 (Diffie-Hellman)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr "CHILD_SA 重新协商密钥前的持续时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "ESP 提议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "启用硬件卸载 (Hardware Offload)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "启用 IPComp 压缩"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "已启用"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "加密算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "加密密钥长度"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "加密提议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr "已建立时长"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr "必须匹配所定义的防火墙区域"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "网关 (对端)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "常规"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "常规设置"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "授予 luci-app-strongswan-swanctl 的权限"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "硬件卸载"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "半开 IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "哈希算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "小时"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "小时"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "IKE 分片"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "IKE 版本"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "IKE 认证 (阶段 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr "IKEv2 刷新密钥材料的间隔；也用于计算生存时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "隧道对端的 IP 地址或 FQDN 域名"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "隧道本端的 IP 地址或 FQDN 域名"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp 压缩"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr "空闲超时"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "安装时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "接收 VPN 流量的接口"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr "关闭非活动 CHILD_SA 前的间隔时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "检查对端存活状态的间隔时间 (Keep-alive)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "密钥交换 (Key Exchange)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr "密钥协商重试次数"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "生存时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "生存时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr "完成密钥更新/重新认证的时间限制"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr "ESP (阶段 2) 提议列表。只有勾选了 ESP 标记的提议才可选"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr "用于认证的 IKE (阶段 1) 提议列表"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "监听接口"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "本地证书"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "本地网关"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "本地 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "本地标识符 (ID)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "本地密钥"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "本地 NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "本地源 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "本地子网"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "本地流量选择器 (TS)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr "IKE 协商中使用的本地地址"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "IKE (阶段 1) 的本地标识符"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "本地网络"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (IKEv2 移动性与多归属协议)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr "CHILD_SA 关闭前的最大持续时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "分钟"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "分钟"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "模式"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr "针对 IP 地址重叠隧道的 NAT 范围"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "名称"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "名称长度不得超过 15 个字符"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr "数值必须带有单位后缀 (s, m, h 或 d)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "初始协商期间的重传尝试次数"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "超时时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "PRF 伪随机函数算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr "使用经过身份验证的加密算法 (AEAD) 时，必须配置 PRF 算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr "CHILD_SA 上线/下线事件发生时运行的脚本路径"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "请先创建一个提议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "请先创建一个隧道"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "请先创建一个 ESP 提议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "预共享密钥 (PSK)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "优先级"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "CHILD_SA 的优先级"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr "配合上述证书使用的私钥路径"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "协议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "查询 strongSwan 状态失败"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr "重新认证剩余时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr "密钥更新时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr "密钥更新剩余时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "对端"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "对端配置"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "对端标识符 (ID)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "对端子网"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "对端流量选择器 (TS)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "IKE (阶段 1) 的对端标识符"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "对端网络"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr "对端配置、加密提议和隧道不能使用相同的名称。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "防重放窗口"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "CHILD_SA 的防重放窗口"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "入站 SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "出站 SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "秒"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "秒"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr "安全联盟 (SA)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr "选择一个接口，留空则表示所有接口"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "显示详情"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr "启动动作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "状态"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "统计"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr "包含 ESP (阶段 2) 部分的隧道"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "该隧道的预共享密钥"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr "追踪级别：0 为最简要，4 为最详细"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "隧道"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "隧道配置"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr "上线/下线脚本路径"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "运行时间"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "启用 IKE 分片"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr "请使用类似 tunnel1_phase1 的组合名称，且长度不超过 15 个字符。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "仅 Netlink 后端支持大于 32 的值"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "版本"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "协商使用的 IKE 版本"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr "在 IKEv2 配置载荷请求中申请的虚拟 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr "这是否是一个 ESP (阶段 2) 提议"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr "在输入和输出接口上设置的 XFRM 接口 ID"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "防火墙区域"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "两者"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "不建议使用 (弃用)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "strongSwan 配置"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "strongSwan 状态"

--- a/applications/luci-app-strongswan-swanctl/po/zh_Hant/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/zh_Hant/strongswan-swanctl.po
@@ -1,0 +1,629 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2026-05-20 17:02+0000\n"
+"Last-Translator: 為什麼不加空格 <c++23@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationsstrongswan-swanctl/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6.dev0\n"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:299
+msgid "Action on initial configuration load"
+msgstr "初始配置載入時的動作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:307
+msgid "Action when CHILD_SA is closed"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:347
+msgid "Action when DPD timeout occurs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
+msgid "Active IKE_SAs"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:92
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid "Advanced"
+msgstr "進階"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:413
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Algorithms marked with * are considered insecure"
+msgstr "標有 * 的演算法被認為不安全"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:91
+msgid "Authentication"
+msgstr "認證"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "Authentication Method"
+msgstr "認證方式"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:123
+msgid "Bytes in"
+msgstr "傳入位元組"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:124
+msgid "Bytes out"
+msgstr "傳出位元組"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:195
+msgid "CA Certificate"
+msgstr "CA 憑證"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid ""
+"CA certificate that need to lie in remote peer's certificate's path of trust"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:151
+msgid "CHILD_SAs"
+msgstr "CHILD_SAs"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+msgid "Certificate pathname to use for authentication"
+msgstr "用於認證的憑證路徑名稱"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:139
+msgid "Close"
+msgstr "關閉"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+msgid "Close Action"
+msgstr "關閉動作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "Configuration is enabled or not"
+msgstr "配置是否啟用"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
+msgid ""
+"Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:57
+msgid "Configure strongSwan for secure VPN connections."
+msgstr "配置 strongSwan 以建立安全 VPN 連線。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+msgid "Crypto Proposal"
+msgstr "加密提案"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+msgid "Crypto Proposal (Phase 2)"
+msgstr "加密提案 (提案 2)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
+msgid "DPD Action"
+msgstr "DPD 動作"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:222
+msgid "DPD Delay"
+msgstr "DPD 延遲"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:103
+msgid "Daemon"
+msgstr "常駐程式"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Day"
+msgstr "天"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:15
+msgid "Days"
+msgstr "天"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:78
+msgid "Debug Level"
+msgstr "除錯等級"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:253
+msgid ""
+"Define Connection Children to be used as Tunnels in Remote Configurations."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:85
+msgid "Define Remote IKE Configurations."
+msgstr "定義遠端 IKE 配置。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:164
+msgid "Details"
+msgstr "詳情"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:412
+msgid "Diffie-Hellman Group"
+msgstr "Diffie-Hellman 群組"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+msgid "Duration of the CHILD_SA before rekeying"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:392
+msgid "ESP Proposal"
+msgstr "ESP 提案"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
+msgid "Enable Hardware offload"
+msgstr "啟用硬體卸載"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:361
+msgid "Enable ipcomp compression"
+msgstr "啟用 ipcomp 壓縮"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Enabled"
+msgstr "已啟用"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:121
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
+msgid "Encryption Algorithm"
+msgstr "加密演算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:122
+msgid "Encryption Keysize"
+msgstr "加密金鑰大小"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+msgid "Encryption Proposals"
+msgstr "加密提案"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:162
+msgid "Established for"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:66
+msgid "Firewall zone that has to match the defined firewall zone"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
+msgid "Gateway (Remote Endpoint)"
+msgstr "閘道 (遠端端點)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid "General"
+msgstr "一般"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:61
+msgid "General Settings"
+msgstr "一般設定"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/rpcd/acl.d/luci-app-strongswan-swanctl.json:3
+msgid "Grant access to luci-app-strongswan-swanctl"
+msgstr "授予存取 luci-app-strongswan-swanctl 的權限"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:365
+msgid "H/W Offload"
+msgstr "H/W 卸載"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:105
+msgid "Half-Open IKE_SAs"
+msgstr "半開放 IKE_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+msgid "Hash Algorithm"
+msgstr "雜湊演算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hour"
+msgstr "小時"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:16
+msgid "Hours"
+msgstr "小時"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid "IKE Fragmentation"
+msgstr "IKE 分片"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:161
+msgid "IKE Version"
+msgstr "IKE 版本"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
+msgid "IKE authentication (phase 1)"
+msgstr "IKE 認證 (階段 1)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+msgid ""
+"IKEv2 interval to refresh keying material; also used to compute lifetime"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
+msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgstr "隧道遠端端點的 IP 位址或 FQDN 名稱"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
+msgid "IP address or FQDN of the tunnel local endpoint"
+msgstr "隧道本地端點的 IP 位址或 FQDN"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:360
+msgid "IPComp"
+msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+msgid "Inactivity"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
+msgid "Install Time"
+msgstr "安裝時間"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:71
+msgid "Interfaces that accept VPN traffic"
+msgstr "接受 VPN 流量的介面"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+msgid "Interval before closing an inactive CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
+msgid "Interval to check liveness of a peer"
+msgstr "檢查對等點在線狀況的間隔"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+msgid "Keyexchange"
+msgstr "金鑰交換"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:216
+msgid "Keying Retries"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:125
+msgid "Life Time"
+msgstr "生命週期"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
+msgid "Lifetime"
+msgstr "生命週期"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:239
+msgid "Limit on time to complete rekeying/reauthentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:316
+msgid ""
+"List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
+"selectable"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:119
+msgid "List of IKE (phase 1) proposals to use for authentication"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "Listening Interfaces"
+msgstr "監聽連接埠"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
+msgid "Local Certificate"
+msgstr "本地憑證"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
+msgid "Local Gateway"
+msgstr "本地閘道"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:113
+msgid "Local IP"
+msgstr "本地 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
+msgid "Local Identifier"
+msgstr "本地識別碼"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Local Key"
+msgstr "本地金鑰"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
+msgid "Local NAT"
+msgstr "本地 NAT"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+msgid "Local Source IP"
+msgstr "本地來源 IP"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:261
+msgid "Local Subnet"
+msgstr "本地子網路"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:119
+msgid "Local Traffic Selectors"
+msgstr "本地流量選擇器"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:114
+msgid "Local address(es) to use in IKE negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
+msgid "Local identifier for IKE (phase 1)"
+msgstr "IKE (階段 1) 本地識別碼"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:262
+msgid "Local network(s)"
+msgstr "本地網路"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:202
+msgid "MOBIKE"
+msgstr "MOBIKE"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:203
+msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
+msgstr "MOBIKE (IKEv2 移動性與多重主目錄協定)"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:342
+msgid "Maximum duration of the CHILD_SA before closing"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minute"
+msgstr "分鐘"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:17
+msgid "Minutes"
+msgstr "分鐘"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:117
+msgid "Mode"
+msgstr "模式"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
+msgid "NAT range for tunnels with overlapping IP addresses"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:158
+msgid "Name"
+msgstr "名稱"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:42
+msgid "Name length shall not exceed 15 characters"
+msgstr "名稱長度不得超過 15 個字元"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:11
+msgid "Number must have suffix s, m, h or d"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:217
+msgid "Number of retransmissions attempts during initial negotiation"
+msgstr "初始協商期間的重傳嘗試次數"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:238
+msgid "Overtime"
+msgstr "逾時"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "PRF Algorithm"
+msgstr "PRF 演算法"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:424
+msgid ""
+"PRF Algorithm must be configured when using an Authenticated Encryption "
+"Algorithm"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+msgid "Path to script to run on CHILD_SA up/down events"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
+msgid "Please create a Proposal first"
+msgstr "請先建立提案"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
+msgid "Please create a Tunnel first"
+msgstr "請先建立隧道"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:325
+msgid "Please create an ESP Proposal first"
+msgstr "請先建立 ESP 提案"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:176
+msgid "Pre-Shared Key"
+msgstr "預共享金鑰"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:373
+msgid "Priority"
+msgstr "優先級"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:374
+msgid "Priority of the CHILD_SA"
+msgstr "CHILD_SA 優先級"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:191
+msgid "Private key pathname to use with above certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:118
+msgid "Protocol"
+msgstr "協定"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:89
+msgid "Querying strongSwan failed"
+msgstr "查詢 strongSwan 失敗"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:163
+msgid "Reauthentication in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+msgid "Rekey Time"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:127
+msgid "Rekey in"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:160
+msgid "Remote"
+msgstr "遠端"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:84
+msgid "Remote Configuration"
+msgstr "遠端配置"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:170
+msgid "Remote Identifier"
+msgstr "遠端識別碼"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:267
+msgid "Remote Subnet"
+msgstr "遠端子網路"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:120
+msgid "Remote Traffic Selectors"
+msgstr "遠端流量選擇器"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:171
+msgid "Remote identifier for IKE (phase 1)"
+msgstr "IKE (階段 1) 遠端識別碼"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
+msgid "Remote network(s)"
+msgstr "遠端網路"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:39
+msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:378
+msgid "Replay Window"
+msgstr "重播視窗"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:379
+msgid "Replay Window of the CHILD_SA"
+msgstr "CHILD_SA 的重播視窗"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:128
+msgid "SPI in"
+msgstr "傳入 SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:129
+msgid "SPI out"
+msgstr "傳出 SPI"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Second"
+msgstr "秒"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:18
+msgid "Seconds"
+msgstr "秒"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:156
+msgid "Security Associations (SAs)"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:73
+msgid "Select an interface or leave empty for all interfaces"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:153
+msgid "Show Details"
+msgstr "顯示詳情"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:298
+msgid "Start Action"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:116
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:159
+msgid "State"
+msgstr "狀態"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:100
+msgid "Stats"
+msgstr "統計資料"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:140
+msgid "The Tunnel containing the ESP (phase 2) section"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:177
+msgid "The pre-shared key for the tunnel"
+msgstr "隧道預共享金鑰"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:79
+msgid "Trace level: 0 is least verbose, 4 is most"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:139
+msgid "Tunnel"
+msgstr "隧道"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+msgid "Tunnel Configuration"
+msgstr "隧道配置"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+msgid "Up/Down Script Path"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:102
+msgid "Uptime"
+msgstr "上線時間"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:208
+msgid "Use IKE fragmentation"
+msgstr "使用 IKE 分片"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:40
+msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
+msgstr "使用像 tunnel1_phase1 這樣不超過 15 個字元的組合。"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:380
+msgid "Values larger than 32 are supported by the Netlink backend only"
+msgstr "大於 32 的值只被 Netlink 後端支援"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:101
+msgid "Version"
+msgstr "版本"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:244
+msgid "Version of IKE for negotiation"
+msgstr "IKE 協商版本"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:393
+msgid "Whether this is an ESP (phase 2) proposal or not"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
+msgid "XFRM interface ID set on input and output interfaces"
+msgstr "設定在傳入和傳出介面上的 XFRM 介面 ID"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:65
+msgid "Zone"
+msgstr "區域"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "both"
+msgstr "兩者"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:245
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
+msgid "deprecated"
+msgstr "已棄用"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:56
+msgid "strongSwan Configuration"
+msgstr "strongSwan 配置"
+
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:3
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
+msgid "strongSwan IPsec"
+msgstr "strongSwan IPsec"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:175
+msgid "strongSwan Status"
+msgstr "strongSwan 狀態"

--- a/applications/luci-app-tailscale-community/po/zh_Hant/community.po
+++ b/applications/luci-app-tailscale-community/po/zh_Hant/community.po
@@ -1,0 +1,510 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8\n"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:34
+msgid "(Experimental) Reduce Memory Usage"
+msgstr "(實驗性) 減少記憶體使用"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:432
+msgid "1. Select \"Accept Routes\" (to access remote devices)."
+msgstr "1. 勾選 接受路由 (接受遠端裝置訪問)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:433
+msgid ""
+"2. In \"Advertise Routes\", select your local subnet (to allow remote "
+"devices to access this LAN)."
+msgstr "2. 在 通告路由 選擇本裝置的區域網段 (讓遠端裝置能訪問你)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:434
+msgid "3. Click \"Auto Configure Firewall\" (to allow traffic forwarding)."
+msgstr "3. 點選 自動配置防火牆 (打通防火牆轉發)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
+msgid "Accept Routes"
+msgstr "接受路由"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:441
+msgid "Account Settings"
+msgstr "賬戶設定"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:21
+msgid "Advertise Exit Node"
+msgstr "通告出口節點"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:400
+msgid "Advertise Routes"
+msgstr "通告路由"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:400
+msgid ""
+"Advertise subnet routes behind this device. Select from the detected subnets "
+"below or enter custom routes (comma-separated)."
+msgstr ""
+"通告此裝置後的子網路由。從下面的子網中選擇，或輸入自定義路由 (逗號分隔)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "Allow LAN Access"
+msgstr "允許區域網訪問"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:20
+msgid "Allow accepting routes announced by other nodes."
+msgstr "允許接受由其他節點通告的路由。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:26
+msgid "Allow connecting to this device through the SSH function of Tailscale."
+msgstr "允許透過 Tailscale 的 SSH 功能連線到此裝置。"
+
+#: applications/luci-app-tailscale-community/root/usr/share/rpcd/acl.d/luci-app-tailscale-community.json:3
+msgid "Allow user access to tailscale"
+msgstr "允許使用者訪問 Tailscale"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:563
+msgid "Applying changes..."
+msgstr "正在應用更改..."
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:515
+msgid "Are you sure you want to log out?"
+msgstr "您確定要登出嗎？"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:408
+msgid "Auto Configure Firewall"
+msgstr "自動配置防火牆"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:522
+msgid "Cancel"
+msgstr "取消"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:466
+msgid "Click to Log out account on this device."
+msgstr "點選以登出此裝置上的賬戶。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:445
+msgid "Click to get a login URL for this device."
+msgstr "點選獲取此裝置的登入 URL。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:166
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:363
+msgid "Collecting data ..."
+msgstr "正在收集資料..."
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:541
+msgid "Confirm Logout"
+msgstr "確認登出"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:253
+msgid "Connection Info"
+msgstr "連線資訊"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:478
+msgid ""
+"Could not open a new tab. Please check if your browser or an extension "
+"blocked the pop-up."
+msgstr "無法開啟新標籤頁。請檢查您的瀏覽器或擴充套件程式是否阻止了彈出視窗。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:450
+msgid "Custom Login Server"
+msgstr "自定義登入伺服器"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:458
+msgid "Custom Login Server Auth Key"
+msgstr "自定義登入伺服器認證金鑰"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:21
+msgid "Declare this device as an Exit Node."
+msgstr "將此裝置宣告為出口節點。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Disable MagicDNS"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
+msgid "Disable SNAT"
+msgstr "停用 SNAT"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:24
+msgid ""
+"Disable Source NAT (SNAT) for traffic to advertised routes. Most users "
+"should leave this unchecked."
+msgstr "為通告路由的流量停用源地址轉換 (SNAT)。大多數使用者應保持此項不勾選。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+msgid "Disabled"
+msgstr "已停用"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:467
+msgid "Disconnect from Tailscale and expire current node key."
+msgstr "從 Tailscale 斷開連線並使當前節點金鑰過期。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:26
+msgid "Enable Tailscale SSH"
+msgstr "啟用 Tailscale SSH"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:23
+msgid "Enable Web Interface"
+msgstr "啟用 Web 介面"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+msgid "Enabled"
+msgstr "已啟用"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:34
+msgid ""
+"Enabling this option can reduce memory usage, but it may sacrifice some "
+"performance (set GOGC=10)."
+msgstr "啟用此選項可以減少記憶體使用，但可能會犧牲一些效能 (設定 GOGC=10)。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:503
+msgid "Error"
+msgstr "錯誤"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:578
+msgid "Error applying settings: %s"
+msgstr "應用設定時出錯: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
+msgid "Error caching DERP region map: %s"
+msgstr "快取 DERP 區域地圖時出錯: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
+msgid "Error fetching DERP region map: %s"
+msgstr "獲取 DERP 區域地圖時出錯: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
+msgid "Error reading cached DERP region map: %s"
+msgstr "讀取快取的 DERP 區域地圖時出錯: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:574
+msgid "Error saving settings: %s"
+msgstr "儲存設定時出錯: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:409
+msgid ""
+"Essential configuration for Subnet Routing (Site-to-Site) and Exit Node "
+"features."
+msgstr "子網路由和出口節點的基本配置。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:278
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
+msgid "Exit Node"
+msgstr "出口節點"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:23
+msgid ""
+"Expose a web interface on port 5252 for managing this node over Tailscale."
+msgstr "在埠 5252 上暴露一個 Web 介面，用於透過 Tailscale 管理此節點。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:420
+msgid "Failed to configure firewall: %s"
+msgstr "獲取防火牆設定失敗: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:504
+msgid "Failed to get login URL. You may close this tab."
+msgstr "獲取登入 URL 失敗。您可以關閉此標籤頁。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:509
+msgid "Failed to get login URL: %s"
+msgstr "獲取登入 URL 失敗: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:505
+msgid "Failed to get login URL: Invalid response from server."
+msgstr "獲取登入 URL 失敗: 伺服器響應無效。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:584
+msgid "Failed to save settings: %s"
+msgstr "儲存設定失敗: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:19
+msgid "Firewall Mode"
+msgstr "防火牆模式"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:417
+msgid "Firewall configuration applied."
+msgstr "已應用防火牆配置"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:372
+msgid "General Settings"
+msgstr "常規設定"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:250
+msgid "Hostname"
+msgstr "主機名"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:427
+msgid "How to enable Site-to-Site?"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:446
+msgid ""
+"If the timeout is displayed, you can refresh the page and click Login again."
+msgstr "如果顯示超時，您可以重新整理頁面並再次點選登入。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:460
+msgid ""
+"If you are using custom login server but not providing an Auth Key, will "
+"redirect to the login page without pre-filling the key."
+msgstr ""
+"如果您使用自定義登入伺服器但未提供認證金鑰，將重定向到登入頁面而不會預先填充"
+"金鑰。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:90
+msgid "Invalid Date"
+msgstr "無效日期"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:410
+msgid ""
+"It automatically creates the tailscale interface, sets up firewall zones for "
+"LAN <-> Tailscale forwarding,"
+msgstr ""
+"子網路由和出口節點的基本配置。會自動tailscale介面，設定防火牆區域LAN <-> "
+"Tailscale轉發"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:93
+msgid "Just now"
+msgstr "剛才"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:205
+msgid "LOGGED OUT"
+msgstr "已登出"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:256
+msgid "Last Seen"
+msgstr "上次線上"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:452
+msgid "Leave blank for default Tailscale control plane."
+msgstr "留空以使用預設的 Tailscale 控制平面。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+msgid "Logging out..."
+msgstr "正在登出..."
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:444
+msgid "Login"
+msgstr "登入"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:465
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:538
+msgid "Logout"
+msgstr "登出"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
+msgid "Logout failed: %s"
+msgstr "登出失敗: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:87
+msgid "N/A"
+msgstr "N/A"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:216
+msgid "NOT RUNNING"
+msgstr "未執行"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:298
+msgid "Network Devices"
+msgstr "網路裝置"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:245
+msgid "No peer devices found."
+msgstr "未找到對等裝置。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:377
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:88
+msgid "Now"
+msgstr "現在"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:252
+msgid "OS"
+msgstr "作業系統"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:278
+msgid "Offline"
+msgstr "離線"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:278
+msgid "Online"
+msgstr "線上"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:451
+msgid ""
+"Optional: Specify a custom control server URL (e.g., a Headscale instance, "
+"%s)."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:459
+msgid ""
+"Optional: Specify an authentication key for the custom control server. Leave "
+"blank if not required."
+msgstr "可選：為自定義控制伺服器指定一個認證金鑰。如果不需要，請留空。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:207
+msgid "Please use the login button in the settings below to authenticate."
+msgstr "請使用下方設定中的登入按鈕進行認證。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:494
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:528
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:563
+msgid "Please wait."
+msgstr "請稍候。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:224
+msgid "RUNNING"
+msgstr "正在執行"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:254
+msgid "RX"
+msgstr "接收"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:488
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:494
+msgid "Requesting Login URL..."
+msgstr "正在請求登入 URL..."
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:485
+msgid "Requesting Tailscale login URL... Please wait."
+msgstr "正在請求 Tailscale 登入 URL... 請稍候。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:376
+msgid ""
+"Select an exit node from the list. If enabled, Allow LAN Access is enabled "
+"implicitly."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:19
+msgid ""
+"Select the firewall backend for Tailscale to use. Requires service restart "
+"to take effect."
+msgstr "選擇 Tailscale 使用的防火牆後端。需要重啟服務才能生效。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:195
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:203
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:215
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:224
+msgid "Service Status"
+msgstr "服務狀態"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:368
+msgid "Settings"
+msgstr "設定"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid "Shields Up"
+msgstr "開啟防護 (Shields Up)"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:249
+msgid "Status"
+msgstr "狀態"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:532
+msgid "Successfully logged out."
+msgstr "登出成功。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:196
+msgid "TAILSCALE NOT FOUND"
+msgstr "未找到 TAILSCALE"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:226
+msgid "TUN Mode"
+msgstr "TUN 模式"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:255
+msgid "TX"
+msgstr "傳送"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:229
+msgid "Tailnet Name"
+msgstr "Tailnet 名稱"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:342
+#: applications/luci-app-tailscale-community/root/usr/share/luci/menu.d/luci-app-tailscale-community.json:3
+msgid "Tailscale"
+msgstr "Tailscale"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:172
+msgid "Tailscale Health Check: %s"
+msgstr "Tailscale 健康檢查: %s"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:251
+msgid "Tailscale IP"
+msgstr "Tailscale IP"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:227
+msgid "Tailscale IPv4"
+msgstr "Tailscale IPv4"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:228
+msgid "Tailscale IPv6"
+msgstr "Tailscale IPv6"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:484
+msgid "Tailscale Login"
+msgstr "Tailscale 登入"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:342
+msgid ""
+"Tailscale is a mesh VPN solution that makes it easy to connect your devices "
+"securely. This configuration page allows you to manage Tailscale settings on "
+"your OpenWrt device."
+msgstr ""
+"Tailscale 是一個網狀 VPN 解決方案，可以輕鬆地安全連線您的裝置。此配置頁面允許"
+"您在 OpenWrt 裝置上管理 Tailscale 設定。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:569
+msgid "Tailscale settings applied successfully."
+msgstr "Tailscale 設定已成功應用。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:486
+msgid "This can take up to 30 seconds."
+msgstr "此過程最多可能需要 30 秒。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:516
+msgid ""
+"This will disconnect this device from your Tailnet and require you to re-"
+"authenticate."
+msgstr "這將使此裝置從您的 Tailnet 斷開連線，並需要您重新進行身份驗證。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:120
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:147
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:150
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:509
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:535
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:574
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:578
+msgid "Unknown error"
+msgstr "未知錯誤"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:27
+msgid "Use system DNS instead of MagicDNS."
+msgstr ""
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:225
+msgid "Version"
+msgstr "版本"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:25
+msgid ""
+"When enabled, blocks all inbound connections from the Tailscale network."
+msgstr "啟用後，將阻止來自 Tailscale 網路的所有入站連線。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:22
+msgid "When using the exit node, access to the local LAN is allowed."
+msgstr "使用出口節點時，允許訪問本地區域網。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:435
+msgid ""
+"[Important] Log in to the Tailscale admin console and manually enable "
+"\"Subnet Routes\" for this device."
+msgstr "【重要】 登入 Tailscale 控制平面，在裝置設定中手動授權子網路由。"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:96
+msgid "ago"
+msgstr "前"
+
+#: applications/luci-app-tailscale-community/htdocs/luci-static/resources/view/tailscale.js:411
+msgid ""
+"and enables Masquerading and MSS Clamping (MTU fix) to ensure stable "
+"connections."
+msgstr "並啟用地址偽裝和 MSS鉗制確保連線穩定。"

--- a/applications/luci-app-wifihistory/po/cs/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/cs/wifihistory.po
@@ -1,0 +1,116 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-02-18 07:12+0000\n"
+"Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/cs/>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 5.16.1-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Vyčistit"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Vyčistit historii"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Vyčistit historii stanic"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Připojeno"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Odpojeno"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Poprvé spatřeno"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Udělit přístup do historie WiFi stanic"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Hostitel"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Naposledy spatřeno"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC adresa"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Síť"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Ne"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Není k dispozici žádná historie stanic"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Šum"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "Odstup signál-šum"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Signál"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Historie stanic"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Tato stránka zobrazuje historii všech WiFi stanic, které se připojily k "
+"tomuto zařízení – těch připojených právě teď, ale i spatřených dříve."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Toto nevratně smaže veškerou zaznamenanou historii stanic. Opravdu to chcete?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Ano"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/de/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/de/wifihistory.po
@@ -1,0 +1,118 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-03-23 18:11+0000\n"
+"Last-Translator: HerbJul <19JulianHerbst95@web.de>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/de/>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Leeren"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Verlauf löschen"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Lösche Stationshistorie"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Verbunden"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Getrennt"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Zuerst gesehen"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Zugriff auf den Verlauf der WLAN-Standorte gewähren"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Host"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Zuletzt gesehen"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC-Adresse"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Netzwerk"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Nein"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Keine Stationsgeschichte verfügbar"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Rauschen"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Signal"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Staionsgeschichte"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Diese Seite zeigt eine Geschichte aller WLAN-Stationen, die sich mit diesem "
+"Gerät verbunden hatten, einschließlich aktuell angeschlossener und zuvor "
+"gesehener Geräte."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Dies wird den gesamten aufgezeichneten Stationsverlauf dauerhaft löschen. "
+"Sind sie sicher?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Ja"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/es/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/es/wifihistory.po
@@ -1,0 +1,118 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-06-27 12:02+0000\n"
+"Last-Translator: apemay <apemay.dev@gmail.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.7.dev0\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Limpiar"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Limpiar historial"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Limpiar el historial de la estación"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Conectado"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Desconectado"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Visto por primera vez"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Conceder acceso al historial de la estación WiFi"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Host"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Visto por última vez"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "Dirección MAC"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Red"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "No"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "No hay historial de estaciones disponible"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Ruido"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Señal"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Historial de la estación"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Esta página muestra un historial de todas las estaciones WiFi que se han "
+"conectado a este dispositivo, incluidos los dispositivos conectados "
+"actualmente y los vistos anteriormente."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Esto eliminará permanentemente todo el historial de estaciones grabadas. "
+"¿Estás seguro?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Sí"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/fr/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/fr/wifihistory.po
@@ -1,0 +1,113 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-04-29 11:04+0000\n"
+"Last-Translator: sllk <sillhack@hotmail.fr>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/fr/>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Annuler"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ga/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ga/wifihistory.po
@@ -1,0 +1,117 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-02-13 16:03+0000\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: Irish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/ga/>\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+"X-Generator: Weblate 5.16-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Cealaigh"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Glan"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Glan an Stair"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Glan Stair an Stáisiúin"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Ceangailte"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Dícheangailte"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Chonaic mé den chéad uair"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Deonaigh rochtain ar stair stáisiúin WiFi"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Óstach"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Chonaic mé an uair dheireanach"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "Seoladh MAC"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Líonra"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Níl"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Níl aon stair stáisiúin ar fáil"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Torann"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Comhartha"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Stair an Stáisiúin"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Taispeánann an leathanach seo stair na stáisiún WiFi uile atá ceangailte "
+"leis an ngléas seo, lena n-áirítear gléasanna atá ceangailte faoi láthair "
+"agus gléasanna a chonacthas roimhe seo."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Scriosfaidh sé seo stair an stáisiúin taifeadta go buan. An bhfuil tú cinnte?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Tá"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/ko/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ko/wifihistory.po
@@ -1,0 +1,115 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-04-20 17:56+0000\n"
+"Last-Translator: Hyeonjeong Lee <h9101654@gmail.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/ko/>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "취소"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "초기화"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "이력 삭제"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "단말 접속 이력 삭제"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "연결"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "연결 해제"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "최초 감지"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "WiFi 단말 접속 이력에 접근 권한 부여"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "호스트"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "최종 감지"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC 주소"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "네트워크"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "아니요"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "단말 접속 이력 없음"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "잡음"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "신호"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "단말 접속 이력"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"현재 연결된 장치 및 이전에 감지된 장치를 포함하여, 본 장치에 연결되었던 모든 "
+"WiFi 단말의 이력을 표시합니다."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr "기록된 모든 단말 접속 이력이 영구적으로 삭제됩니다. 계속하시겠습니까?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "예"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/lt/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/lt/wifihistory.po
@@ -1,0 +1,117 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-03-13 14:10+0000\n"
+"Last-Translator: Džiugas Januševičius <dziugas1959@hotmail.com>\n"
+"Language-Team: Lithuanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/lt/>\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Atšaukti"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Išvalyti"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Išvalyti istoriją"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Išvalyti stoties istoriją"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Prijungtas/-a"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Atjungtas/-a"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Pirmą kartą matytas"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Suteikti prieigą prie „WiFi“ stoties istorijos"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Skleidėjas/Vedėjas"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Paskutinį kartą matytas"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "„MAC“ adresas"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Tinklas"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Ne"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Nėra pasiekiamos stoties istorijos"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Triukšmas"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "„SNR“"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Signalas"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Stoties istorija"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Šiame puslapyje rodoma visų prie šio įrenginio prijungtų „Wi-Fi“ stočių "
+"istorija, įskaitant šiuo metu prijungtus ir anksčiau matytus įrenginius."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Tai visam laikui ištrins visą įrašytą stoties istoriją. Ar Jūs esate tikras?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Taip"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/pl/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/pl/wifihistory.po
@@ -1,0 +1,118 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-02-14 00:51+0000\n"
+"Last-Translator: Matthaiks <kitynska@gmail.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/pl/>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.16-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Wyczyść"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Wyczyść historię"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Wyczyść historię stacji"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Połączony"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Rozłączony"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Pierwszy raz widziany"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Udziel dostępu do historii stacji Wi-Fi"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Host"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Ostatnio widziany"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "Adres MAC"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Sieć"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Nie"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Brak historii stacji"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Szum"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Sygnał"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Historia stacji"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Ta strona wyświetla historię wszystkich stacji Wi-Fi, które łączyły się z "
+"tym urządzeniem — zarówno obecnie, jak i wcześniej podłączonych."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Spowoduje to trwałe usunięcie całej historii stacji. Czy na pewno chcesz to "
+"zrobić?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Tak"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/pt/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/pt/wifihistory.po
@@ -1,0 +1,117 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-05-07 13:14+0000\n"
+"Last-Translator: ssantos <ssantos@web.de>\n"
+"Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/pt/>\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17.1\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Limpar"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Limpar Histórico"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Limpar histórico da estação"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Conectado"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Desconectado"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Visto primeiro"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Conceder acesso ao histórico da estação WiFi"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Anfitrião"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Visto pela última vez"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "Endereço MAC"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Rede"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Não"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Sem histórico da estação disponível"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Ruído"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Sinal"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "História da estação"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Esta página exibe um histórico de todas as estações WiFi conectadas a este "
+"dispositivo, incluindo dispositivos conectados e previamente vistos."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Isto apagará permanentemente todo o histórico da estação registada. Tem "
+"certeza?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Sim"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/ro/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ro/wifihistory.po
@@ -1,0 +1,114 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-03-18 02:23+0000\n"
+"Last-Translator: CRISTIAN ANDREI <cristianvdr@gmail.com>\n"
+"Language-Team: Romanian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/ro/>\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Anulare"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Curățare"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/ru/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/ru/wifihistory.po
@@ -1,0 +1,117 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-04-25 03:13+0000\n"
+"Last-Translator: SnIPeRSnIPeR "
+"<snipersniper@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/ru/>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 5.17.1-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Отмена"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Сбросить"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Очистить историю"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Очистить историю станций"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Подключён"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Отключён"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Первое подключение"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Предоставить доступ к истории станций Wi‑Fi"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Хост"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Последнее подключение"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC-адрес"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Сеть"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Нет"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "История станций отсутствует"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Шум"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Сигнал"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "История станций"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"На этой странице отображается история всех станций Wi‑Fi, подключавшихся к "
+"устройству, включая текущие и ранее обнаруженные устройства."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr "Это безвозвратно удалит всю сохранённую историю станций. Продолжить?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Да"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/sv/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/sv/wifihistory.po
@@ -1,0 +1,118 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-02-14 00:51+0000\n"
+"Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
+"Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/sv/>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.16-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Rensa"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Rensa historiken"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Rensa stationshistoriken"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Ansluten"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Frånkopplad"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Sågs först"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Godkänn åtkomst till WiFi-stationens historik"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Värd"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Sågs senast"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC-adress"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Nätverk"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Nej"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Ingen stationshistorik tillgänglig"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Oljud"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Signal"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Stationshistorik"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Den här sidan visar en historik över alla WiFi-stationer som har anslutits "
+"till den här enheten, inklusive de som är anslutna just nu och enheter som "
+"nyss har setts."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+"Det här kommer att permanent ta bort all insamlad stationshistorik. Är du "
+"säker?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Ja"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/templates/wifihistory.pot
+++ b/applications/luci-app-wifihistory/po/templates/wifihistory.pot
@@ -1,0 +1,102 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/tr/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/tr/wifihistory.po
@@ -1,0 +1,113 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-04-12 14:28+0000\n"
+"Last-Translator: Yusuf Bekil <sempoonet@gmail.com>\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/tr/>\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Vazgeç"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr ""

--- a/applications/luci-app-wifihistory/po/uk/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/uk/wifihistory.po
@@ -1,0 +1,116 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-05-12 09:07+0000\n"
+"Last-Translator: Oleksandr Yurov <oyurov@icloud.com>\n"
+"Language-Team: Ukrainian <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswifihistory/uk/>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.5-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "Очистити"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "Очистити історію"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "Очистити історію станцій"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "Підключено"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "Відʼєднано"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "Перше виявлення"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "Надати доступ до історії WiFi-станцій"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "Вузол"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "Останнє виявлення"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC-адреса"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "Мережа"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "Ні"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "Історія станцій відсутня"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "Шум"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "Сигнал"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Історія станцій"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"Ця сторінка відображає історію всіх WiFi-станцій, що підключалися до цього "
+"пристрою, включно з підключеними наразі та раніше виявленими пристроями."
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr "Це остаточно видалить усю записану історію станцій. Ви впевнені?"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "Так"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "дБм"

--- a/applications/luci-app-wifihistory/po/zh_Hans/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/zh_Hans/wifihistory.po
@@ -1,0 +1,116 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-06-05 19:01+0000\n"
+"Last-Translator: 大王叫我来巡山 "
+"<hamburger2048@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationswifihistory/zh_Hans/>\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 2026.6\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "取消"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "清除"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "清除历史"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "清除客户端历史记录"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "已连接"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "已断开"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "首次连接时间"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "授予 WiFi 客户端历史记录的权限"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "主机"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "最后一次连接时间"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC 地址"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "网络"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "不"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "无客户端连接历史记录"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "噪声"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "信噪比"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "信号强度"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "WiFi 客户端历史记录"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"本页面展示所有连接过本设备的 WiFi 客户端历史记录，包括正在连接和曾经连接过的"
+"客户端。"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr "即将永久删除所有客户端连接历史记录。确定吗？"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "是"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"

--- a/applications/luci-app-wifihistory/po/zh_Hant/wifihistory.po
+++ b/applications/luci-app-wifihistory/po/zh_Hant/wifihistory.po
@@ -1,0 +1,115 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2026-04-14 04:13+0000\n"
+"Last-Translator: ZW <roc_fe@users.noreply.hosted.weblate.org>\n"
+"Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
+"projects/openwrt/luciapplicationswifihistory/zh_Hant/>\n"
+"Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:120
+msgid "Cancel"
+msgstr "取消"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:131
+msgid "Clear"
+msgstr "清除"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:150
+msgid "Clear History"
+msgstr "清除歷史"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:114
+msgid "Clear Station History"
+msgstr "清除連線歷史"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:155
+msgid "Connected"
+msgstr "已連線"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:96
+msgid "Disconnected"
+msgstr "已斷線"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:160
+msgid "First seen"
+msgstr "首次見到"
+
+#: applications/luci-app-wifihistory/root/usr/share/rpcd/acl.d/luci-app-wifihistory.json:3
+msgid "Grant access to WiFi station history"
+msgstr "授予存取 WiFi 連線歷史的權限"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:157
+msgid "Host"
+msgstr "主機"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:161
+msgid "Last seen"
+msgstr "最後見到"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:156
+msgid "MAC address"
+msgstr "MAC 位址"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:158
+msgid "Network"
+msgstr "網路"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "No"
+msgstr "否"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:110
+msgid "No station history available"
+msgstr "無連線歷史可用"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Noise"
+msgstr "雜訊"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:64
+msgid "SNR"
+msgstr "SNR"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:159
+msgid "Signal"
+msgstr "訊號"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:140
+#: applications/luci-app-wifihistory/root/usr/share/luci/menu.d/luci-app-wifihistory.json:3
+msgid "Station History"
+msgstr "Station History"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:142
+msgid ""
+"This page displays a history of all WiFi stations that have connected to "
+"this device, including currently connected and previously seen devices."
+msgstr ""
+"本頁顯示所有已連線到此裝置的 WiFi 網路的歷史記錄，包括目前已連線和先前看過的"
+"裝置。"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:115
+msgid ""
+"This will permanently delete all recorded station history. Are you sure?"
+msgstr "這將永久刪除所有已記錄的連線歷史。您確定嗎？"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:99
+msgid "Yes"
+msgstr "是"
+
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:60
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:62
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:63
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:67
+#: applications/luci-app-wifihistory/htdocs/luci-static/resources/view/status/wifihistory.js:68
+msgid "dBm"
+msgstr "dBm"


### PR DESCRIPTION
## Pull request details

### Description

Several LuCI apps got their first translations on master after the
openwrt-25.12 branch was cut. Their po directories never existed on the
branch, so the translation sync skipped them and no i18n packages were
built for them in the 25.12 release feed (#8796).

This backports the missing po files from master and syncs them against
the 25.12 source strings. Languages that exist on Weblate but carry no
actual translation are left out, as are three apps whose only language
was empty (luci-app-ledtrig-rssi, -switch, -usbport).

This will recur on the next branch cut, since the sync only updates po
files already present on the branch.

### Maintainer
@hnyman

---

## Checklist
- [x] This PR is not from my *main* or *master* branch, but a *separate* branch.
- [x] Each commit has a valid `Signed-off-by` row.
- [x] Each commit and PR title has a valid `<package name>: title` first line subject.
- [x] Includes what Issue it closes (openwrt/luci#8796).