### PR TITLE
luci-base: add missing pollinterval option to config

### DIFF
--- a/modules/luci-base/root/etc/config/luci
+++ b/modules/luci-base/root/etc/config/luci
@@ -3,6 +3,7 @@ config core 'main'
 	option mediaurlbase '/luci-static/bootstrap'
 	option resourcebase '/luci-static/resources'
 	option ubuspath '/ubus/'
+	option pollinterval '5'
 
 config internal 'languages'
 

--- a/modules/luci-base/root/etc/config/luci
+++ b/modules/luci-base/root/etc/config/luci
@@ -1,22 +1,22 @@
-config core main
-	option lang auto
-	option mediaurlbase /luci-static/bootstrap
-	option resourcebase /luci-static/resources
-	option ubuspath /ubus/
+config core 'main'
+	option lang 'auto'
+	option mediaurlbase '/luci-static/bootstrap'
+	option resourcebase '/luci-static/resources'
+	option ubuspath '/ubus/'
 
-config internal languages
+config internal 'languages'
 
-config internal sauth
-	option sessionpath "/tmp/luci-sessions"
-	option sessiontime 3600
+config internal 'sauth'
+	option sessionpath '/tmp/luci-sessions'
+	option sessiontime '3600'
 
-config internal ccache
-	option enable 1
+config internal 'ccache'
+	option enable '1'
 
-config internal themes
+config internal 'themes'
 
-config internal apply
-	option rollback 90
-	option holdoff 4
-	option timeout 5
-	option display 1.5
+config internal 'apply'
+	option rollback '90'
+	option holdoff '4'
+	option timeout '5'
+	option display '1.5'


### PR DESCRIPTION
Include `option pollinterval` to config file, as it is otherwise undocumented and very difficult to discover.

Run file through `uci export` to fix all whitespace and quoting.