### PR TITLE
luci-proto-wireguard: pre-fill peer addresses

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -723,6 +723,10 @@ return network.registerProtocol('wireguard', {
 						if (next && !next.error) {
 							if (next.ipv4) eips.push(next.ipv4);
 							if (next.ipv6) eips.push(next.ipv6);
+							// Write the allocated addresses back as allowed_ips so the
+							// server-side peer entry is complete without a manual edit.
+							uci.set('network', section_id, 'allowed_ips', eips);
+							return parent.save(null, true);
 						}
 					}).then(function() {
 						const hostnames = [];

--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -28,6 +28,13 @@ var generatePsk = rpc.declare({
 	expect: { psk: '' }
 });
 
+var getNextPeerAddress = rpc.declare({
+	object: 'luci.wireguard',
+	method: 'getNextPeerAddress',
+	params: ['interface'],
+	expect: {}
+});
+
 var qrIcon = '<svg viewBox="0 0 29 29" xmlns="http://www.w3.org/2000/svg"><path fill="#fff" d="M0 0h29v29H0z"/><path d="M4 4h1v1H4zM5 4h1v1H5zM6 4h1v1H6zM7 4h1v1H7zM8 4h1v1H8zM9 4h1v1H9zM10 4h1v1h-1zM12 4h1v1h-1zM13 4h1v1h-1zM14 4h1v1h-1zM15 4h1v1h-1zM16 4h1v1h-1zM18 4h1v1h-1zM19 4h1v1h-1zM20 4h1v1h-1zM21 4h1v1h-1zM22 4h1v1h-1zM23 4h1v1h-1zM24 4h1v1h-1zM4 5h1v1H4zM10 5h1v1h-1zM12 5h1v1h-1zM14 5h1v1h-1zM16 5h1v1h-1zM18 5h1v1h-1zM24 5h1v1h-1zM4 6h1v1H4zM6 6h1v1H6zM7 6h1v1H7zM8 6h1v1H8zM10 6h1v1h-1zM12 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM21 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM4 7h1v1H4zM6 7h1v1H6zM7 7h1v1H7zM8 7h1v1H8zM10 7h1v1h-1zM12 7h1v1h-1zM13 7h1v1h-1zM14 7h1v1h-1zM15 7h1v1h-1zM18 7h1v1h-1zM20 7h1v1h-1zM21 7h1v1h-1zM22 7h1v1h-1zM24 7h1v1h-1zM4 8h1v1H4zM6 8h1v1H6zM7 8h1v1H7zM8 8h1v1H8zM10 8h1v1h-1zM16 8h1v1h-1zM18 8h1v1h-1zM20 8h1v1h-1zM21 8h1v1h-1zM22 8h1v1h-1zM24 8h1v1h-1zM4 9h1v1H4zM10 9h1v1h-1zM12 9h1v1h-1zM13 9h1v1h-1zM15 9h1v1h-1zM18 9h1v1h-1zM24 9h1v1h-1zM4 10h1v1H4zM5 10h1v1H5zM6 10h1v1H6zM7 10h1v1H7zM8 10h1v1H8zM9 10h1v1H9zM10 10h1v1h-1zM12 10h1v1h-1zM14 10h1v1h-1zM16 10h1v1h-1zM18 10h1v1h-1zM19 10h1v1h-1zM20 10h1v1h-1zM21 10h1v1h-1zM22 10h1v1h-1zM23 10h1v1h-1zM24 10h1v1h-1zM13 11h1v1h-1zM14 11h1v1h-1zM15 11h1v1h-1zM16 11h1v1h-1zM4 12h1v1H4zM5 12h1v1H5zM8 12h1v1H8zM9 12h1v1H9zM10 12h1v1h-1zM13 12h1v1h-1zM15 12h1v1h-1zM19 12h1v1h-1zM21 12h1v1h-1zM22 12h1v1h-1zM23 12h1v1h-1zM24 12h1v1h-1zM5 13h1v1H5zM6 13h1v1H6zM8 13h1v1H8zM11 13h1v1h-1zM13 13h1v1h-1zM14 13h1v1h-1zM15 13h1v1h-1zM16 13h1v1h-1zM19 13h1v1h-1zM22 13h1v1h-1zM4 14h1v1H4zM5 14h1v1H5zM9 14h1v1H9zM10 14h1v1h-1zM11 14h1v1h-1zM15 14h1v1h-1zM18 14h1v1h-1zM19 14h1v1h-1zM20 14h1v1h-1zM21 14h1v1h-1zM22 14h1v1h-1zM23 14h1v1h-1zM7 15h1v1H7zM8 15h1v1H8zM9 15h1v1H9zM11 15h1v1h-1zM12 15h1v1h-1zM13 15h1v1h-1zM17 15h1v1h-1zM18 15h1v1h-1zM20 15h1v1h-1zM21 15h1v1h-1zM23 15h1v1h-1zM4 16h1v1H4zM6 16h1v1H6zM10 16h1v1h-1zM11 16h1v1h-1zM13 16h1v1h-1zM14 16h1v1h-1zM16 16h1v1h-1zM17 16h1v1h-1zM18 16h1v1h-1zM22 16h1v1h-1zM23 16h1v1h-1zM24 16h1v1h-1zM12 17h1v1h-1zM16 17h1v1h-1zM17 17h1v1h-1zM18 17h1v1h-1zM4 18h1v1H4zM5 18h1v1H5zM6 18h1v1H6zM7 18h1v1H7zM8 18h1v1H8zM9 18h1v1H9zM10 18h1v1h-1zM14 18h1v1h-1zM16 18h1v1h-1zM17 18h1v1h-1zM21 18h1v1h-1zM22 18h1v1h-1zM23 18h1v1h-1zM4 19h1v1H4zM10 19h1v1h-1zM12 19h1v1h-1zM13 19h1v1h-1zM15 19h1v1h-1zM16 19h1v1h-1zM19 19h1v1h-1zM21 19h1v1h-1zM23 19h1v1h-1zM24 19h1v1h-1zM4 20h1v1H4zM6 20h1v1H6zM7 20h1v1H7zM8 20h1v1H8zM10 20h1v1h-1zM12 20h1v1h-1zM13 20h1v1h-1zM15 20h1v1h-1zM18 20h1v1h-1zM19 20h1v1h-1zM20 20h1v1h-1zM22 20h1v1h-1zM23 20h1v1h-1zM24 20h1v1h-1zM4 21h1v1H4zM6 21h1v1H6zM7 21h1v1H7zM8 21h1v1H8zM10 21h1v1h-1zM13 21h1v1h-1zM15 21h1v1h-1zM16 21h1v1h-1zM19 21h1v1h-1zM21 21h1v1h-1zM23 21h1v1h-1zM24 21h1v1h-1zM4 22h1v1H4zM6 22h1v1H6zM7 22h1v1H7zM8 22h1v1H8zM10 22h1v1h-1zM13 22h1v1h-1zM15 22h1v1h-1zM18 22h1v1h-1zM19 22h1v1h-1zM20 22h1v1h-1zM21 22h1v1h-1zM22 22h1v1h-1zM4 23h1v1H4zM10 23h1v1h-1zM12 23h1v1h-1zM13 23h1v1h-1zM14 23h1v1h-1zM17 23h1v1h-1zM18 23h1v1h-1zM20 23h1v1h-1zM22 23h1v1h-1zM4 24h1v1H4zM5 24h1v1H5zM6 24h1v1H6zM7 24h1v1H7zM8 24h1v1H8zM9 24h1v1H9zM10 24h1v1h-1zM12 24h1v1h-1zM13 24h1v1h-1zM14 24h1v1h-1zM16 24h1v1h-1zM17 24h1v1h-1zM18 24h1v1h-1zM22 24h1v1h-1zM24 24h1v1h-1z"/></svg>';
 
 function validateBase64(section_id, value) {
@@ -696,7 +703,7 @@ return network.registerProtocol('wireguard', {
 			const headNode = mapNode.parentNode.querySelector('h4');
 			const configGenerator = this.createPeerConfig.bind(this, section_id);
 			const parent = this.map;
-			const eips = this.section.formvalue(section_id, 'allowed_ips');
+			const peerSection = this.section;
 
 			return Promise.all([
 				network.getWANNetworks(),
@@ -706,179 +713,192 @@ return network.registerProtocol('wireguard', {
 				L.resolveDefault(uci.load('system')),
 				parent.save(null, true)
 			]).then(function([wNets, w6Nets, lnet]) {
-				const hostnames = [];
+				// Read allowed_ips via cfgvalue() after the save has committed form
+				// state. For existing peers this gives their tunnel address; for new
+				// peers (no IPs set) we fall through to next-address allocation.
+				let eips = L.toArray(peerSection.cfgvalue(section_id, 'allowed_ips'));
 
-				uci.sections('ddns', 'service', function(s) {
-					if (typeof(s?.lookup_host) == 'string' && s?.enabled == '1')
-						hostnames.push(s.lookup_host);
-				});
+				return (eips.length ? Promise.resolve(null) : getNextPeerAddress(s.section))
+					.then(function(next) {
+						if (next && !next.error) {
+							if (next.ipv4) eips.push(next.ipv4);
+							if (next.ipv6) eips.push(next.ipv6);
+						}
+					}).then(function() {
+						const hostnames = [];
 
-				uci.sections('system', 'system', function(s) {
-					if (typeof(s?.hostname) == 'string' && s?.hostname?.indexOf('.') > 0)
-						hostnames.push(s.hostname);
-				});
+						uci.sections('ddns', 'service', function(s) {
+							if (typeof(s?.lookup_host) == 'string' && s?.enabled == '1')
+								hostnames.push(s.lookup_host);
+						});
 
-				for (let wNet of wNets)
-					hostnames.push.apply(hostnames, wNet.getIPAddrs().map(function(ip) { return ip.split('/')[0] }));
+						uci.sections('system', 'system', function(s) {
+							if (typeof(s?.hostname) == 'string' && s?.hostname?.indexOf('.') > 0)
+								hostnames.push(s.hostname);
+						});
 
-				for (let w6Net of w6Nets)
-					hostnames.push.apply(hostnames, w6Net.getIP6Addrs().map(function(ip) { return ip.split('/')[0] }));
+						for (let wNet of wNets)
+							hostnames.push.apply(hostnames, wNet.getIPAddrs().map(function(ip) { return ip.split('/')[0] }));
 
-				const ips = [ '0.0.0.0/0', '::/0' ];
+						for (let w6Net of w6Nets)
+							hostnames.push.apply(hostnames, w6Net.getIP6Addrs().map(function(ip) { return ip.split('/')[0] }));
 
-				const dns = [];
+						const ips = [ '0.0.0.0/0', '::/0' ];
 
-				if (lnet) {
-					const lanIp = lnet.getIPAddr();
-					if (lanIp) {
-						dns.unshift(lanIp)
-					}
-				}
+						const dns = [];
 
-				let qrm, qrs, qro;
-
-				qrm = new form.JSONMap({ config: { endpoint: hostnames[0] || '', allowed_ips: ips, addresses: eips, dns_servers: dns } }, null, _('The generated configuration can be imported into a WireGuard client application to set up a connection towards this device.'));
-				qrm.parent = parent;
-
-				qrs = qrm.section(form.NamedSection, 'config');
-
-				function handleConfigChange(ev, section_id, value) {
-					const code = this.map.findElement('.qr-code');
-					const conf = this.map.findElement('.client-config');
-					const endpoint = this.section.getUIElement(section_id, 'endpoint');
-					const ips = this.section.getUIElement(section_id, 'allowed_ips');
-					const eips = this.section.getUIElement(section_id, 'addresses');
-					const dns = this.section.getUIElement(section_id, 'dns_servers');
-
-					if (this.isValid(section_id)) {
-						conf.firstChild.data = configGenerator(endpoint.getValue(), ips.getValue(), eips.getValue(), dns.getValue());
-						code.style.opacity = '.5';
-
-						buildSVGQRCode(conf.firstChild.data, code);
-					}
-				};
-
-				qro = qrs.option(form.Value, 'endpoint', _('Connection endpoint'), _('The public hostname or IP address of this system the peer should connect to. This usually is a static public IP address, a static hostname or a DDNS domain.'));
-				qro.datatype = 'or(ipaddr,hostname)';
-				hostnames.forEach(function(hostname) { qro.value(hostname) });
-				qro.onchange = handleConfigChange;
-
-				qro = qrs.option(form.DynamicList, 'allowed_ips', _('Allowed IPs'), _('IP addresses that are allowed inside the tunnel. The peer will accept tunnelled packets with source IP addresses matching this list and route back packets with matching destination IP.'));
-				qro.datatype = 'ipaddr';
-				qro.default = ips;
-				ips.forEach(function(ip) { qro.value(ip) });
-				qro.onchange = handleConfigChange;
-
-				qro = qrs.option(form.DynamicList, 'dns_servers', _('DNS Servers'), _('DNS servers for the remote clients using this tunnel to your openwrt device. Some wireguard clients require this to be set.'));
-				qro.datatype = 'ipaddr';
-				qro.default = dns;
-				qro.onchange = handleConfigChange;
-
-				qro = qrs.option(form.DynamicList, 'addresses', _('Addresses'), _('IP addresses for the peer to use inside the tunnel. Some clients require this setting.'));
-				qro.datatype = 'ipaddr';
-				qro.default = eips;
-				eips.forEach(function(eip) { qro.value(eip) });
-				qro.onchange = handleConfigChange;
-
-				qro = qrs.option(form.DummyValue, 'output');
-				qro.renderWidget = function() {
-					const peer_config = configGenerator(hostnames[0], ips, eips, dns);
-
-					const node = E('div', {
-						'style': 'display:flex;flex-wrap:wrap;align-items:center;gap:.5em;width:100%'
-					}, [
-						E('div', {
-							'class': 'qr-code',
-							'style': 'width:320px;flex:0 1 320px;text-align:center'
-						}, [
-							E('em', { 'class': 'spinning' }, [ _('Generating QR code…') ])
-						]),
-						E('pre', {
-							'class': 'client-config',
-							'style': 'flex:1;white-space:pre;overflow:auto',
-							'click'(ev) {
-								const sel = window.getSelection();
-								const range = document.createRange();
-
-								range.selectNodeContents(ev.currentTarget);
-
-								sel.removeAllRanges();
-								sel.addRange(range);
+						if (lnet) {
+							const lanIp = lnet.getIPAddr();
+							if (lanIp) {
+								dns.unshift(lanIp)
 							}
-						}, [ peer_config ])
-					]);
+						}
 
-					const linkdiv = E('div', {
-						'style': 'width:100%;text-align:center'
-					}, [
-						E('button', {
-							'class': 'btn',
-							'click'(ev) {
-								ev.preventDefault();
+						let qrm, qrs, qro;
 
-								const blob = new Blob([peer_config], { type: 'text/plain' });
-								const url = URL.createObjectURL(blob);
-								const a = document.createElement('a');
+						qrm = new form.JSONMap({ config: { endpoint: hostnames[0] || '', allowed_ips: ips, addresses: eips, dns_servers: dns } }, null, _('The generated configuration can be imported into a WireGuard client application to set up a connection towards this device.'));
+						qrm.parent = parent;
 
-								a.href = url;
-								a.download = 'wireguard-peer.conf';
-								document.body.appendChild(a);
-								a.click();
-								document.body.removeChild(a);
-								URL.revokeObjectURL(url);
+						qrs = qrm.section(form.NamedSection, 'config');
+
+						function handleConfigChange(ev, section_id, value) {
+							const code = this.map.findElement('.qr-code');
+							const conf = this.map.findElement('.client-config');
+							const endpoint = this.section.getUIElement(section_id, 'endpoint');
+							const ips = this.section.getUIElement(section_id, 'allowed_ips');
+							const eips = this.section.getUIElement(section_id, 'addresses');
+							const dns = this.section.getUIElement(section_id, 'dns_servers');
+
+							if (this.isValid(section_id)) {
+								conf.firstChild.data = configGenerator(endpoint.getValue(), ips.getValue(), eips.getValue(), dns.getValue());
+								code.style.opacity = '.5';
+
+								buildSVGQRCode(conf.firstChild.data, code);
 							}
-						}, [ _('Download peer configuration file') ])
-					]);
+						};
 
-					buildSVGQRCode(peer_config, node.firstChild);
-					node.appendChild(linkdiv);
+						qro = qrs.option(form.Value, 'endpoint', _('Connection endpoint'), _('The public hostname or IP address of this system the peer should connect to. This usually is a static public IP address, a static hostname or a DDNS domain.'));
+						qro.datatype = 'or(ipaddr,hostname)';
+						hostnames.forEach(function(hostname) { qro.value(hostname) });
+						qro.onchange = handleConfigChange;
 
-					return node;
-				};
+						qro = qrs.option(form.DynamicList, 'allowed_ips', _('Allowed IPs'), _('IP addresses that are allowed inside the tunnel. The peer will accept tunnelled packets with source IP addresses matching this list and route back packets with matching destination IP.'));
+						qro.datatype = 'ipaddr';
+						qro.default = ips;
+						ips.forEach(function(ip) { qro.value(ip) });
+						qro.onchange = handleConfigChange;
 
-				return qrm.render().then(function(nodes) {
-					// stash the current dialogue style (visible)
-					const dStyle = mapNode.style;
-					// hide the current modal window
-					mapNode.style.display = 'none';
-					// stash the current button row style (visible)
-					const bRowStyle = mapNode.nextElementSibling.style;
-					// hide the [ Dismiss | Save ] button row
-					mapNode.nextElementSibling.style.display = 'none';
+						qro = qrs.option(form.DynamicList, 'dns_servers', _('DNS Servers'), _('DNS servers for the remote clients using this tunnel to your openwrt device. Some wireguard clients require this to be set.'));
+						qro.datatype = 'ipaddr';
+						qro.default = dns;
+						qro.onchange = handleConfigChange;
 
-					headNode.appendChild(E('span', [ ' » ', _('Generate configuration') ]));
-					mapNode.parentNode.appendChild(E([], [
-						nodes,
-						E('div', {
-							'class': 'right'
-						}, [
-							E('button', {
-								'class': 'btn',
-								'click'() {
-									// Remove QR code button (row)
-									nodes.parentNode.removeChild(nodes.nextSibling);
-									// Remove QR code form
-									nodes.parentNode.removeChild(nodes);
-									// unhide the WiFi modal dialogue
-									mapNode.style = dStyle;
-									// Revert button row style to visible again
-									mapNode.nextSibling.style = bRowStyle;
-									// Remove the H4 span (») title
-									headNode.removeChild(headNode.lastChild);
-								}
-							}, [ _('Back to peer configuration') ])
-						])
-					]));
+						qro = qrs.option(form.DynamicList, 'addresses', _('Addresses'), _('IP addresses for the peer to use inside the tunnel. Some clients require this setting.'));
+						qro.datatype = 'ipaddr';
+						qro.default = eips;
+						eips.forEach(function(eip) { qro.value(eip) });
+						qro.onchange = handleConfigChange;
 
-					if (!s.formvalue(s.section, 'listen_port')) {
-						nodes.appendChild(E('div', { 'class': 'alert-message' }, [
-							E('p', [
-								_('No fixed interface listening port defined, peers might not be able to initiate connections to this WireGuard instance!')
-							])
-						]));
-					}
-				});
-			});
+						qro = qrs.option(form.DummyValue, 'output');
+						qro.renderWidget = function() {
+							const peer_config = configGenerator(hostnames[0], ips, eips, dns);
+
+							const node = E('div', {
+								'style': 'display:flex;flex-wrap:wrap;align-items:center;gap:.5em;width:100%'
+							}, [
+								E('div', {
+									'class': 'qr-code',
+									'style': 'width:320px;flex:0 1 320px;text-align:center'
+								}, [
+									E('em', { 'class': 'spinning' }, [ _('Generating QR code…') ])
+								]),
+								E('pre', {
+									'class': 'client-config',
+									'style': 'flex:1;white-space:pre;overflow:auto',
+									'click'(ev) {
+										const sel = window.getSelection();
+										const range = document.createRange();
+
+										range.selectNodeContents(ev.currentTarget);
+
+										sel.removeAllRanges();
+										sel.addRange(range);
+									}
+								}, [ peer_config ])
+							]);
+
+							const linkdiv = E('div', {
+								'style': 'width:100%;text-align:center'
+							}, [
+								E('button', {
+									'class': 'btn',
+									'click'(ev) {
+										ev.preventDefault();
+
+										const blob = new Blob([peer_config], { type: 'text/plain' });
+										const url = URL.createObjectURL(blob);
+										const a = document.createElement('a');
+
+										a.href = url;
+										a.download = 'wireguard-peer.conf';
+										document.body.appendChild(a);
+										a.click();
+										document.body.removeChild(a);
+										URL.revokeObjectURL(url);
+									}
+								}, [ _('Download peer configuration file') ])
+							]);
+
+							buildSVGQRCode(peer_config, node.firstChild);
+							node.appendChild(linkdiv);
+
+							return node;
+						};
+
+						return qrm.render().then(function(nodes) {
+							// stash the current dialogue style (visible)
+							const dStyle = mapNode.style;
+							// hide the current modal window
+							mapNode.style.display = 'none';
+							// stash the current button row style (visible)
+							const bRowStyle = mapNode.nextElementSibling.style;
+							// hide the [ Dismiss | Save ] button row
+							mapNode.nextElementSibling.style.display = 'none';
+
+							headNode.appendChild(E('span', [ ' » ', _('Generate configuration') ]));
+							mapNode.parentNode.appendChild(E([], [
+								nodes,
+								E('div', {
+									'class': 'right'
+								}, [
+									E('button', {
+										'class': 'btn',
+										'click'() {
+											// Remove QR code button (row)
+											nodes.parentNode.removeChild(nodes.nextSibling);
+											// Remove QR code form
+											nodes.parentNode.removeChild(nodes);
+											// unhide the WiFi modal dialogue
+											mapNode.style = dStyle;
+											// Revert button row style to visible again
+											mapNode.nextSibling.style = bRowStyle;
+											// Remove the H4 span (») title
+											headNode.removeChild(headNode.lastChild);
+										}
+									}, [ _('Back to peer configuration') ])
+								])
+							]));
+
+							if (!s.formvalue(s.section, 'listen_port')) {
+								nodes.appendChild(E('div', { 'class': 'alert-message' }, [
+									E('p', [
+										_('No fixed interface listening port defined, peers might not be able to initiate connections to this WireGuard instance!')
+									])
+								]));
+							}
+						});
+					}); // end address resolution
+				}); // end Promise.all
 		};
 
 		o.cfgvalue = function(section_id, value) {

--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -31,9 +31,13 @@ var generatePsk = rpc.declare({
 var getNextPeerAddress = rpc.declare({
 	object: 'luci.wireguard',
 	method: 'getNextPeerAddress',
-	params: ['interface'],
+	params: ['interface', 'reserved'],
 	expect: {}
 });
+
+// Octets allocated this page session but not yet committed to UCI,
+// so back-to-back peer creation doesn't produce duplicate addresses.
+var _sessionReserved = [];
 
 var qrIcon = '<svg viewBox="0 0 29 29" xmlns="http://www.w3.org/2000/svg"><path fill="#fff" d="M0 0h29v29H0z"/><path d="M4 4h1v1H4zM5 4h1v1H5zM6 4h1v1H6zM7 4h1v1H7zM8 4h1v1H8zM9 4h1v1H9zM10 4h1v1h-1zM12 4h1v1h-1zM13 4h1v1h-1zM14 4h1v1h-1zM15 4h1v1h-1zM16 4h1v1h-1zM18 4h1v1h-1zM19 4h1v1h-1zM20 4h1v1h-1zM21 4h1v1h-1zM22 4h1v1h-1zM23 4h1v1h-1zM24 4h1v1h-1zM4 5h1v1H4zM10 5h1v1h-1zM12 5h1v1h-1zM14 5h1v1h-1zM16 5h1v1h-1zM18 5h1v1h-1zM24 5h1v1h-1zM4 6h1v1H4zM6 6h1v1H6zM7 6h1v1H7zM8 6h1v1H8zM10 6h1v1h-1zM12 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM21 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM4 7h1v1H4zM6 7h1v1H6zM7 7h1v1H7zM8 7h1v1H8zM10 7h1v1h-1zM12 7h1v1h-1zM13 7h1v1h-1zM14 7h1v1h-1zM15 7h1v1h-1zM18 7h1v1h-1zM20 7h1v1h-1zM21 7h1v1h-1zM22 7h1v1h-1zM24 7h1v1h-1zM4 8h1v1H4zM6 8h1v1H6zM7 8h1v1H7zM8 8h1v1H8zM10 8h1v1h-1zM16 8h1v1h-1zM18 8h1v1h-1zM20 8h1v1h-1zM21 8h1v1h-1zM22 8h1v1h-1zM24 8h1v1h-1zM4 9h1v1H4zM10 9h1v1h-1zM12 9h1v1h-1zM13 9h1v1h-1zM15 9h1v1h-1zM18 9h1v1h-1zM24 9h1v1h-1zM4 10h1v1H4zM5 10h1v1H5zM6 10h1v1H6zM7 10h1v1H7zM8 10h1v1H8zM9 10h1v1H9zM10 10h1v1h-1zM12 10h1v1h-1zM14 10h1v1h-1zM16 10h1v1h-1zM18 10h1v1h-1zM19 10h1v1h-1zM20 10h1v1h-1zM21 10h1v1h-1zM22 10h1v1h-1zM23 10h1v1h-1zM24 10h1v1h-1zM13 11h1v1h-1zM14 11h1v1h-1zM15 11h1v1h-1zM16 11h1v1h-1zM4 12h1v1H4zM5 12h1v1H5zM8 12h1v1H8zM9 12h1v1H9zM10 12h1v1h-1zM13 12h1v1h-1zM15 12h1v1h-1zM19 12h1v1h-1zM21 12h1v1h-1zM22 12h1v1h-1zM23 12h1v1h-1zM24 12h1v1h-1zM5 13h1v1H5zM6 13h1v1H6zM8 13h1v1H8zM11 13h1v1h-1zM13 13h1v1h-1zM14 13h1v1h-1zM15 13h1v1h-1zM16 13h1v1h-1zM19 13h1v1h-1zM22 13h1v1h-1zM4 14h1v1H4zM5 14h1v1H5zM9 14h1v1H9zM10 14h1v1h-1zM11 14h1v1h-1zM15 14h1v1h-1zM18 14h1v1h-1zM19 14h1v1h-1zM20 14h1v1h-1zM21 14h1v1h-1zM22 14h1v1h-1zM23 14h1v1h-1zM7 15h1v1H7zM8 15h1v1H8zM9 15h1v1H9zM11 15h1v1h-1zM12 15h1v1h-1zM13 15h1v1h-1zM17 15h1v1h-1zM18 15h1v1h-1zM20 15h1v1h-1zM21 15h1v1h-1zM23 15h1v1h-1zM4 16h1v1H4zM6 16h1v1H6zM10 16h1v1h-1zM11 16h1v1h-1zM13 16h1v1h-1zM14 16h1v1h-1zM16 16h1v1h-1zM17 16h1v1h-1zM18 16h1v1h-1zM22 16h1v1h-1zM23 16h1v1h-1zM24 16h1v1h-1zM12 17h1v1h-1zM16 17h1v1h-1zM17 17h1v1h-1zM18 17h1v1h-1zM4 18h1v1H4zM5 18h1v1H5zM6 18h1v1H6zM7 18h1v1H7zM8 18h1v1H8zM9 18h1v1H9zM10 18h1v1h-1zM14 18h1v1h-1zM16 18h1v1h-1zM17 18h1v1h-1zM21 18h1v1h-1zM22 18h1v1h-1zM23 18h1v1h-1zM4 19h1v1H4zM10 19h1v1h-1zM12 19h1v1h-1zM13 19h1v1h-1zM15 19h1v1h-1zM16 19h1v1h-1zM19 19h1v1h-1zM21 19h1v1h-1zM23 19h1v1h-1zM24 19h1v1h-1zM4 20h1v1H4zM6 20h1v1H6zM7 20h1v1H7zM8 20h1v1H8zM10 20h1v1h-1zM12 20h1v1h-1zM13 20h1v1h-1zM15 20h1v1h-1zM18 20h1v1h-1zM19 20h1v1h-1zM20 20h1v1h-1zM22 20h1v1h-1zM23 20h1v1h-1zM24 20h1v1h-1zM4 21h1v1H4zM6 21h1v1H6zM7 21h1v1H7zM8 21h1v1H8zM10 21h1v1h-1zM13 21h1v1h-1zM15 21h1v1h-1zM16 21h1v1h-1zM19 21h1v1h-1zM21 21h1v1h-1zM23 21h1v1h-1zM24 21h1v1h-1zM4 22h1v1H4zM6 22h1v1H6zM7 22h1v1H7zM8 22h1v1H8zM10 22h1v1h-1zM13 22h1v1h-1zM15 22h1v1h-1zM18 22h1v1h-1zM19 22h1v1h-1zM20 22h1v1h-1zM21 22h1v1h-1zM22 22h1v1h-1zM4 23h1v1H4zM10 23h1v1h-1zM12 23h1v1h-1zM13 23h1v1h-1zM14 23h1v1h-1zM17 23h1v1h-1zM18 23h1v1h-1zM20 23h1v1h-1zM22 23h1v1h-1zM4 24h1v1H4zM5 24h1v1H5zM6 24h1v1H6zM7 24h1v1H7zM8 24h1v1H8zM9 24h1v1H9zM10 24h1v1h-1zM12 24h1v1h-1zM13 24h1v1h-1zM14 24h1v1h-1zM16 24h1v1h-1zM17 24h1v1h-1zM18 24h1v1h-1zM22 24h1v1h-1zM24 24h1v1h-1z"/></svg>';
 
@@ -718,15 +722,20 @@ return network.registerProtocol('wireguard', {
 				// peers (no IPs set) we fall through to next-address allocation.
 				let eips = L.toArray(peerSection.cfgvalue(section_id, 'allowed_ips'));
 
-				return (eips.length ? Promise.resolve(null) : getNextPeerAddress(s.section))
+				return (eips.length ? Promise.resolve(null) : getNextPeerAddress(s.section, _sessionReserved))
 					.then(function(next) {
 						if (next && !next.error) {
 							if (next.ipv4) eips.push(next.ipv4);
 							if (next.ipv6) eips.push(next.ipv6);
+							// Remember this octet for the lifetime of the page so a
+							// second peer allocation in the same session skips it.
+							_sessionReserved.push(next.octet);
 							// Write the allocated addresses back as allowed_ips so the
 							// server-side peer entry is complete without a manual edit.
+							// Use uci.save() directly: parent.save() re-reads the DOM
+							// (where allowed_ips is still empty) and would overwrite us.
 							uci.set('network', section_id, 'allowed_ips', eips);
-							return parent.save(null, true);
+							return uci.save();
 						}
 					}).then(function() {
 						const hostnames = [];
@@ -891,6 +900,10 @@ return network.registerProtocol('wireguard', {
 											mapNode.nextSibling.style = bRowStyle;
 											// Remove the H4 span (») title
 											headNode.removeChild(headNode.lastChild);
+											// Sync the allowed_ips widget with what we wrote
+											// to UCI so a subsequent Save doesn't overwrite it.
+											if (eips.length)
+												peerSection.getUIElement(section_id, 'allowed_ips')?.setValue(eips);
 										}
 									}, [ _('Back to peer configuration') ])
 								])

--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -748,10 +748,13 @@ return network.registerProtocol('wireguard', {
 						const dns = [];
 
 						if (lnet) {
+							const lanIp6 = lnet.getIP6Addr();
+							if (lanIp6)
+								dns.push(lanIp6.split('/')[0]);
+
 							const lanIp = lnet.getIPAddr();
-							if (lanIp) {
-								dns.unshift(lanIp)
-							}
+							if (lanIp)
+								dns.unshift(lanIp);
 						}
 
 						let qrm, qrs, qro;

--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -35,8 +35,9 @@ var getNextPeerAddress = rpc.declare({
 	expect: {}
 });
 
-// Octets allocated this page session but not yet committed to UCI,
+// Addresses allocated this page session but not yet committed to UCI,
 // so back-to-back peer creation doesn't produce duplicate addresses.
+// Contains bare IPv4 addresses (e.g. "10.0.0.2") and IPv6 low-bytes.
 var _sessionReserved = [];
 
 var qrIcon = '<svg viewBox="0 0 29 29" xmlns="http://www.w3.org/2000/svg"><path fill="#fff" d="M0 0h29v29H0z"/><path d="M4 4h1v1H4zM5 4h1v1H5zM6 4h1v1H6zM7 4h1v1H7zM8 4h1v1H8zM9 4h1v1H9zM10 4h1v1h-1zM12 4h1v1h-1zM13 4h1v1h-1zM14 4h1v1h-1zM15 4h1v1h-1zM16 4h1v1h-1zM18 4h1v1h-1zM19 4h1v1h-1zM20 4h1v1h-1zM21 4h1v1h-1zM22 4h1v1h-1zM23 4h1v1h-1zM24 4h1v1h-1zM4 5h1v1H4zM10 5h1v1h-1zM12 5h1v1h-1zM14 5h1v1h-1zM16 5h1v1h-1zM18 5h1v1h-1zM24 5h1v1h-1zM4 6h1v1H4zM6 6h1v1H6zM7 6h1v1H7zM8 6h1v1H8zM10 6h1v1h-1zM12 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM21 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM4 7h1v1H4zM6 7h1v1H6zM7 7h1v1H7zM8 7h1v1H8zM10 7h1v1h-1zM12 7h1v1h-1zM13 7h1v1h-1zM14 7h1v1h-1zM15 7h1v1h-1zM18 7h1v1h-1zM20 7h1v1h-1zM21 7h1v1h-1zM22 7h1v1h-1zM24 7h1v1h-1zM4 8h1v1H4zM6 8h1v1H6zM7 8h1v1H7zM8 8h1v1H8zM10 8h1v1h-1zM16 8h1v1h-1zM18 8h1v1h-1zM20 8h1v1h-1zM21 8h1v1h-1zM22 8h1v1h-1zM24 8h1v1h-1zM4 9h1v1H4zM10 9h1v1h-1zM12 9h1v1h-1zM13 9h1v1h-1zM15 9h1v1h-1zM18 9h1v1h-1zM24 9h1v1h-1zM4 10h1v1H4zM5 10h1v1H5zM6 10h1v1H6zM7 10h1v1H7zM8 10h1v1H8zM9 10h1v1H9zM10 10h1v1h-1zM12 10h1v1h-1zM14 10h1v1h-1zM16 10h1v1h-1zM18 10h1v1h-1zM19 10h1v1h-1zM20 10h1v1h-1zM21 10h1v1h-1zM22 10h1v1h-1zM23 10h1v1h-1zM24 10h1v1h-1zM13 11h1v1h-1zM14 11h1v1h-1zM15 11h1v1h-1zM16 11h1v1h-1zM4 12h1v1H4zM5 12h1v1H5zM8 12h1v1H8zM9 12h1v1H9zM10 12h1v1h-1zM13 12h1v1h-1zM15 12h1v1h-1zM19 12h1v1h-1zM21 12h1v1h-1zM22 12h1v1h-1zM23 12h1v1h-1zM24 12h1v1h-1zM5 13h1v1H5zM6 13h1v1H6zM8 13h1v1H8zM11 13h1v1h-1zM13 13h1v1h-1zM14 13h1v1h-1zM15 13h1v1h-1zM16 13h1v1h-1zM19 13h1v1h-1zM22 13h1v1h-1zM4 14h1v1H4zM5 14h1v1H5zM9 14h1v1H9zM10 14h1v1h-1zM11 14h1v1h-1zM15 14h1v1h-1zM18 14h1v1h-1zM19 14h1v1h-1zM20 14h1v1h-1zM21 14h1v1h-1zM22 14h1v1h-1zM23 14h1v1h-1zM7 15h1v1H7zM8 15h1v1H8zM9 15h1v1H9zM11 15h1v1h-1zM12 15h1v1h-1zM13 15h1v1h-1zM17 15h1v1h-1zM18 15h1v1h-1zM20 15h1v1h-1zM21 15h1v1h-1zM23 15h1v1h-1zM4 16h1v1H4zM6 16h1v1H6zM10 16h1v1h-1zM11 16h1v1h-1zM13 16h1v1h-1zM14 16h1v1h-1zM16 16h1v1h-1zM17 16h1v1h-1zM18 16h1v1h-1zM22 16h1v1h-1zM23 16h1v1h-1zM24 16h1v1h-1zM12 17h1v1h-1zM16 17h1v1h-1zM17 17h1v1h-1zM18 17h1v1h-1zM4 18h1v1H4zM5 18h1v1H5zM6 18h1v1H6zM7 18h1v1H7zM8 18h1v1H8zM9 18h1v1H9zM10 18h1v1h-1zM14 18h1v1h-1zM16 18h1v1h-1zM17 18h1v1h-1zM21 18h1v1h-1zM22 18h1v1h-1zM23 18h1v1h-1zM4 19h1v1H4zM10 19h1v1h-1zM12 19h1v1h-1zM13 19h1v1h-1zM15 19h1v1h-1zM16 19h1v1h-1zM19 19h1v1h-1zM21 19h1v1h-1zM23 19h1v1h-1zM24 19h1v1h-1zM4 20h1v1H4zM6 20h1v1H6zM7 20h1v1H7zM8 20h1v1H8zM10 20h1v1h-1zM12 20h1v1h-1zM13 20h1v1h-1zM15 20h1v1h-1zM18 20h1v1h-1zM19 20h1v1h-1zM20 20h1v1h-1zM22 20h1v1h-1zM23 20h1v1h-1zM24 20h1v1h-1zM4 21h1v1H4zM6 21h1v1H6zM7 21h1v1H7zM8 21h1v1H8zM10 21h1v1h-1zM13 21h1v1h-1zM15 21h1v1h-1zM16 21h1v1h-1zM19 21h1v1h-1zM21 21h1v1h-1zM23 21h1v1h-1zM24 21h1v1h-1zM4 22h1v1H4zM6 22h1v1H6zM7 22h1v1H7zM8 22h1v1H8zM10 22h1v1h-1zM13 22h1v1h-1zM15 22h1v1h-1zM18 22h1v1h-1zM19 22h1v1h-1zM20 22h1v1h-1zM21 22h1v1h-1zM22 22h1v1h-1zM4 23h1v1H4zM10 23h1v1h-1zM12 23h1v1h-1zM13 23h1v1h-1zM14 23h1v1h-1zM17 23h1v1h-1zM18 23h1v1h-1zM20 23h1v1h-1zM22 23h1v1h-1zM4 24h1v1H4zM5 24h1v1H5zM6 24h1v1H6zM7 24h1v1H7zM8 24h1v1H8zM9 24h1v1H9zM10 24h1v1h-1zM12 24h1v1h-1zM13 24h1v1h-1zM14 24h1v1h-1zM16 24h1v1h-1zM17 24h1v1h-1zM18 24h1v1h-1zM22 24h1v1h-1zM24 24h1v1h-1z"/></svg>';
@@ -727,9 +728,11 @@ return network.registerProtocol('wireguard', {
 						if (next && !next.error) {
 							if (next.ipv4) eips.push(next.ipv4);
 							if (next.ipv6) eips.push(next.ipv6);
-							// Remember this octet for the lifetime of the page so a
-							// second peer allocation in the same session skips it.
-							_sessionReserved.push(next.octet);
+							// Remember this allocation for the lifetime of the page so
+							// back-to-back peer creation skips already-allocated addresses.
+							// IPv4: pass bare address; IPv6: pass low-byte integer.
+							if (next.ipv4_bare) _sessionReserved.push(next.ipv4_bare);
+							if (next.octet != null) _sessionReserved.push(next.octet);
 							// Write the allocated addresses back as allowed_ips so the
 							// server-side peer entry is complete without a manual edit.
 							// Use uci.save() directly: parent.save() re-reads the DOM

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json
@@ -4,7 +4,8 @@
 		"read": {
 			"ubus": {
 				"luci.wireguard": [
-					"getWgInstances"
+					"getWgInstances",
+					"getNextPeerAddress"
 				]
 			},
 			"uci": [ "ddns", "system" ]

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -4,7 +4,7 @@
 'use strict';
 
 import { cursor } from 'uci';
-import { popen } from 'fs';
+import { popen, opendir } from 'fs';
 
 
 function shellquote(s) {
@@ -54,6 +54,93 @@ const methods = {
 			const pub = command(`echo ${shellquote(priv)} | wg pubkey 2>/dev/null`);
 
 			return { keys: { priv, pub } };
+		}
+	},
+
+	getNextPeerAddress: {
+		args: { interface: 'interface' },
+		call: function(req) {
+			const ifname = req.args?.interface ?? 'wg0';
+			const uci = cursor();
+
+			uci.load('network');
+
+			// Derive subnet prefixes from the server interface's own addresses.
+			//
+			// IPv4: "10.0.0.1/24" → ipv4_prefix = "10.0.0"
+			//
+			// IPv6: "fd11:5ee:bad:c0de::ac7:9301/64"
+			//   The last 16-bit group encodes a high byte shared by all client
+			//   addresses plus the host octet.  We record the group base (high byte
+			//   shifted left) so we can reconstruct e.g. "930d" for octet 13.
+			//   ipv6_prefix    = "fd11:5ee:bad:c0de::ac7:"
+			//   ipv6_group_base = 0x9300
+			let ipv4_prefix = null;
+			let ipv6_prefix = null;
+			let ipv6_group_base = 0;
+
+			for (let addr in (uci.get('network', ifname, 'addresses') ?? [])) {
+				const bare = split(addr, '/')[0];
+
+				if (index(bare, ':') < 0) {
+					if (!ipv4_prefix) {
+						const parts = split(bare, '.');
+						if (length(parts) == 4)
+							ipv4_prefix = parts[0] + '.' + parts[1] + '.' + parts[2];
+					}
+				} else {
+					if (!ipv6_prefix) {
+						const last_colon = rindex(bare, ':');
+						if (last_colon >= 0) {
+							ipv6_prefix = substr(bare, 0, last_colon + 1);
+							ipv6_group_base = +('0x' + substr(bare, last_colon + 1)) & 0xff00;
+						}
+					}
+				}
+			}
+
+			if (!ipv4_prefix && !ipv6_prefix)
+				return { error: 'No server addresses configured on interface' };
+
+			// Collect the host octets already in use across all UCI peers.
+			const used = {};
+
+			uci.foreach('network', 'wireguard_' + ifname, (peer) => {
+				for (let cidr in (peer.allowed_ips ?? [])) {
+					const bare = split(cidr, '/')[0];
+
+					if (ipv4_prefix && index(bare, ':') < 0) {
+						const parts = split(bare, '.');
+						if (length(parts) == 4 &&
+						    parts[0] + '.' + parts[1] + '.' + parts[2] == ipv4_prefix)
+							used[+parts[3]] = true;
+
+					} else if (ipv6_prefix && index(bare, ':') >= 0) {
+						if (substr(bare, 0, length(ipv6_prefix)) == ipv6_prefix) {
+							const last_group = +('0x' + substr(bare, length(ipv6_prefix)));
+							used[last_group & 0xff] = true;
+						}
+					}
+				}
+			});
+
+			// Find the lowest free host value >= 2 (1 is reserved for the server).
+			let octet = 2;
+			while (used[octet] && octet < 255)
+				octet++;
+
+			if (octet >= 255)
+				return { error: 'No free addresses in pool' };
+
+			const result = { octet };
+
+			if (ipv4_prefix)
+				result.ipv4 = ipv4_prefix + '.' + octet + '/32';
+
+			if (ipv6_prefix)
+				result.ipv6 = ipv6_prefix + sprintf('%x', ipv6_group_base | octet) + '/128';
+
+			return result;
 		}
 	},
 

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -66,18 +66,15 @@ const methods = {
 			uci.load('network');
 
 			// Derive subnet prefixes from the server interface's own addresses.
+			// Peers always receive /32 (IPv4) or /128 (IPv6) addresses, so the
+			// server's prefix length does not bound allocation.  We vary only the
+			// last octet (IPv4) or the low byte of the last 16-bit group (IPv6).
 			//
 			// IPv4: "10.0.0.1/24" → ipv4_prefix = "10.0.0"
-			//
 			// IPv6: "fd11:5ee:bad:c0de::ac7:9301/64"
-			//   The last 16-bit group encodes a high byte shared by all client
-			//   addresses plus the host octet.  We record the group base (high byte
-			//   shifted left) so we can reconstruct e.g. "930d" for octet 13.
-			//   ipv6_prefix    = "fd11:5ee:bad:c0de::ac7:"
-			//   ipv6_group_base = 0x9300
+			//   ipv6_prefix = "fd11:5ee:bad:c0de::ac7:", ipv6_group_base = 0x9300
 			let ipv4_prefix = null;
-			let ipv6_prefix = null;
-			let ipv6_group_base = 0;
+			let ipv6_prefix = null, ipv6_group_base = 0;
 
 			for (let addr in (uci.get('network', ifname, 'addresses') ?? [])) {
 				const bare = split(addr, '/')[0];

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -65,81 +65,109 @@ const methods = {
 
 			uci.load('network');
 
-			// Derive subnet prefixes from the server interface's own addresses.
-			// Peers always receive /32 (IPv4) or /128 (IPv6) addresses, so the
-			// server's prefix length does not bound allocation.  We vary only the
-			// last octet (IPv4) or the low byte of the last 16-bit group (IPv6).
-			//
-			// IPv4: "10.0.0.1/24" → ipv4_prefix = "10.0.0"
-			// IPv6: "fd11:5ee:bad:c0de::ac7:9301/64"
-			//   ipv6_prefix = "fd11:5ee:bad:c0de::ac7:", ipv6_group_base = 0x9300
-			let ipv4_prefix = null;
-			let ipv6_prefix = null, ipv6_group_base = 0;
+			let ipv4_net = null, ipv4_plen = 0, ipv4_server = null;
+			let ipv6_template = null;
 
 			for (let addr in (uci.get('network', ifname, 'addresses') ?? [])) {
-				const bare = split(addr, '/')[0];
+				const parts = split(addr, '/');
+				const arr   = iptoarr(parts[0]);
+				const plen  = +(parts[1] ?? 0);
 
-				if (index(bare, ':') < 0) {
-					if (!ipv4_prefix) {
-						const parts = split(bare, '.');
-						if (length(parts) == 4)
-							ipv4_prefix = parts[0] + '.' + parts[1] + '.' + parts[2];
+				if (!arr)
+					continue;
+
+				if (length(arr) == 4) {
+					if (!ipv4_net && plen > 0) {
+						const ip32 = (arr[0] << 24) | (arr[1] << 16) | (arr[2] << 8) | arr[3];
+						const mask = ~0 << (32 - plen);
+						ipv4_net    = ip32 & mask;
+						ipv4_plen   = plen;
+						ipv4_server = ip32;
 					}
 				} else {
-					if (!ipv6_prefix) {
-						const last_colon = rindex(bare, ':');
-						if (last_colon >= 0) {
-							ipv6_prefix = substr(bare, 0, last_colon + 1);
-							ipv6_group_base = +('0x' + substr(bare, last_colon + 1)) & 0xff00;
-						}
-					}
+					if (!ipv6_template)
+						ipv6_template = arr;
 				}
 			}
 
-			if (!ipv4_prefix && !ipv6_prefix)
+			if (ipv4_net === null && !ipv6_template)
 				return { error: 'No server addresses configured on interface' };
 
-			// Collect the host octets already in use across all UCI peers.
-			const used = {};
+			// Collect used IPv4 host addresses and used IPv6 low-bytes (arr[15]).
+			const used_ipv4 = {};
+			const used_ipv6 = {};
 
 			uci.foreach('network', 'wireguard_' + ifname, (peer) => {
 				for (let cidr in (peer.allowed_ips ?? [])) {
-					const bare = split(cidr, '/')[0];
+					const arr = iptoarr(split(cidr, '/')[0]);
+					if (!arr) continue;
 
-					if (ipv4_prefix && index(bare, ':') < 0) {
-						const parts = split(bare, '.');
-						if (length(parts) == 4 &&
-						    parts[0] + '.' + parts[1] + '.' + parts[2] == ipv4_prefix)
-							used[+parts[3]] = true;
+					if (ipv4_net !== null && length(arr) == 4) {
+						const ip32 = (arr[0] << 24) | (arr[1] << 16) | (arr[2] << 8) | arr[3];
+						const mask = ~0 << (32 - ipv4_plen);
+						if ((ip32 & mask) == ipv4_net)
+							used_ipv4[ip32] = true;
 
-					} else if (ipv6_prefix && index(bare, ':') >= 0) {
-						if (substr(bare, 0, length(ipv6_prefix)) == ipv6_prefix) {
-							const last_group = +('0x' + substr(bare, length(ipv6_prefix)));
-							used[last_group & 0xff] = true;
+					} else if (ipv6_template && length(arr) == 16) {
+						let match = true;
+						for (let i = 0; i < 15; i++) {
+							if (arr[i] != ipv6_template[i]) { match = false; break; }
 						}
+						if (match)
+							used_ipv6[arr[15]] = true;
 					}
 				}
 			});
 
-			// Also mark octets the client reserved this session but hasn't saved yet.
-			for (let o in (req.args?.reserved ?? []))
-				used[+o] = true;
+			// Session reservations: client pushes bare IPv4 strings or integer
+			// low-bytes for IPv6.
+			for (let r in (req.args?.reserved ?? [])) {
+				if (type(r) == 'string') {
+					const arr = iptoarr(r);
+					if (arr && length(arr) == 4)
+						used_ipv4[(arr[0] << 24) | (arr[1] << 16) | (arr[2] << 8) | arr[3]] = true;
+				} else {
+					used_ipv6[+r] = true;
+				}
+			}
 
-			// Find the lowest free host value >= 2 (1 is reserved for the server).
-			let octet = 2;
-			while (used[octet] && octet < 255)
-				octet++;
+			const result = {};
 
-			if (octet >= 255)
-				return { error: 'No free addresses in pool' };
+			if (ipv4_net !== null) {
+				const host_bits = 32 - ipv4_plen;
+				const total     = 1 << host_bits;
+				let   found     = null;
 
-			const result = { octet };
+				for (let i = 1; i < total - 1; i++) {
+					const last = i & 0xff;
+					if (last == 0 || last == 255) continue;
+					const candidate = ipv4_net + i;
+					if (candidate == ipv4_server) continue;
+					if (!used_ipv4[candidate]) { found = candidate; break; }
+				}
 
-			if (ipv4_prefix)
-				result.ipv4 = ipv4_prefix + '.' + octet + '/32';
+				if (found === null)
+					return { error: 'No free addresses in pool' };
 
-			if (ipv6_prefix)
-				result.ipv6 = ipv6_prefix + sprintf('%x', ipv6_group_base | octet) + '/128';
+				const bare      = arrtoip([(found >> 24) & 0xff, (found >> 16) & 0xff,
+				                           (found >>  8) & 0xff,  found        & 0xff]);
+				result.ipv4      = bare + '/32';
+				result.ipv4_bare = bare;
+			}
+
+			if (ipv6_template) {
+				let octet = 2;
+				while (used_ipv6[octet] && octet < 255)
+					octet++;
+
+				if (octet >= 255)
+					return { error: 'No free addresses in pool' };
+
+				const peer_arr = [...ipv6_template];
+				peer_arr[15]   = octet;
+				result.ipv6    = arrtoip(peer_arr) + '/128';
+				result.octet   = octet;
+			}
 
 			return result;
 		}

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -58,7 +58,7 @@ const methods = {
 	},
 
 	getNextPeerAddress: {
-		args: { interface: 'interface' },
+		args: { interface: 'interface', reserved: [] },
 		call: function(req) {
 			const ifname = req.args?.interface ?? 'wg0';
 			const uci = cursor();
@@ -123,6 +123,10 @@ const methods = {
 					}
 				}
 			});
+
+			// Also mark octets the client reserved this session but hasn't saved yet.
+			for (let o in (req.args?.reserved ?? []))
+				used[+o] = true;
 
 			// Find the lowest free host value >= 2 (1 is reserved for the server).
 			let octet = 2;

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/ucode/luci.wireguard
@@ -4,7 +4,7 @@
 'use strict';
 
 import { cursor } from 'uci';
-import { popen, opendir } from 'fs';
+import { popen } from 'fs';
 
 
 function shellquote(s) {


### PR DESCRIPTION
## Pull request details

### Description
Improve the "Generate configuration" dialog:

1. Fix the Address field being empty for existing peers: previously eips
   was read via formvalue() before parent.save() resolved, so the DOM
   state was stale. Now reads via cfgvalue() after save completes.

2. Auto-assign the next free IPv4+IPv6 address for new peers via a new
   getNextPeerAddress RPC method. It derives the subnet from the server
   interface's own addresses and finds the lowest unused host address,
   iterating across /24 block boundaries when the current block is full
   (e.g. a /8 with peers spanning multiple /24s). A client-side
   reservation list prevents duplicate allocation when creating multiple
   peers back-to-back in the same session.

3. Write the allocated addresses back to allowed_ips in UCI immediately,
   so the server-side peer entry is complete without manual editing.
   Uses uci.save() directly to avoid parent.save() re-reading the empty
   DOM widget and overwriting the allocation.

Also pre-fills the DNS Servers field with both IPv4 and IPv6 LAN
addresses, and repopulates the allowed_ips form widget on return from
the dialog so a subsequent Save does not overwrite the value.


### Maintainer _(preferred)_
@jow-

---

## Tested on
OpenWrt version: OpenWrt 25.12.5 r33051-f5dae5ece4
LuCI version: luci-proto-wireguard-26.183.16146~6aacb73
Web browser(s): Firefox 152.0.4, Chrome 149.0.7827.196
