### PR TITLE
luci-app-package-manager: count only one provider for alternative deps

### DIFF
--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -523,7 +523,7 @@ function versionSatisfied(ver, ref, vop)
 	return false;
 }
 
-function pkgStatus(pkg, vop, ver, info)
+function pkgStatus(pkg, vop, ver, info, count)
 {
 	info.errors = info.errors || [];
 	info.install = info.install || [];
@@ -559,7 +559,8 @@ function pkgStatus(pkg, vop, ver, info)
 	}
 	else if (!pkg.missing) {
 		if (!vop || versionSatisfied(pkg.version, ver, vop)) {
-			info.install.push(pkg);
+			if (count !== false)
+				info.install.push(pkg);
 			return E('span', { 'class': 'label' }, _('Not installed'));
 		}
 
@@ -586,6 +587,42 @@ function renderDependencyItem(dep, info, flat)
 	const ver = dep.version ? dep.version[1] : null;
 	const depends = [];
 
+	// A dependency with several providers (alternatives) is satisfied by any
+	// single one of them, so apk only ever installs one. Mirror the apk
+	// solver's provider selection - an already installed one, otherwise the
+	// available one with the highest provider-priority, otherwise the first
+	// available one - and count only that towards the size estimate and
+	// subdependencies instead of every alternative.
+	let effective = -1;
+
+	for (let i = 0; dep.pkgs && i < dep.pkgs.length; i++) {
+		if (isPkgInstalled(packages.installed.pkgs[dep.pkgs[i]])) {
+			effective = i;
+			break;
+		}
+	}
+
+	const satisfied = effective >= 0;
+
+	if (!satisfied && dep.pkgs && dep.pkgs.length) {
+		let prio = null;
+
+		for (let i = 0; i < dep.pkgs.length; i++) {
+			const p = packages.available.pkgs[dep.pkgs[i]];
+			if (!p)
+				continue;
+
+			const pprio = Number(p['provider-priority']) || 0;
+			if (prio === null || pprio > prio) {
+				effective = i;
+				prio = pprio;
+			}
+		}
+
+		if (effective < 0)
+			effective = 0;
+	}
+
 	for (let i = 0; dep.pkgs && i < dep.pkgs.length; i++) {
 		const pkg = packages.installed.pkgs[dep.pkgs[i]] ||
 		          packages.available.pkgs[dep.pkgs[i]] ||
@@ -602,12 +639,13 @@ function renderDependencyItem(dep, info, flat)
 			text += ' (~%1024mB)'.format(pkg.size);
 
 		li.appendChild(E('span', { 'data-tooltip': pkg.description },
-			[ text, ' ', pkgStatus(pkg, vop, ver, info) ]));
+			[ text, ' ', pkgStatus(pkg, vop, ver, info, !satisfied && i === effective) ]));
 
-		(pkg.depends || []).forEach(function(d) {
-			if (depends.indexOf(d) === -1)
-				depends.push(d);
-		});
+		if (i === effective)
+			(pkg.depends || []).forEach(function(d) {
+				if (depends.indexOf(d) === -1)
+					depends.push(d);
+			});
 	}
 
 	if (!li.firstChild)


### PR DESCRIPTION
## Pull request details

### Description

Fixes #8411.

When a package depends on a virtual name with several providers (for example a dependency on `wget-any`, provided by `wget-ssl`, `wget-nossl` and `uclient-fetch`), the dependency details listed every provider and added each one to the download size estimate and the subdependency tree. apk installs only a single provider, so the size was overstated, and once one provider was already installed the dependency still showed the others as pending.

This picks one effective provider per dependency, an installed one if present, otherwise the first, and counts only that towards the size estimate and subdependencies. The install command is unchanged: it passes the target package to apk, which resolves providers itself, so `info.install` only ever drove the displayed estimate.

When no provider is installed yet the first one is used as the estimate. The exact provider apk would pick is not reproduced, since that would mean duplicating its preference rules, but the estimate now reflects a single provider instead of the sum of all of them.

### Maintainer
@jow-

---

## Tested on

Not tested on a device. The dependency selection and size accounting (`renderDependencies`, `renderDependencyItem`, `pkgStatus`) were run headless against fixtures shaped like the internal package model, using the reporter's `apk-mbedtls` -> `wget-any` case:

- nothing installed: before counted all three providers, now counts one
- a provider already installed: before still counted the remaining two, now counts none
- single-provider dependency chains: unchanged

eslint passes on the changed file.

---

## Checklist
- [x] This PR is not from my *main* or *master* branch, but a *separate* branch.
- [x] Each commit has a valid `Signed-off-by` row.
- [x] Each commit and PR title has a valid `<package name>: title` first line subject.
- [x] Includes what Issue it closes (openwrt/luci#8411).