### PR TITLE
luci-proto-xfrm: replace ifid datatype check with range check

### DIFF
--- a/protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js
+++ b/protocols/luci-proto-xfrm/htdocs/luci-static/resources/protocol/xfrm.js
@@ -37,7 +37,8 @@ return network.registerProtocol('xfrm', {
 		var o, ss;
 
 		o = s.taboption('general', form.Value, 'ifid', _('Interface ID'), _('Required. XFRM interface ID to be used for SA.'));
-		o.datatype = 'integer';
+		o.datatype = 'range(1,4294967295)';
+		o.rmempty = false;
 
 		o = s.taboption('general', widgets.NetworkSelect, 'tunlink', _('Underlying interface'),_('Optional. Bind to a specific interface.'));
 		o.exclude = s.section;


### PR DESCRIPTION
## Pull request details

### Description
According to the documentation, values from '1' to '4294967295' are allowed values for the 'ifid' option. The value ‘0’ is excluded, as '0' is treated as the default ID or an unassigned ID.

While we’re at it, mark the option as non-optional.


### Maintainer _(preferred)_
@hgl 

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch. :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`).
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages.

