### PR TITLE
luci-app-mwan3: fix Rules view ACL permission error

### DIFF
--- a/applications/luci-app-mwan3/root/usr/share/rpcd/acl.d/luci-app-mwan3.json
+++ b/applications/luci-app-mwan3/root/usr/share/rpcd/acl.d/luci-app-mwan3.json
@@ -55,6 +55,11 @@
 			"cgi-io": [
 				"exec"
 			],
+			"file": {
+				"/usr/libexec/luci-mwan3 ipset dump": [
+					"exec"
+				]
+			},
 			"ubus": {
 				"mwan3": [
 					"status"


### PR DESCRIPTION
### Description
Fixes a frontend regression where navigating to **Network -> MultiWAN Manager -> Rules** breaks on fresh installations with a red `PermissionError: Access to command denied by ACL` banner.

### Root Cause Analysis
The modern client-side rendering file `view/mwan3/network/rule.js` executes an internal backend validation subroutine (`/usr/libexec/luci-mwan3 ipset dump`) via `fs.exec_direct()`. 

As `fs.exec_direct()` evaluates execution privileges against the generic `read` scope rules (mirroring core UBUS-based exec permissions), the request drops with a 403 Forbidden error because the `luci-app-mwan3` configuration profile completely lacked a targeted file execution whitelist path for this specific script and argument structure.

### Proposed Solution
- Added the tightest possible execution path constraint `"/usr/libexec/luci-mwan3 ipset dump": ["exec"]` right inside the existing `luci-app-mwan3` configuration profile's `read -> file` array.