### PR TITLE
luci-mod-status: channel_analysis: draw graph on first tab activation

### DIFF
--- a/modules/luci-mod-status/Makefile
+++ b/modules/luci-mod-status/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Status Pages
 LUCI_DEPENDS:=+luci-base +libiwinfo +rpcd-mod-iwinfo
 
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_BUILD_DEPENDS:=iwinfo
 PKG_LICENSE:=Apache-2.0
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -185,12 +185,6 @@ return view.extend({
 			}
 		}
 		createGraphHLine(G,curr_offset+step, 0.1, 1);
-
-		chan_analysis.tab.addEventListener('cbi-tab-active', L.bind(function(ev) {
-			this.active_tab = ev.detail.tab;
-			if (!this.radios[this.active_tab].loadedOnce)
-				poll.start();
-		}, this));
 	},
 
 	handleScanRefresh: function() {
@@ -475,6 +469,8 @@ return view.extend({
 					offset_tbl: {},
 					col_width: 0,
 					tab: tab,
+					created: false,
+					channels: bands[band].channels,
 				};
 
 				this.radios[ifname+band] = {
@@ -488,9 +484,24 @@ return view.extend({
 
 				cbi_update_table(table, [], E('em', { class: 'spinning' }, _('Starting wireless scan...')));
 
-				tabs.firstElementChild.appendChild(tab)
+				tabs.firstElementChild.appendChild(tab);
 
-				requestAnimationFrame(L.bind(this.create_channel_graph, this, graph_data, bands[band].channels, band));
+				/* Draw on first tab activation: column width comes from
+				 * offsetWidth, which is 0 while the pane is hidden, so
+				 * rendering all tabs upfront squishes inactive ones. */
+				tab.addEventListener('cbi-tab-active', L.bind(function(ev) {
+					this.active_tab = ev.detail.tab;
+					var radio = this.radios[this.active_tab];
+
+					if (!radio.graph.created) {
+						radio.graph.created = true;
+						this.create_channel_graph(radio.graph, radio.graph.channels, radio.band);
+					}
+
+					if (!radio.loadedOnce) {
+						poll.start();
+					}
+				}, this));
 			}
 		}
 


### PR DESCRIPTION
The channel graph for every radio/band was drawn via requestAnimationFrame() right after each tab was created. For tab panes still hidden at that point, offsetWidth is 0 (themes that hide inactive panes with display:none), so the column width collapsed and the graph was drawn squished until the tab was first opened.

Defer create_channel_graph() to a cbi-tab-active handler attached in render and draw each graph exactly once, guarded by a "created" flag, when its tab first becomes visible and offsetWidth is correct. Store the band channels on the graph data and start the poll from the same handler. Move the poll-start logic out of create_channel_graph, which becomes a pure drawing function.