### PR TITLE
Fix for `PermissionError: Access to command denied by ACL` banner on LuCi -> Network -> MultiWAN Manager -> Rules`

### DIFF
--- a/applications/luci-app-mwan3/root/usr/share/rpcd/acl.d/luci-app-mwan3.json
+++ b/applications/luci-app-mwan3/root/usr/share/rpcd/acl.d/luci-app-mwan3.json
@@ -38,7 +38,8 @@
 			},
 			"uci": [
 				"mwan3",
-				"network"
+				"network",
+				"firewall"
 			]
 		},
 		"write": {
@@ -58,11 +59,15 @@
 			"ubus": {
 				"mwan3": [
 					"status"
+				],
+				"system": [
+					"validate_uci_config"
 				]
 			},
 			"uci": [
 				"mwan3",
-				"network"
+				"network",
+				"firewall"
 			]
 		},
 		"write": {


### PR DESCRIPTION
### Description
Fixes an upstream front-end regression where navigating to **Network -> MultiWAN Manager -> Rules** breaks instantly on clean installations with a red `PermissionError: Access to command denied by ACL` banner.

### Root Cause Analysis
The modern client-side rendering file `view/mwan3/network/rule.js` requires system level validations (`validate_uci_config`) and pulls operational zone targets from `/etc/config/firewall` to build input elements. 

While the existing ACL definition profile opens up `cgi-io` execution privileges, it completely omits the tracking tokens for the `firewall` config scope and doesn't explicitly expose the `system` namespace on the UBUS communications tier inside the primary `luci-app-mwan3` scope. Because these security structures are locked down, the background security helper `rpcd` returns a `403 Forbidden` response to the front-end AJAX requests, crashing the page view compilation loop.

### Fix Verification
- Tested and verified on a clean stock hardware node environment by appending `"firewall"` array elements to UCI sections and registering the `"system"` block manually.
- Cleared local compiled LuCI caches, resolving the page loop and restoring fully functioning control mechanics over the MultiWAN routing lists.