### PR TITLE
luci-mod-status: fix channel analysis graph on tab switch

### DIFF
--- a/modules/luci-mod-status/Makefile
+++ b/modules/luci-mod-status/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Status Pages
 LUCI_DEPENDS:=+luci-base +libiwinfo +rpcd-mod-iwinfo
 
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_BUILD_DEPENDS:=iwinfo
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -185,12 +185,6 @@ return view.extend({
 			}
 		}
 		createGraphHLine(G,curr_offset+step, 0.1, 1);
-
-		chan_analysis.tab.addEventListener('cbi-tab-active', L.bind(function(ev) {
-			this.active_tab = ev.detail.tab;
-			if (!this.radios[this.active_tab].loadedOnce)
-				poll.start();
-		}, this));
 	},
 
 	handleScanRefresh: function() {
@@ -475,6 +469,9 @@ return view.extend({
 					offset_tbl: {},
 					col_width: 0,
 					tab: tab,
+					band: band,
+					created: false,
+					channels: bands[band].channels,
 				};
 
 				this.radios[ifname+band] = {
@@ -488,9 +485,21 @@ return view.extend({
 
 				cbi_update_table(table, [], E('em', { class: 'spinning' }, _('Starting wireless scan...')));
 
-				tabs.firstElementChild.appendChild(tab)
+				tabs.firstElementChild.appendChild(tab);
 
-				requestAnimationFrame(L.bind(this.create_channel_graph, this, graph_data, bands[band].channels, band));
+				/* Draw on first tab activation: column width comes from
+				 * offsetWidth, which is 0 while the pane is hidden, so
+				 * rendering all tabs upfront squishes inactive ones. */
+				tab.addEventListener('cbi-tab-active', L.bind(function(ev) {
+					this.active_tab = ev.detail.tab;
+					var radio = this.radios[this.active_tab];
+					if (radio && !radio.graph.created) {
+						radio.graph.created = true;
+						this.create_channel_graph(radio.graph, radio.graph.channels, radio.graph.band);
+					}
+					if (radio && !radio.loadedOnce)
+						poll.start();
+				}, this));
 			}
 		}
 


### PR DESCRIPTION
defer graph drawing to first cbi-tab-active so offsetWidth is correct for hidden panes. Fixes channel numbers and AP curves piling up on the left when switching tabs in themes that hide panes with display:none.