### PR TITLE
luci-app-strongsnwan-swanctl: split page into tunnel and service config

### DIFF
--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js
@@ -1,0 +1,31 @@
+'use strict';
+'require form';
+'require view';
+'require tools.widgets as widgets';
+
+return view.extend({
+	render: function (result) {
+		let m, s, o;
+
+		m = new form.Map('ipsec', _('Service configuration'),
+			_('On this page, you can configure the IPsec service.'));
+		m.tabbed = true;
+
+		// strongSwan General Settings
+		s = m.section(form.NamedSection, 'globals', 'ipsec', _('General Settings'));
+
+		o = s.option(widgets.NetworkSelect, 'interface', _('Listening Interfaces'),
+			_('Interfaces that accept VPN traffic.') + '<br /> ' +
+			_('Select an interface or leave empty for all interfaces.'));
+		o.multiple = true;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.option(form.Value, 'debug', _('Debug Level'),
+			_('Trace level: 0 is least verbose, 4 is most'));
+		o.default = '0';
+		o.datatype = 'range(0,4)';
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
@@ -4,7 +4,6 @@
 'require rpc';
 'require uci';
 'require ui';
-'require tools.widgets as widgets';
 
 const callListAlgorithms = rpc.declare({
 	object: 'luci.swanctl',
@@ -67,24 +66,9 @@ return view.extend({
 		if (error)
 			ui.addNotification(null, E('p', _('Some options are unavailable because swanctl failed to load: %s').format(error)), 'warning');
 
-		m = new form.Map('ipsec', _('strongSwan Configuration'),
-			_('Configure strongSwan for secure VPN connections.'));
+		m = new form.Map('ipsec', _('Remote/Tunnel configuration'),
+			_('On this page, you can configure the IPsec tunnels and remotes.'));
 		m.tabbed = true;
-
-		// strongSwan General Settings
-		s = m.section(form.NamedSection, 'globals', 'ipsec', _('General Settings'));
-
-		o = s.option(widgets.NetworkSelect, 'interface', _('Listening Interfaces'),
-			_('Interfaces that accept VPN traffic') + '<br /> ' +
-			_('Select an interface or leave empty for all interfaces'));
-		o.multiple = true;
-		o.nocreate = true;
-		o.optional = true;
-
-		o = s.option(form.Value, 'debug', _('Debug Level'),
-			_('Trace level: 0 is least verbose, 4 is most'));
-		o.default = '0';
-		o.datatype = 'range(0,4)';
 
 		// Remote Configuration
 		s = m.section(form.GridSection, 'remote', _('Remote Configuration'),

--- a/applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json
+++ b/applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json
@@ -3,13 +3,29 @@
 		"title": "strongSwan IPsec",
 		"order": 90,
 		"action": {
-			"type": "view",
-			"path": "strongswan-swanctl/swanctl"
+			"type": "alias",
+			"path": "admin/vpn/strongswan-swanctl/swanctl"
 		},
 		"depends": {
 			"acl": [
 				"luci-app-strongswan-swanctl"
 			]
+		}
+	},
+	"admin/vpn/strongswan-swanctl/swanctl": {
+		"title": "Remote/Tunnel",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "strongswan-swanctl/swanctl"
+		}
+	},
+	"admin/vpn/strongswan-swanctl/strongswan": {
+		"title": "Service",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "strongswan-swanctl/strongswan"
 		}
 	},
 	"admin/status/strongswan": {


### PR DESCRIPTION

### Description
Strongswan has many options that are not yet included in LuCI. For future expansion, it would make sense to split these across different domains.
* Service is for strongswan.conf needs are restart of the whole service to apply the changes (not supported yet)
* Tunnel/Remote is for swanctl.conf needs **no** restart to apply the changes



### Screenshot or video of changes _(if applicable)_

**Before change:**

<img width="1134" height="607" alt="Screenshot 2026-07-10 at 15-22-53 FG2-999991 - LuCI" src="https://github.com/user-attachments/assets/2176f92e-a635-4821-8cad-22aa00cf4c18" />

**After change:**

<img width="1162" height="708" alt="Screenshot 2026-07-10 at 15-17-51 FG2-999991 - LuCI" src="https://github.com/user-attachments/assets/db8b67b0-70a1-4dce-8e7b-b0cfa7efb75f" />



---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:**
master
**LuCI version:**
master
**Web browser(s):**
firefox

