### PR TITLE
build: skip waiting for formality check on bot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,14 @@ permissions:
 jobs:
   wait-for-formalities:
     name: Wait for FormalityCheck
+    if: github.event.pull_request.user.login != 'weblate'
     runs-on: ubuntu-slim
     steps:
       - name: Wait for Check Run
+        if: |
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          github.event.pull_request.user.login != 'Copilot' &&
+          github.event.pull_request.user.type != 'Bot'
         uses: lewagon/wait-on-check-action@v1.8.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Automated translation updates from Weblate and dependency bumps from Dependabot do not trigger the formality webhook [1].

Consequently, the build workflow hangs indefinitely on the 'Wait for FormalityCheck' step and
subsequently fails/times out.

- Let's skip it entirely for weblate PRs and do not build packages with new translations as we discussed it (https://github.com/openwrt/luci/pull/8809#issuecomment-4917707175) and we don't need it currently.

- Allow building packages for other bots as Dependabot, Copilot, because sometimes they can introduce breaking changes and we need to know, if it does not break CI/CD stuff.

[1] https://github.com/openwrt/openwrt-bot-worker/blob/31112ca8c0c60e64c002eef72137d6c085efa9f2/cloudflare-worker/src/index.js#L129