### PR TITLE
luci-app-lpac: add eSIM profile manager

### DIFF
--- a/applications/luci-app-lpac/Makefile
+++ b/applications/luci-app-lpac/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for lpac
 LUCI_DESCRIPTION:=Manage eUICC information and eSIM profiles with lpac
 LUCI_DEPENDS:=+luci-base +lpac
-LUCI_EXTRA_DEPENDS:=lpac (>=2.3.0-r2)
+LUCI_EXTRA_DEPENDS:=lpac (>=2.3.0-r3)
 
 PKG_MAINTAINER:=As Tsaqib <0xfiqks@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/applications/luci-app-lpac/Makefile
+++ b/applications/luci-app-lpac/Makefile
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for lpac
+LUCI_DESCRIPTION:=Manage eUICC information and eSIM profiles with lpac
+LUCI_DEPENDS:=+luci-base +lpac
+LUCI_EXTRA_DEPENDS:=lpac (>=2.3.0-r2)
+
+PKG_MAINTAINER:=As Tsaqib <0xfiqks@gmail.com>
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-lpac/README.md
+++ b/applications/luci-app-lpac/README.md
@@ -1,0 +1,122 @@
+# luci-app-lpac
+
+`luci-app-lpac` is a LuCI frontend for the OpenWrt
+[`lpac`](https://github.com/openwrt/packages/tree/master/utils/lpac) package.
+It uses the packaged `/usr/bin/lpac` and `/etc/config/lpac` directly and does
+not bundle lpac, a modem manager, or a hardware-specific wrapper.
+
+## Scope
+
+- Show the installed lpac version, compiled drivers, and eUICC information.
+- List, enable, disable, rename, and delete profiles.
+- List and remove pending eUICC notifications.
+- Configure the packaged AT, uqmi, MBIM, and PC/SC backends through validated
+  RPC methods.
+
+Network operations such as profile download, discovery, and notification
+processing are intentionally deferred until the packaged lpac verifies TLS
+peers and hostnames. Exposing those operations in a web UI before then would
+not be safe. lpac 2.3.0 explicitly disables curl peer and hostname
+verification in
+[driver/http/curl.c](https://github.com/estkme-group/lpac/blob/v2.3.0/driver/http/curl.c#L90-L91).
+Separately,
+[estkme-group/lpac#444](https://github.com/estkme-group/lpac/pull/444)
+tracks hardening of untrusted server-response handling.
+
+Removing a pending notification only deletes its record from the eUICC. It
+does not contact the provider or undo the profile operation, and discarding an
+unprocessed record can leave the provider state out of sync. A bulk Process
+action is intentionally absent while lpac TLS verification is disabled. The
+packaged bulk implementation can also complete only part of a batch before an
+error and does not guarantee the grouping and ordering required by SGP.22.
+
+Notification sequence `0` is valid and is displayed, but its explicit Remove
+action is disabled. The packaged lpac 2.3.0 reports false success without
+removing that sequence. Upstream fixed this after 2.3.0 in
+[estkme-group/lpac#429](https://github.com/estkme-group/lpac/pull/429), but the
+fix is not yet present in the OpenWrt package; see also
+[estkme-group/lpac#430](https://github.com/estkme-group/lpac/issues/430).
+
+lpac 2.3.0 may report `v0.0.0-unknown` because its generated version header
+collides with an applet header and release tarballs lack Git metadata. This is
+a dependency build issue rather than evidence that an eUICC operation failed.
+Upstream corrected version handling after 2.3.0 in
+[estkme-group/lpac#310](https://github.com/estkme-group/lpac/pull/310).
+
+## Compatibility
+
+The package targets LuCI `master`, requires `lpac >= 2.3.0-r2`, and is
+architecture-independent.
+
+When driver discovery succeeds, Settings offers the reported AT, uqmi, MBIM,
+or PC/SC backends. Safe AT and MBIM device paths below `/dev` are accepted.
+The active OpenWrt uqmi backend remains restricted to `/dev/cdc-wdmN` because
+that downstream integration currently constructs a shell command.
+
+## Architecture
+
+The browser calls a small typed `luci.lpac` rpcd/ucode facade. The facade:
+
+- validates every argument and never accepts a raw command line;
+- serializes access to the eUICC with a non-blocking file lock;
+- delegates asynchronously to rpcd `file.exec` using an argv array;
+- validates the lpac UCI settings before every execution;
+- executes only the packaged `/usr/bin/lpac` entrypoint;
+- parses lpac newline-delimited JSON and returns a normalized response;
+- does not return raw APDU, HTTP, activation-code, or confirmation-code data.
+
+OpenWrt configures rpcd command execution with a 30-second timeout. The
+initial RPC methods are therefore limited to one-shot local eUICC operations;
+the application does not change this system-wide timeout.
+
+eUICC operations are launched through BusyBox `flock` on the same lock file
+used by configuration writes. Before either use, the backend creates or repairs
+the lock as a regular root-owned mode-0600 file and rejects non-regular or
+non-root-owned paths. The lock descriptor is inherited by the packaged lpac
+shim and compiled child process, so the eUICC remains serialized even if rpcd
+times out or stops collecting an oversized command response. This locking
+layer does not perform modem, interface, or network orchestration.
+
+Serialization applies to calls made through this application. Direct CLI calls
+or other managers must voluntarily use `/var/run/luci-lpac.lock` to avoid racing
+the LuCI backend.
+
+This favors safety over cancellation: after an rpcd timeout, a descendant lpac
+process may continue holding the lock until it exits. Subsequent operations can
+therefore remain busy if a modem driver is permanently hung; recovery then
+requires terminating the stale process or rebooting the router.
+
+The application does not reset modems or network interfaces. Some hardware
+requires a SIM power cycle or reconnect after enabling or disabling a profile;
+that lifecycle remains the responsibility of the modem/network stack.
+
+The profile refresh flag is an ES10c request indicating that terminal refresh
+is required; it is not a modem reboot. A host stack may respond with a logical
+SIM reprobe, while some eUICCs may reject the flag, so the choice remains
+explicit rather than universal.
+
+The Profiles view only offers deletion for a profile reported as disabled.
+Direct RPC calls bypass that browser state check; the backend relies on the
+eUICC to reject deletion of an enabled profile and normalizes the resulting
+lpac error.
+
+Settings writes update only the options managed by this application.
+Additional package- or vendor-specific UCI options in the named sections are
+left intact.
+
+## Testing
+
+The package targets the LuCI `master` branch. Before submission, run:
+
+```sh
+npx eslint applications/luci-app-lpac
+applications/luci-app-lpac/tests/run-tests.sh
+node applications/luci-app-lpac/tests/frontend.js
+git diff --check
+./build/i18n-scan.pl applications/luci-app-lpac \
+  > applications/luci-app-lpac/po/templates/lpac.pot
+make package/luci-app-lpac/clean package/luci-app-lpac/compile V=s
+```
+
+Real-device testing is required for every APDU backend that is claimed in a
+pull request.

--- a/applications/luci-app-lpac/README.md
+++ b/applications/luci-app-lpac/README.md
@@ -45,11 +45,14 @@ Upstream corrected version handling after 2.3.0 in
 
 ## Compatibility
 
-The package targets LuCI `master`, requires `lpac >= 2.3.0-r2`, and is
+The package targets LuCI `master`, requires `lpac >= 2.3.0-r3`, and is
 architecture-independent.
 
 When driver discovery succeeds, Settings offers the reported AT, uqmi, MBIM,
 or PC/SC backends. Safe AT and MBIM device paths below `/dev` are accepted.
+The MBIM section exposes the upstream slot-mapping bypass as an opt-in setting
+for devices that cannot use normal MBIM slot mapping. It remains disabled by
+default because enabling it ignores the configured MBIM UIM slot.
 The active OpenWrt uqmi backend remains restricted to `/dev/cdc-wdmN` because
 that downstream integration currently constructs a shell command.
 
@@ -100,7 +103,8 @@ Direct RPC calls bypass that browser state check; the backend relies on the
 eUICC to reject deletion of an enabled profile and normalizes the resulting
 lpac error.
 
-Settings writes update only the options managed by this application.
+Settings writes update only the options managed by this application,
+including the packaged MBIM skip-slot-mapping preference.
 Additional package- or vendor-specific UCI options in the named sections are
 left intact.
 

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict';
+'require rpc';
+'require baseclass';
+
+const callGetVersion = rpc.declare({
+	object: 'luci.lpac',
+	method: 'get_version',
+	expect: {}
+});
+
+const callGetDrivers = rpc.declare({
+	object: 'luci.lpac',
+	method: 'get_drivers',
+	expect: {}
+});
+
+const callGetInfo = rpc.declare({
+	object: 'luci.lpac',
+	method: 'get_info',
+	expect: {}
+});
+
+const callListProfiles = rpc.declare({
+	object: 'luci.lpac',
+	method: 'list_profiles',
+	expect: {}
+});
+
+const callListNotifications = rpc.declare({
+	object: 'luci.lpac',
+	method: 'list_notifications',
+	expect: {}
+});
+
+const callEnableProfile = rpc.declare({
+	object: 'luci.lpac',
+	method: 'enable_profile',
+	params: [ 'iccid', 'refresh' ],
+	expect: {}
+});
+
+const callDisableProfile = rpc.declare({
+	object: 'luci.lpac',
+	method: 'disable_profile',
+	params: [ 'iccid', 'refresh' ],
+	expect: {}
+});
+
+const callNicknameProfile = rpc.declare({
+	object: 'luci.lpac',
+	method: 'nickname_profile',
+	params: [ 'iccid', 'nickname' ],
+	expect: {}
+});
+
+const callDeleteProfile = rpc.declare({
+	object: 'luci.lpac',
+	method: 'delete_profile',
+	params: [ 'iccid' ],
+	expect: {}
+});
+
+const callRemoveNotification = rpc.declare({
+	object: 'luci.lpac',
+	method: 'remove_notification',
+	params: [ 'seq' ],
+	expect: {}
+});
+
+const callGetConfig = rpc.declare({
+	object: 'luci.lpac',
+	method: 'get_config',
+	expect: {}
+});
+
+const callSetConfig = rpc.declare({
+	object: 'luci.lpac',
+	method: 'set_config',
+	params: [ 'config' ],
+	expect: {}
+});
+
+function safeCall(call) {
+	return function() {
+		return call.apply(null, arguments).catch(function() {
+			return {
+				success: false,
+				error: 'transport_error'
+			};
+		});
+	};
+}
+
+return baseclass.extend({
+	getVersion: safeCall(callGetVersion),
+	getDrivers: safeCall(callGetDrivers),
+	getInfo: safeCall(callGetInfo),
+	listProfiles: safeCall(callListProfiles),
+	listNotifications: safeCall(callListNotifications),
+	enableProfile: safeCall(callEnableProfile),
+	disableProfile: safeCall(callDisableProfile),
+	nicknameProfile: safeCall(callNicknameProfile),
+	deleteProfile: safeCall(callDeleteProfile),
+	removeNotification: safeCall(callRemoveNotification),
+	getConfig: safeCall(callGetConfig),
+	setConfig: safeCall(callSetConfig),
+
+	errorMessage: function(result) {
+		if (!result)
+			return _('No response from the lpac service.');
+
+		switch (result.error) {
+		case 'busy':
+			return _('Another lpac operation is already running.');
+		case 'invalid_argument':
+			return _('The request contains an invalid argument.');
+		case 'invalid_config':
+			return _('The lpac configuration is invalid.');
+		case 'not_installed':
+			return _('The lpac executable is not installed.');
+		case 'timeout':
+			return _('The lpac operation timed out.');
+		case 'output_too_large':
+			return _('The lpac output exceeded the RPC response limit.');
+		case 'execution_failed':
+			return _('The lpac process could not be executed.');
+		case 'lock_failed':
+			return _('The lpac operation lock could not be created.');
+		case 'config_write_failed':
+			return _('The lpac configuration could not be saved.');
+		case 'transport_error':
+			return _('The lpac RPC request failed or timed out.');
+		case 'lpac_error':
+			switch (result.reason) {
+			case 'profile_not_found':
+				return _('lpac could not find that profile identifier. Try the other identifier if available.');
+			case 'profile_not_disabled':
+				return _('The profile is not in the disabled state required for enabling.');
+			case 'profile_not_enabled':
+				return _('The profile is not in the enabled state required for disabling.');
+			case 'policy_denied':
+				return _('The eUICC profile policy rejected this operation.');
+			case 'wrong_reenable':
+				return _('The eUICC rejected re-enabling this profile.');
+			case 'profile_internal_error':
+				return _('lpac reported an internal profile error. Try the other identifier and refresh setting.');
+			}
+
+			return Number.isInteger(result.code)
+				? _('lpac rejected the operation (code %d).').format(result.code)
+				: _('lpac rejected the operation.');
+		case 'invalid_response':
+			return _('lpac returned an invalid or unexpected response.');
+		case 'rpc_error':
+			return result.message || _('The lpac RPC request failed.');
+		default:
+			return result.message || result.error || _('The lpac operation failed.');
+		}
+	},
+
+	dataOr: function(result, fallback) {
+		return result && result.success ? result.data : fallback;
+	}
+});

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+/* global lpac */
+
+'use strict';
+'require view';
+'require ui';
+'require lpac';
+
+const isReadonlyView = !L.hasViewPermission() || null;
+
+function operationLabel(operation) {
+	switch (operation) {
+	case 'install':
+		return _('Install');
+	case 'enable':
+		return _('Enable');
+	case 'disable':
+		return _('Disable');
+	case 'delete':
+		return _('Delete');
+	default:
+		return _('Unknown');
+	}
+}
+
+return view.extend({
+	load: function() {
+		return L.resolveDefault(lpac.listNotifications(), null);
+	},
+
+	showRemoveModal: function(notification) {
+		const seq = notification.seqNumber;
+
+		ui.showModal(_('Remove notification'), [
+			E('p', {}, [
+				_('Remove notification sequence %s from the eUICC?').format(seq)
+			]),
+			E('p', { 'class': 'alert-message warning' }, [
+				_('Removing an unprocessed notification permanently discards its eUICC record without contacting the provider. It does not undo the profile operation and may leave the provider state out of sync. Only continue if the notification was processed elsewhere or is no longer needed.')
+			]),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'btn',
+					'click': ui.hideModal
+				}, [ _('Cancel') ]),
+				' ',
+				E('button', {
+					'class': 'btn cbi-button-negative important',
+					'click': ui.createHandlerFn(this, function() {
+						ui.showModal(_('Removing notification'), [
+							E('p', { 'class': 'spinning' }, [ _('Waiting for lpac…') ])
+						]);
+
+						return lpac.removeNotification(String(seq)).then(function(result) {
+							if (!result || !result.success)
+								throw new Error(lpac.errorMessage(result));
+
+							ui.hideModal();
+							window.location.reload();
+						}).catch(function(error) {
+							ui.hideModal();
+							ui.addNotification(null, E('p', {}, [ error.message ]), 'error');
+						});
+					})
+				}, [ _('Remove') ])
+			])
+		]);
+	},
+
+	render: function(result) {
+		const notifications = lpac.dataOr(result, []);
+		const hasSequenceZero = notifications.some(function(notification) {
+			return notification.seqNumber === 0;
+		});
+		const table = E('table', { 'class': 'table' }, [
+			E('tr', { 'class': 'tr table-titles' }, [
+				E('th', { 'class': 'th left' }, [ _('Sequence') ]),
+				E('th', { 'class': 'th left' }, [ _('Operation') ]),
+				E('th', { 'class': 'th left' }, [ _('ICCID') ]),
+				E('th', { 'class': 'th left' }, [ _('Notification address') ]),
+				E('th', { 'class': 'th right' }, [ _('Actions') ])
+			])
+		]);
+		const rows = [];
+
+		if (result && result.success) {
+			notifications.forEach(function(notification) {
+				rows.push([
+					notification.seqNumber != null ? String(notification.seqNumber) : '-',
+					operationLabel(notification.profileManagementOperation),
+					notification.iccid || '-',
+					notification.notificationAddress || '-',
+					E('button', {
+						'class': 'btn cbi-button-negative',
+						'disabled': isReadonlyView || notification.seqNumber == null ||
+							notification.seqNumber === 0 || null,
+						'title': notification.seqNumber === 0
+							? _('The packaged lpac cannot explicitly remove sequence 0 safely') : '',
+						'click': ui.createHandlerFn(this, 'showRemoveModal', notification)
+					}, [ _('Remove') ])
+				]);
+			}, this);
+		}
+
+		cbi_update_table(table, rows, E('em', {}, [
+			result && result.success
+				? _('No pending notifications found.')
+				: _('Notification data is unavailable.')
+		]));
+
+		return E([
+			E('h2', {}, [ _('eUICC notifications') ]),
+			E('div', { 'class': 'cbi-map-descr' }, [
+				_('Profile operations can create notifications that should normally be sent to the provider.')
+			]),
+			E('div', { 'class': 'alert-message warning' }, [
+				_('Sending notifications is disabled because the packaged lpac does not securely verify RSP TLS certificates. Remove only discards the eUICC record; it does not contact the provider.')
+			]),
+			hasSequenceZero
+				? E('div', { 'class': 'alert-message warning' }, [
+					_('Notification sequence 0 is valid and remains visible, but explicit removal is disabled because the packaged lpac reports false success for that sequence.')
+				])
+				: E([]),
+			(!result || !result.success)
+				? E('div', { 'class': 'alert-message warning' }, [ lpac.errorMessage(result) ])
+				: E([]),
+			table,
+			E('div', { 'class': 'cbi-page-actions' }, [
+				E('button', {
+					'class': 'btn cbi-button cbi-button-action',
+					'click': ui.createHandlerFn(this, function() {
+						window.location.reload();
+					})
+				}, [ _('Refresh') ])
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+/* global lpac */
+
+'use strict';
+'require view';
+'require ui';
+'require lpac';
+
+function resultError(title, result) {
+	return E('div', { 'class': 'alert-message warning' }, [
+		E('strong', {}, [ title ]),
+		E('br'),
+		lpac.errorMessage(result)
+	]);
+}
+
+function valueOrUnknown(value) {
+	return value != null && value !== '' ? value : _('Unknown');
+}
+
+function formatBytes(value) {
+	return value != null && value !== '' && Number.isFinite(+value)
+		? '%1024.2mB'.format(+value)
+		: _('Unknown');
+}
+
+function detailsTable(fields) {
+	const table = E('table', { 'class': 'table' });
+
+	for (let i = 0; i < fields.length; i += 2) {
+		table.appendChild(E('tr', { 'class': 'tr' }, [
+			E('td', { 'class': 'td left', 'width': '35%' }, [ fields[i] ]),
+			E('td', { 'class': 'td left' }, [ valueOrUnknown(fields[i + 1]) ])
+		]));
+	}
+
+	return table;
+}
+
+return view.extend({
+	load: function() {
+		return Promise.all([
+			L.resolveDefault(lpac.getVersion(), null),
+			L.resolveDefault(lpac.getDrivers(), null),
+			L.resolveDefault(lpac.getInfo(), null),
+			L.resolveDefault(lpac.getConfig(), null)
+		]);
+	},
+
+	render: function(results) {
+		const versionResult = results[0];
+		const driversResult = results[1];
+		const infoResult = results[2];
+		const configResult = results[3];
+		const version = lpac.dataOr(versionResult, _('Unavailable'));
+		const drivers = lpac.dataOr(driversResult, {});
+		const config = lpac.dataOr(configResult, {});
+		const apduDrivers = drivers.apdu || drivers.LPAC_APDU || [];
+		const httpDrivers = drivers.http || drivers.LPAC_HTTP || [];
+		const backend = config.global && config.global.apdu_backend;
+		const nodes = [
+			E('h2', {}, [ _('eSIM Manager') ]),
+			E('div', { 'class': 'cbi-map-descr' }, [
+				_('Manage the eUICC through the packaged lpac backend. Modem and network lifecycle operations remain outside this application.')
+			]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, [ _('Backend status') ]),
+				detailsTable([
+					_('lpac version'), version,
+					_('Selected APDU backend'), backend,
+					_('Available APDU backends'), apduDrivers.length ? apduDrivers.join(', ') : null,
+					_('Available HTTP backends'), httpDrivers.length ? httpDrivers.join(', ') : null
+				])
+			])
+		];
+
+		if (!versionResult || !versionResult.success)
+			nodes.push(resultError(_('Unable to read lpac version'), versionResult));
+
+		if (!driversResult || !driversResult.success)
+			nodes.push(resultError(_('Unable to read lpac drivers'), driversResult));
+
+		if (!configResult || !configResult.success)
+			nodes.push(resultError(_('Unable to read lpac settings'), configResult));
+
+		if (!infoResult || !infoResult.success) {
+			nodes.push(resultError(_('Unable to read eUICC information'), infoResult));
+		}
+		else {
+			const info = infoResult.data || {};
+			const addresses = info.EuiccConfiguredAddresses || {};
+			const info2 = info.EUICCInfo2 || {};
+			const resources = info2.extCardResource || {};
+
+			nodes.push(E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, [ _('eUICC information') ]),
+				detailsTable([
+					_('EID'), info.eidValue,
+					_('Firmware version'), info2.euiccFirmwareVer,
+					_('Profile specification'), info2.profileVersion,
+					_('SVN version'), info2.svn,
+					_('Default SM-DP+ address'), addresses.defaultDpAddress,
+					_('Root SM-DS address'), addresses.rootDsAddress,
+					_('Free non-volatile memory'), formatBytes(resources.freeNonVolatileMemory),
+					_('Free volatile memory'), formatBytes(resources.freeVolatileMemory)
+			])
+		]));
+		}
+
+		nodes.push(E('div', { 'class': 'cbi-page-actions' }, [
+			E('button', {
+				'class': 'btn cbi-button cbi-button-action',
+				'click': ui.createHandlerFn(this, function() {
+					window.location.reload();
+				})
+			}, [ _('Refresh') ])
+		]));
+
+		return E(nodes);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.css
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.css
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.lpac-profile-key {
+	display: none;
+}
+
+.lpac-profile-field,
+.lpac-profile-value {
+	min-width: 0;
+}
+
+@media screen and (max-width: 854px) {
+	#lpac-profile-table,
+	#lpac-profile-table > tbody {
+		display: block;
+		width: 100%;
+	}
+
+	#lpac-profile-table .tr.table-titles {
+		display: none;
+	}
+
+	#lpac-profile-table .tr:not(.table-titles):not(.placeholder) {
+		display: grid;
+		grid-template-columns: minmax(0, 2fr) minmax(7rem, 1fr);
+		column-gap: .5em;
+		align-items: start;
+		width: 100%;
+		border-top: 1px solid var(--border-color-medium, var(--gray-color, rgba(127, 127, 127, .35)));
+	}
+
+	#lpac-profile-table .td {
+		display: block;
+		width: auto;
+		max-width: none;
+		min-width: 0;
+		padding: 3px;
+		position: static;
+		border-top: 0;
+		box-sizing: border-box;
+	}
+
+	#lpac-profile-table .td[data-title]::before,
+	#lpac-profile-table .td[data-title]::after {
+		display: none !important;
+		content: none !important;
+	}
+
+	#lpac-profile-table .tr.placeholder {
+		display: block;
+		width: 100%;
+		height: auto;
+	}
+
+	#lpac-profile-table .tr.placeholder > .td {
+		display: block;
+		width: 100%;
+		position: static;
+		text-align: center;
+		line-height: 3em;
+	}
+
+	#lpac-profile-table .td:nth-child(1) {
+		grid-column: 1;
+		grid-row: 1;
+	}
+
+	#lpac-profile-table .td:nth-child(2) {
+		grid-column: 2;
+		grid-row: 1;
+	}
+
+	#lpac-profile-table .td:nth-child(3) {
+		grid-column: 1;
+		grid-row: 2;
+	}
+
+	#lpac-profile-table .td:nth-child(4) {
+		grid-column: 2;
+		grid-row: 2;
+	}
+
+	#lpac-profile-table .td.cbi-section-actions {
+		grid-column: 1 / -1;
+		grid-row: 3;
+		width: auto;
+		max-width: none;
+		display: flex;
+		align-items: baseline;
+	}
+
+	#lpac-profile-table .lpac-profile-field {
+		display: flex;
+		align-items: baseline;
+		gap: .3em;
+		width: 100%;
+		font-size: 1em;
+		line-height: 1.5;
+	}
+
+	#lpac-profile-table .lpac-profile-key {
+		display: inline;
+		flex: 0 0 auto;
+	}
+
+	#lpac-profile-table .lpac-profile-value {
+		overflow-wrap: anywhere;
+		word-break: normal;
+	}
+
+	#lpac-profile-table .td:nth-child(3) .lpac-profile-value {
+		font-variant-numeric: tabular-nums;
+	}
+
+	#lpac-profile-table .td.cbi-section-actions > .lpac-profile-actions {
+		display: flex;
+		align-items: center;
+		gap: .3em;
+		width: 100%;
+	}
+
+	#lpac-profile-table .lpac-profile-actions > .btn {
+		flex: 1 1 0;
+		min-width: 0;
+		font-size: 13px !important;
+		line-height: 1.8em;
+		padding: 0 .6em;
+		margin-left: .15em;
+		margin-right: .15em;
+	}
+}

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+/* global lpac */
+
+'use strict';
+'require view';
+'require ui';
+'require lpac';
+
+const isReadonlyView = !L.hasViewPermission() || null;
+
+function profileLabel(profile) {
+	return profile.profileNickname || profile.profileName ||
+		profile.serviceProviderName || profile.iccid || profile.isdpAid || _('Unknown profile');
+}
+
+function profileStateLabel(state) {
+	switch (state) {
+	case 'enabled':
+		return _('Enabled');
+	case 'disabled':
+		return _('Disabled');
+	default:
+		return _('Unknown');
+	}
+}
+
+function profileStateIndicator(state) {
+	const className = state === 'enabled'
+		? 'label success'
+		: state === 'disabled' ? 'label' : 'label warning';
+
+	return E('span', { 'class': className }, [ profileStateLabel(state) ]);
+}
+
+function profileField(label, value) {
+	return E('span', { 'class': 'lpac-profile-field' }, [
+		E('strong', { 'class': 'lpac-profile-key' }, [ label, ':' ]),
+		E('span', { 'class': 'lpac-profile-value' }, [ value ])
+	]);
+}
+
+return view.extend({
+	load: function() {
+		return L.resolveDefault(lpac.listProfiles(), null);
+	},
+
+	runOperation: function(title, operation) {
+		ui.showModal(title, [
+			E('p', { 'class': 'spinning' }, [ _('Waiting for lpac…') ])
+		]);
+
+		return operation.then(function(result) {
+			if (!result || !result.success)
+				throw new Error(lpac.errorMessage(result));
+
+			ui.hideModal();
+			window.location.reload();
+		}).catch(function(error) {
+			ui.hideModal();
+			ui.addNotification(null, E('p', {}, [ error.message ]), 'error');
+		});
+	},
+
+	showStateModal: function(profile, enable) {
+		const label = profileLabel(profile);
+		const identifiers = [];
+
+		if (profile.iccid)
+			identifiers.push({ value: profile.iccid, label: _('ICCID') });
+
+		if (profile.isdpAid)
+			identifiers.push({ value: profile.isdpAid, label: _('ISD-P AID') });
+
+		const identifier = E('select', {
+			'id': 'lpac-profile-identifier',
+			'class': 'cbi-input-select'
+		}, identifiers.map(function(item, index) {
+			return E('option', {
+				'value': item.value,
+				'selected': index === 0 ? '' : null
+			}, [ item.label ]);
+		}));
+		const refresh = E('input', {
+			'id': 'lpac-profile-refresh',
+			'type': 'checkbox'
+		});
+
+		ui.showModal(enable ? _('Enable profile') : _('Disable profile'), [
+			E('p', {}, [
+				enable
+					? _('Enable profile “%s”?').format(label)
+					: _('Disable profile “%s”?').format(label)
+			]),
+			E('div', { 'class': 'cbi-value' }, [
+				E('label', {
+					'class': 'cbi-value-title',
+					'for': 'lpac-profile-identifier'
+				}, [ _('Profile identifier') ]),
+				E('div', { 'class': 'cbi-value-field' }, [
+					identifier,
+					E('div', { 'class': 'cbi-value-description' }, [
+						_('Try the ISD-P AID if this eUICC rejects an operation by ICCID.')
+					])
+				])
+			]),
+			E('label', { 'class': 'cbi-value' }, [
+				refresh,
+				' ',
+				_('Request an eUICC refresh')
+			]),
+			E('p', { 'class': 'cbi-value-description' }, [
+				_('Requests a logical UICC refresh after the profile change; it does not reboot the modem. Some eUICCs require this flag, while others reject it.')
+			]),
+			E('p', {
+				'class': 'cbi-value-description',
+				'role': 'note'
+			}, [
+				_('Changing the active profile can interrupt mobile connectivity. Some modems require a separate SIM power cycle or reconnect afterwards.')
+			]),
+			E('p', {
+				'class': 'cbi-value-description',
+				'role': 'note'
+			}, [
+				_('lpac may create a provider notification after this change. Secure network notification processing is not exposed, so the notification may remain pending on the eUICC.')
+			]),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'btn',
+					'click': ui.hideModal
+				}, [ _('Cancel') ]),
+				' ',
+				E('button', {
+					'class': 'btn cbi-button-action important',
+					'click': ui.createHandlerFn(this, function() {
+						const id = identifier.value;
+						const operation = enable
+							? lpac.enableProfile(id, refresh.checked)
+							: lpac.disableProfile(id, refresh.checked);
+
+						return this.runOperation(
+							enable ? _('Enabling profile') : _('Disabling profile'),
+							operation
+						);
+					})
+				}, [ enable ? _('Enable') : _('Disable') ])
+			])
+		]);
+	},
+
+	showNicknameModal: function(profile) {
+		const iccid = profile.iccid;
+		const input = E('input', {
+			'id': 'lpac-profile-nickname',
+			'class': 'cbi-input-text',
+			'type': 'text',
+			'maxlength': 64,
+			'value': profile.profileNickname || '',
+			'placeholder': _('Leave empty to clear the nickname')
+		});
+
+		ui.showModal(_('Set profile nickname'), [
+			E('div', { 'class': 'cbi-value' }, [
+				E('label', {
+					'class': 'cbi-value-title',
+					'for': 'lpac-profile-nickname'
+				}, [ _('Nickname') ]),
+				E('div', { 'class': 'cbi-value-field' }, [ input ])
+			]),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'btn',
+					'click': ui.hideModal
+				}, [ _('Cancel') ]),
+				' ',
+				E('button', {
+					'class': 'btn cbi-button-positive important',
+					'click': ui.createHandlerFn(this, function() {
+						return this.runOperation(
+							_('Updating nickname'),
+							lpac.nicknameProfile(iccid, input.value)
+						);
+					})
+				}, [ _('Save') ])
+			])
+		]);
+
+		input.focus();
+	},
+
+	showDeleteModal: function(profile) {
+		const id = profile.iccid || profile.isdpAid;
+
+		ui.showModal(_('Delete profile'), [
+			E('p', {}, [
+				_('Permanently delete profile “%s”? This action cannot be undone.').format(profileLabel(profile))
+			]),
+			E('p', { 'class': 'alert-message warning' }, [
+				_('lpac creates a provider notification after deletion. Secure network notification processing is not exposed, so the notification will remain pending on the eUICC.')
+			]),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'btn',
+					'click': ui.hideModal
+				}, [ _('Cancel') ]),
+				' ',
+				E('button', {
+					'class': 'btn cbi-button-negative important',
+					'click': ui.createHandlerFn(this, function() {
+						return this.runOperation(_('Deleting profile'), lpac.deleteProfile(id));
+					})
+				}, [ _('Delete') ])
+			])
+		]);
+	},
+
+	render: function(result) {
+		const profiles = lpac.dataOr(result, []);
+		const table = E('table', {
+			'id': 'lpac-profile-table',
+			'class': 'table lpac-profile-table'
+		}, [
+			E('tr', { 'class': 'tr table-titles' }, [
+				E('th', { 'class': 'th left' }, [ _('Profile') ]),
+				E('th', { 'class': 'th left' }, [ _('Provider') ]),
+				E('th', { 'class': 'th left' }, [ _('ICCID') ]),
+				E('th', { 'class': 'th left' }, [ _('State') ]),
+				E('th', { 'class': 'th right cbi-section-actions' }, [ _('Actions') ])
+			])
+		]);
+		const rows = [];
+
+		if (result && result.success) {
+			profiles.forEach(function(profile) {
+				const name = profileLabel(profile);
+				const provider = profile.serviceProviderName || '-';
+				const iccid = profile.iccid || '-';
+				const state = String(profile.profileState || '').toLowerCase();
+				const enabled = state === 'enabled';
+				const disabled = state === 'disabled';
+				const id = profile.iccid || profile.isdpAid;
+				const actions = E('div', { 'class': 'lpac-profile-actions' }, [
+					E('button', {
+						'class': 'btn cbi-button-action',
+						'disabled': isReadonlyView || !id ||
+							(!enabled && !disabled) || null,
+						'title': (!enabled && !disabled)
+							? _('The profile state does not allow this action') : '',
+						'click': ui.createHandlerFn(this, 'showStateModal', profile, !enabled)
+					}, [ enabled ? _('Disable') : disabled ? _('Enable') : _('Unavailable') ]),
+					E('button', {
+						'class': 'btn cbi-button-edit',
+						'disabled': isReadonlyView || !profile.iccid || null,
+						'title': !profile.iccid
+							? _('An ICCID is required to rename this profile') : '',
+						'click': ui.createHandlerFn(this, 'showNicknameModal', profile)
+					}, [ _('Rename') ]),
+					E('button', {
+						'class': 'btn cbi-button-negative',
+						'disabled': isReadonlyView || !disabled || !id || null,
+						'title': !disabled
+							? _('Only a disabled profile can be deleted') : '',
+						'click': ui.createHandlerFn(this, 'showDeleteModal', profile)
+					}, [ _('Delete') ])
+				]);
+
+				rows.push([
+					[ name, profileField(_('Profile'), name) ],
+					[ provider, profileField(_('Provider'), provider) ],
+					[ iccid, profileField(_('ICCID'), iccid) ],
+					[ state, profileField(_('State'), profileStateIndicator(state)) ],
+					actions
+				]);
+			}, this);
+		}
+
+		cbi_update_table(table, rows, E('em', {}, [
+			result && result.success
+				? _('No eSIM profiles found.')
+				: _('Profile data is unavailable.')
+		]));
+
+		return E([
+			E('link', {
+				'rel': 'stylesheet',
+				'href': L.resource('view/lpac/profiles.css')
+			}),
+			E('h2', {}, [ _('eSIM profiles') ]),
+			E('div', { 'class': 'cbi-map-descr' }, [
+				_('Profiles are read directly from the eUICC using the configured lpac APDU backend.')
+			]),
+			(!result || !result.success)
+				? E('div', { 'class': 'alert-message warning' }, [ lpac.errorMessage(result) ])
+				: E([]),
+			table,
+			E('div', { 'class': 'cbi-page-actions' }, [
+				E('button', {
+					'class': 'btn cbi-button cbi-button-action',
+					'click': ui.createHandlerFn(this, function() {
+						window.location.reload();
+					})
+				}, [ _('Refresh') ])
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+/* global lpac */
+
+'use strict';
+'require view';
+'require ui';
+'require lpac';
+
+const isReadonlyView = !L.hasViewPermission() || null;
+const supportedBackends = [ 'uqmi', 'mbim', 'at', 'pcsc' ];
+
+function formRow(label, input, description) {
+	return E('div', { 'class': 'cbi-value' }, [
+		E('label', {
+			'class': 'cbi-value-title',
+			'for': input.getAttribute('id') || null
+		}, [ label ]),
+		E('div', { 'class': 'cbi-value-field' }, [
+			input,
+			description ? E('div', { 'class': 'cbi-value-description' }, [ description ]) : E([])
+		])
+	]);
+}
+
+function textInput(id, value, placeholder, maxlength) {
+	return E('input', {
+		'id': id,
+		'class': 'cbi-input-text',
+		'type': 'text',
+		'value': value || '',
+		'placeholder': placeholder || '',
+		'maxlength': maxlength || 128,
+		'disabled': isReadonlyView
+	});
+}
+
+function checkbox(id, checked) {
+	return E('input', {
+		'id': id,
+		'type': 'checkbox',
+		'checked': checked ? '' : null,
+		'disabled': isReadonlyView
+	});
+}
+
+function selectedBackends(drivers, current, discoveryAvailable) {
+	const reported = drivers.apdu || drivers.LPAC_APDU || [];
+	const values = (discoveryAvailable ? reported : supportedBackends).filter(function(name) {
+		return supportedBackends.indexOf(name) !== -1;
+	});
+
+	if (current && values.indexOf(current) === -1 && supportedBackends.indexOf(current) !== -1)
+		values.push(current);
+
+	return values;
+}
+
+function validDevicePath(value) {
+	if (typeof value !== 'string' || value.length < 6 || value.length > 128 ||
+	    !/^\/dev\/[A-Za-z0-9._:+@,/-]+$/.test(value))
+		return false;
+
+	return !value.slice(5).split('/').some(function(part) {
+		return !part || part === '.' || part === '..';
+	});
+}
+
+return view.extend({
+	load: function() {
+		return Promise.all([
+			L.resolveDefault(lpac.getConfig(), null),
+			L.resolveDefault(lpac.getDrivers(), null)
+		]);
+	},
+
+	handleSaveConfig: function() {
+		const atDevice = document.getElementById('lpac-at-device').value.trim();
+		const uqmiDevice = document.getElementById('lpac-uqmi-device').value.trim();
+		const mbimDevice = document.getElementById('lpac-mbim-device').value.trim();
+		const aid = document.getElementById('lpac-custom-aid').value.trim();
+		const backend = document.getElementById('lpac-apdu-backend').value;
+
+		if (!validDevicePath(atDevice) || !validDevicePath(uqmiDevice) ||
+		    !validDevicePath(mbimDevice)) {
+			ui.addNotification(null, E('p', {}, [ _('Device paths must be safe absolute paths below /dev without empty, . or .. components.') ]), 'error');
+			return;
+		}
+
+		if (backend === 'uqmi' && !/^\/dev\/cdc-wdm[0-9]+$/.test(uqmiDevice)) {
+			ui.addNotification(null, E('p', {}, [ _('The active uqmi backend currently requires a /dev/cdc-wdmN control device.') ]), 'error');
+			return;
+		}
+
+		if (!/^[0-9A-Fa-f]{32}$/.test(aid)) {
+			ui.addNotification(null, E('p', {}, [ _('The custom ISD-R AID must contain exactly 32 hexadecimal characters.') ]), 'error');
+			return;
+		}
+
+		const config = {
+			global: {
+				apdu_backend: backend,
+				http_backend: 'curl',
+				apdu_debug: document.getElementById('lpac-apdu-debug').checked ? '1' : '0',
+				http_debug: document.getElementById('lpac-http-debug').checked ? '1' : '0',
+				custom_isd_r_aid: aid.toUpperCase()
+			},
+			at: {
+				device: atDevice,
+				debug: document.getElementById('lpac-at-debug').checked ? '1' : '0'
+			},
+			uqmi: {
+				device: uqmiDevice,
+				debug: document.getElementById('lpac-uqmi-debug').checked ? '1' : '0'
+			},
+			mbim: {
+				device: mbimDevice,
+				proxy: document.getElementById('lpac-mbim-proxy').checked ? '1' : '0'
+			}
+		};
+
+		ui.showModal(_('Saving lpac settings'), [
+			E('p', { 'class': 'spinning' }, [ _('Applying validated configuration…') ])
+		]);
+
+		return lpac.setConfig(config).then(function(result) {
+			if (!result || !result.success)
+				throw new Error(lpac.errorMessage(result));
+
+			document.getElementById('lpac-custom-aid').value =
+				result.data?.global?.custom_isd_r_aid || aid.toUpperCase();
+			ui.hideModal();
+			ui.addNotification(null, E('p', {}, [ _('The lpac settings were saved.') ]), 'info');
+		}).catch(function(error) {
+			ui.hideModal();
+			ui.addNotification(null, E('p', {}, [ error.message ]), 'error');
+		});
+	},
+
+	render: function(results) {
+		const configResult = results[0];
+		const driversResult = results[1];
+
+		if (!configResult || !configResult.success) {
+			return E([
+				E('h2', {}, [ _('lpac settings') ]),
+				E('div', { 'class': 'alert-message warning' }, [ lpac.errorMessage(configResult) ])
+			]);
+		}
+
+		const config = configResult.data || {};
+		const global = config.global || {};
+		const at = config.at || {};
+		const uqmi = config.uqmi || {};
+		const mbim = config.mbim || {};
+		const drivers = lpac.dataOr(driversResult, {});
+		const driverListAvailable = !!(driversResult && driversResult.success &&
+			(drivers.apdu || drivers.LPAC_APDU || []).length);
+		const backends = selectedBackends(drivers, global.apdu_backend,
+			driverListAvailable);
+		const backendSelect = E('select', {
+			'id': 'lpac-apdu-backend',
+			'class': 'cbi-input-select',
+			'disabled': isReadonlyView
+		}, backends.map(function(name) {
+			return E('option', {
+				'value': name,
+				'selected': name === global.apdu_backend ? '' : null
+			}, [ name ]);
+		}));
+
+		return E([
+			E('h2', {}, [ _('lpac settings') ]),
+			E('div', { 'class': 'cbi-map-descr' }, [
+				_('These values are stored in /etc/config/lpac. Changes apply to the next lpac operation and do not restart any modem or network interface.'),
+				' ',
+				_('Options not managed by this page are preserved when settings are saved.')
+			]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, [ _('General') ]),
+				formRow(_('APDU backend'), backendSelect,
+					driverListAvailable
+						? _('Reported drivers are offered; an unreported current value is retained.')
+						: _('Driver availability could not be confirmed, so supported backend names are offered without verification.')),
+				formRow(_('Custom ISD-R AID'),
+					textInput('lpac-custom-aid', global.custom_isd_r_aid || 'A0000005591010FFFFFFFF8900000100', '', 32),
+					_('32-character hexadecimal application identifier used to select the eUICC ISD-R applet.')),
+				formRow(_('APDU debug'), checkbox('lpac-apdu-debug', global.apdu_debug === '1'),
+					_('Debug output can contain raw APDU data. Enable only for controlled troubleshooting.')),
+				formRow(_('HTTP debug'), checkbox('lpac-http-debug', global.http_debug === '1'),
+					_('Debug output can contain sensitive HTTP payloads. Enable only for controlled troubleshooting.'))
+			]),
+			!driverListAvailable
+				? E('div', { 'class': 'alert-message warning' }, [
+					driversResult && driversResult.success
+						? _('No supported APDU drivers were reported by lpac.')
+						: lpac.errorMessage(driversResult)
+				])
+				: E([]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, [ _('uqmi backend') ]),
+				formRow(_('Control device'),
+					textInput('lpac-uqmi-device', uqmi.device || '/dev/cdc-wdm0', '/dev/cdc-wdm0'),
+					_('Use the /dev/cdc-wdmN device associated with the eUICC. Alternate control devices may not work with the current OpenWrt uqmi backend.')),
+				formRow(_('uqmi debug'), checkbox('lpac-uqmi-debug', uqmi.debug === '1'))
+			]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, [ _('MBIM backend') ]),
+				formRow(_('Control device'), textInput('lpac-mbim-device', mbim.device || '/dev/cdc-wdm0', '/dev/cdc-wdm0')),
+				formRow(_('Use mbim-proxy'), checkbox('lpac-mbim-proxy', mbim.proxy !== '0'))
+			]),
+			E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, [ _('AT backend') ]),
+				formRow(_('Serial device'),
+					textInput('lpac-at-device', at.device || '/dev/ttyUSB2', '/dev/ttyUSB2'),
+					_('The AT backend is timing-sensitive and may not support every profile operation on all modems.')),
+				formRow(_('AT debug'), checkbox('lpac-at-debug', at.debug === '1'))
+			]),
+			E('div', { 'class': 'cbi-page-actions' }, [
+				E('button', {
+					'class': 'btn cbi-button cbi-button-positive important',
+					'disabled': isReadonlyView,
+					'click': ui.createHandlerFn(this, 'handleSaveConfig')
+				}, [ _('Save') ])
+			])
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js
+++ b/applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js
@@ -114,7 +114,8 @@ return view.extend({
 			},
 			mbim: {
 				device: mbimDevice,
-				proxy: document.getElementById('lpac-mbim-proxy').checked ? '1' : '0'
+				proxy: document.getElementById('lpac-mbim-proxy').checked ? '1' : '0',
+				skip_slot_mapping: document.getElementById('lpac-mbim-skip-slot-mapping').checked ? '1' : '0'
 			}
 		};
 
@@ -206,7 +207,10 @@ return view.extend({
 			E('div', { 'class': 'cbi-section' }, [
 				E('h3', {}, [ _('MBIM backend') ]),
 				formRow(_('Control device'), textInput('lpac-mbim-device', mbim.device || '/dev/cdc-wdm0', '/dev/cdc-wdm0')),
-				formRow(_('Use mbim-proxy'), checkbox('lpac-mbim-proxy', mbim.proxy !== '0'))
+				formRow(_('Use mbim-proxy'), checkbox('lpac-mbim-proxy', mbim.proxy !== '0')),
+				formRow(_('Skip MBIM slot mapping'),
+					checkbox('lpac-mbim-skip-slot-mapping', mbim.skip_slot_mapping === '1'),
+					_('Use the modem\'s currently selected slot without querying or changing MBIM Device Slot Mapping. Enable only for devices that cannot use normal slot mapping; the configured MBIM UIM slot is ignored.'))
 			]),
 			E('div', { 'class': 'cbi-section' }, [
 				E('h3', {}, [ _('AT backend') ]),

--- a/applications/luci-app-lpac/po/templates/lpac.pot
+++ b/applications/luci-app-lpac/po/templates/lpac.pot
@@ -1,25 +1,25 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:186
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:187
 msgid ""
 "32-character hexadecimal application identifier used to select the eUICC ISD-"
 "R applet."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:180
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:181
 msgid "APDU backend"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:187
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:188
 msgid "APDU debug"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:212
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:216
 msgid "AT backend"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:216
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:220
 msgid "AT debug"
 msgstr ""
 
@@ -36,7 +36,7 @@ msgstr ""
 msgid "Another lpac operation is already running."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:122
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:123
 msgid "Applying validated configuration…"
 msgstr ""
 
@@ -65,22 +65,22 @@ msgid ""
 "require a separate SIM power cycle or reconnect afterwards."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:201
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:208
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:202
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:209
 msgid "Control device"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:184
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:185
 msgid "Custom ISD-R AID"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:188
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:189
 msgid ""
 "Debug output can contain raw APDU data. Enable only for controlled "
 "troubleshooting."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:190
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:191
 msgid ""
 "Debug output can contain sensitive HTTP payloads. Enable only for controlled "
 "troubleshooting."
@@ -132,7 +132,7 @@ msgstr ""
 msgid "Disabling profile"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:183
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:184
 msgid ""
 "Driver availability could not be confirmed, so supported backend names are "
 "offered without verification."
@@ -176,7 +176,7 @@ msgstr ""
 msgid "Free volatile memory"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:179
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:180
 msgid "General"
 msgstr ""
 
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Grant access to the lpac eSIM manager"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:189
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:190
 msgid "HTTP debug"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Leave empty to clear the nickname"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:207
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:208
 msgid "MBIM backend"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 msgid "No response from the lpac service."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:195
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:196
 msgid "No supported APDU drivers were reported by lpac."
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr ""
 msgid "Operation"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:176
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:177
 msgid "Options not managed by this page are preserved when settings are saved."
 msgstr ""
 
@@ -349,7 +349,7 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:182
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:183
 msgid "Reported drivers are offered; an unreported current value is retained."
 msgstr ""
 
@@ -372,11 +372,11 @@ msgid "SVN version"
 msgstr ""
 
 #: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:183
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:223
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:227
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:121
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:122
 msgid "Saving lpac settings"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Sequence"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:213
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:217
 msgid "Serial device"
 msgstr ""
 
@@ -407,12 +407,16 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:211
+msgid "Skip MBIM slot mapping"
+msgstr ""
+
 #: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:226
 #: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:270
 msgid "State"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:215
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:219
 msgid ""
 "The AT backend is timing-sensitive and may not support every profile "
 "operation on all modems."
@@ -475,7 +479,7 @@ msgstr ""
 msgid "The lpac process could not be executed."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:132
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:133
 msgid "The lpac settings were saved."
 msgstr ""
 
@@ -499,7 +503,7 @@ msgstr ""
 msgid "The request contains an invalid argument."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:174
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:175
 msgid ""
 "These values are stored in /etc/config/lpac. Changes apply to the next lpac "
 "operation and do not restart any modem or network interface."
@@ -545,14 +549,21 @@ msgstr ""
 msgid "Updating nickname"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:209
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:210
 msgid "Use mbim-proxy"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:203
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:204
 msgid ""
 "Use the /dev/cdc-wdmN device associated with the eUICC. Alternate control "
 "devices may not work with the current OpenWrt uqmi backend."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:213
+msgid ""
+"Use the modem's currently selected slot without querying or changing MBIM "
+"Device Slot Mapping. Enable only for devices that cannot use normal slot "
+"mapping; the configured MBIM UIM slot is ignored."
 msgstr ""
 
 #: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:51
@@ -615,8 +626,8 @@ msgstr ""
 msgid "lpac returned an invalid or unexpected response."
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:145
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:172
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:146
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:173
 msgid "lpac settings"
 msgstr ""
 
@@ -624,10 +635,10 @@ msgstr ""
 msgid "lpac version"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:200
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:201
 msgid "uqmi backend"
 msgstr ""
 
-#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:204
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:205
 msgid "uqmi debug"
 msgstr ""

--- a/applications/luci-app-lpac/po/templates/lpac.pot
+++ b/applications/luci-app-lpac/po/templates/lpac.pot
@@ -1,0 +1,633 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:186
+msgid ""
+"32-character hexadecimal application identifier used to select the eUICC ISD-"
+"R applet."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:180
+msgid "APDU backend"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:187
+msgid "APDU debug"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:212
+msgid "AT backend"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:216
+msgid "AT debug"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:81
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:227
+msgid "Actions"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:254
+msgid "An ICCID is required to rename this profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:116
+msgid "Another lpac operation is already running."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:122
+msgid "Applying validated configuration…"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:71
+msgid "Available APDU backends"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:72
+msgid "Available HTTP backends"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:67
+msgid "Backend status"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:45
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:130
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:173
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:204
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:118
+msgid ""
+"Changing the active profile can interrupt mobile connectivity. Some modems "
+"require a separate SIM power cycle or reconnect afterwards."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:201
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:208
+msgid "Control device"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:184
+msgid "Custom ISD-R AID"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:188
+msgid ""
+"Debug output can contain raw APDU data. Enable only for controlled "
+"troubleshooting."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:190
+msgid ""
+"Debug output can contain sensitive HTTP payloads. Enable only for controlled "
+"troubleshooting."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:102
+msgid "Default SM-DP+ address"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:20
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:211
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:263
+msgid "Delete"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:193
+msgid "Delete profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:209
+msgid "Deleting profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:85
+msgid ""
+"Device paths must be safe absolute paths below /dev without empty, . or .. "
+"components."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:18
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:145
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:249
+msgid "Disable"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:88
+msgid "Disable profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:92
+msgid "Disable profile “%s”?"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:21
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:141
+msgid "Disabling profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:183
+msgid ""
+"Driver availability could not be confirmed, so supported backend names are "
+"offered without verification."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:98
+msgid "EID"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:16
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:145
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:249
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:88
+msgid "Enable profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:91
+msgid "Enable profile “%s”?"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:19
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:141
+msgid "Enabling profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:99
+msgid "Firmware version"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:104
+msgid "Free non-volatile memory"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:105
+msgid "Free volatile memory"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:179
+msgid "General"
+msgstr ""
+
+#: applications/luci-app-lpac/root/usr/share/rpcd/acl.d/luci-app-lpac.json:3
+msgid "Grant access to the lpac eSIM manager"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:189
+msgid "HTTP debug"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:79
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:69
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:225
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:269
+msgid "ICCID"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:72
+msgid "ISD-P AID"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:14
+msgid "Install"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:158
+msgid "Leave empty to clear the nickname"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:207
+msgid "MBIM backend"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:64
+msgid ""
+"Manage the eUICC through the packaged lpac backend. Modem and network "
+"lifecycle operations remain outside this application."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:166
+msgid "Nickname"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:278
+msgid "No eSIM profiles found."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:107
+msgid "No pending notifications found."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:112
+msgid "No response from the lpac service."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:195
+msgid "No supported APDU drivers were reported by lpac."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:80
+msgid "Notification address"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:108
+msgid "Notification data is unavailable."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:121
+msgid ""
+"Notification sequence 0 is valid and remains visible, but explicit removal "
+"is disabled because the packaged lpac reports false success for that "
+"sequence."
+msgstr ""
+
+#: applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json:32
+msgid "Notifications"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:261
+msgid "Only a disabled profile can be deleted"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:78
+msgid "Operation"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:176
+msgid "Options not managed by this page are preserved when settings are saved."
+msgstr ""
+
+#: applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json:14
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:195
+msgid "Permanently delete profile “%s”? This action cannot be undone."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:223
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:267
+msgid "Profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:279
+msgid "Profile data is unavailable."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:98
+msgid "Profile identifier"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:114
+msgid ""
+"Profile operations can create notifications that should normally be sent to "
+"the provider."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:100
+msgid "Profile specification"
+msgstr ""
+
+#: applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json:23
+msgid "Profiles"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:289
+msgid ""
+"Profiles are read directly from the eUICC using the configured lpac APDU "
+"backend."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:224
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:268
+msgid "Provider"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:134
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:116
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:301
+msgid "Refresh"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:65
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:100
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:34
+msgid "Remove notification"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:36
+msgid "Remove notification sequence %s from the eUICC?"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:39
+msgid ""
+"Removing an unprocessed notification permanently discards its eUICC record "
+"without contacting the provider. It does not undo the profile operation and "
+"may leave the provider state out of sync. Only continue if the notification "
+"was processed elsewhere or is no longer needed."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:50
+msgid "Removing notification"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:256
+msgid "Rename"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:182
+msgid "Reported drivers are offered; an unreported current value is retained."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:109
+msgid "Request an eUICC refresh"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:112
+msgid ""
+"Requests a logical UICC refresh after the profile change; it does not reboot "
+"the modem. Some eUICCs require this flag, while others reject it."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:103
+msgid "Root SM-DS address"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:101
+msgid "SVN version"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:183
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:223
+msgid "Save"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:121
+msgid "Saving lpac settings"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:70
+msgid "Selected APDU backend"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:117
+msgid ""
+"Sending notifications is disabled because the packaged lpac does not "
+"securely verify RSP TLS certificates. Remove only discards the eUICC record; "
+"it does not contact the provider."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:77
+msgid "Sequence"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:213
+msgid "Serial device"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:161
+msgid "Set profile nickname"
+msgstr ""
+
+#: applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json:41
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:226
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:270
+msgid "State"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:215
+msgid ""
+"The AT backend is timing-sensitive and may not support every profile "
+"operation on all modems."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:90
+msgid ""
+"The active uqmi backend currently requires a /dev/cdc-wdmN control device."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:95
+msgid "The custom ISD-R AID must contain exactly 32 hexadecimal characters."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:144
+msgid "The eUICC profile policy rejected this operation."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:146
+msgid "The eUICC rejected re-enabling this profile."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:134
+msgid "The lpac RPC request failed or timed out."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:157
+msgid "The lpac RPC request failed."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:132
+msgid "The lpac configuration could not be saved."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:120
+msgid "The lpac configuration is invalid."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:122
+msgid "The lpac executable is not installed."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:159
+msgid "The lpac operation failed."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:130
+msgid "The lpac operation lock could not be created."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:124
+msgid "The lpac operation timed out."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:126
+msgid "The lpac output exceeded the RPC response limit."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:128
+msgid "The lpac process could not be executed."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:132
+msgid "The lpac settings were saved."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:98
+msgid "The packaged lpac cannot explicitly remove sequence 0 safely"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:140
+msgid "The profile is not in the disabled state required for enabling."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:142
+msgid "The profile is not in the enabled state required for disabling."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:247
+msgid "The profile state does not allow this action"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:118
+msgid "The request contains an invalid argument."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:174
+msgid ""
+"These values are stored in /etc/config/lpac. Changes apply to the next lpac "
+"operation and do not restart any modem or network interface."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:102
+msgid "Try the ISD-P AID if this eUICC rejects an operation by ICCID."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:87
+msgid "Unable to read eUICC information"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:81
+msgid "Unable to read lpac drivers"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:84
+msgid "Unable to read lpac settings"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:78
+msgid "Unable to read lpac version"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:55
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:249
+msgid "Unavailable"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:22
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:18
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:24
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:23
+msgid "Unknown"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:13
+msgid "Unknown profile"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:179
+msgid "Updating nickname"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:209
+msgid "Use mbim-proxy"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:203
+msgid ""
+"Use the /dev/cdc-wdmN device associated with the eUICC. Alternate control "
+"devices may not work with the current OpenWrt uqmi backend."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:51
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:49
+msgid "Waiting for lpac…"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:62
+#: applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json:3
+msgid "eSIM Manager"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:287
+msgid "eSIM profiles"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:96
+msgid "eUICC information"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/notifications.js:112
+msgid "eUICC notifications"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:138
+msgid ""
+"lpac could not find that profile identifier. Try the other identifier if "
+"available."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:198
+msgid ""
+"lpac creates a provider notification after deletion. Secure network "
+"notification processing is not exposed, so the notification will remain "
+"pending on the eUICC."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/profiles.js:124
+msgid ""
+"lpac may create a provider notification after this change. Secure network "
+"notification processing is not exposed, so the notification may remain "
+"pending on the eUICC."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:152
+msgid "lpac rejected the operation (code %d)."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:153
+msgid "lpac rejected the operation."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:148
+msgid ""
+"lpac reported an internal profile error. Try the other identifier and "
+"refresh setting."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/lpac.js:155
+msgid "lpac returned an invalid or unexpected response."
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:145
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:172
+msgid "lpac settings"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/overview.js:69
+msgid "lpac version"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:200
+msgid "uqmi backend"
+msgstr ""
+
+#: applications/luci-app-lpac/htdocs/luci-static/resources/view/lpac/settings.js:204
+msgid "uqmi debug"
+msgstr ""

--- a/applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json
+++ b/applications/luci-app-lpac/root/usr/share/luci/menu.d/luci-app-lpac.json
@@ -1,0 +1,48 @@
+{
+	"admin/network/lpac": {
+		"title": "eSIM Manager",
+		"order": 90,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-lpac" ]
+		}
+	},
+
+	"admin/network/lpac/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "lpac/overview"
+		}
+	},
+
+	"admin/network/lpac/profiles": {
+		"title": "Profiles",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "lpac/profiles"
+		}
+	},
+
+	"admin/network/lpac/notifications": {
+		"title": "Notifications",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "lpac/notifications"
+		}
+	},
+
+	"admin/network/lpac/settings": {
+		"title": "Settings",
+		"order": 40,
+		"action": {
+			"type": "view",
+			"path": "lpac/settings"
+		}
+	}
+}

--- a/applications/luci-app-lpac/root/usr/share/rpcd/acl.d/luci-app-lpac.json
+++ b/applications/luci-app-lpac/root/usr/share/rpcd/acl.d/luci-app-lpac.json
@@ -1,0 +1,29 @@
+{
+	"luci-app-lpac": {
+		"description": "Grant access to the lpac eSIM manager",
+		"read": {
+			"ubus": {
+				"luci.lpac": [
+					"get_version",
+					"get_drivers",
+					"get_info",
+					"list_profiles",
+					"list_notifications",
+					"get_config"
+				]
+			}
+		},
+		"write": {
+			"ubus": {
+				"luci.lpac": [
+					"enable_profile",
+					"disable_profile",
+					"nickname_profile",
+					"delete_profile",
+					"remove_notification",
+					"set_config"
+				]
+			}
+		}
+	}
+}

--- a/applications/luci-app-lpac/root/usr/share/rpcd/ucode/luci.lpac
+++ b/applications/luci-app-lpac/root/usr/share/rpcd/ucode/luci.lpac
@@ -644,7 +644,9 @@ function normalize_config(config) {
 	    }) ||
 	    !has_exact_keys(config.at, { device: true, debug: true }) ||
 	    !has_exact_keys(config.uqmi, { device: true, debug: true }) ||
-	    !has_exact_keys(config.mbim, { device: true, proxy: true }))
+	    !has_exact_keys(config.mbim, {
+		device: true, proxy: true, skip_slot_mapping: true
+	    }))
 		return null;
 
 	const apdu_backend = config.global.apdu_backend;
@@ -654,12 +656,14 @@ function normalize_config(config) {
 	const at_debug = normalize_flag(config.at.debug);
 	const uqmi_debug = normalize_flag(config.uqmi.debug);
 	const mbim_proxy = normalize_flag(config.mbim.proxy);
+	const mbim_skip_slot_mapping = normalize_flag(config.mbim.skip_slot_mapping);
 	const aid = config.global.custom_isd_r_aid;
 
 	if (type(apdu_backend) != 'string' ||
 	    index([ 'uqmi', 'mbim', 'at', 'pcsc' ], apdu_backend) < 0 ||
 	    http_backend !== 'curl' || apdu_debug === null || http_debug === null ||
 	    at_debug === null || uqmi_debug === null || mbim_proxy === null ||
+	    mbim_skip_slot_mapping === null ||
 	    !valid_aid(aid) ||
 	    !valid_device_path(config.at.device) ||
 	    !valid_device_path(config.uqmi.device) ||
@@ -685,7 +689,8 @@ function normalize_config(config) {
 		},
 		mbim: {
 			device: config.mbim.device,
-			proxy: mbim_proxy
+			proxy: mbim_proxy,
+			skip_slot_mapping: mbim_skip_slot_mapping
 		}
 	};
 }
@@ -726,7 +731,9 @@ read_config = function() {
 			},
 			mbim: {
 				device: uci_value(uci, 'mbim', 'device', '/dev/cdc-wdm0'),
-				proxy: uci_value(uci, 'mbim', 'proxy', '1')
+				proxy: uci_value(uci, 'mbim', 'proxy', '1'),
+				skip_slot_mapping:
+					uci_value(uci, 'mbim', 'skip_slot_mapping', '0')
 			}
 		});
 	}
@@ -765,6 +772,8 @@ function write_config(config) {
 			uci.set('lpac', 'mbim', 'mbim') &&
 			uci.set('lpac', 'mbim', 'device', config.mbim.device) &&
 			uci.set('lpac', 'mbim', 'proxy', config.mbim.proxy) &&
+			uci.set('lpac', 'mbim', 'skip_slot_mapping',
+				config.mbim.skip_slot_mapping) &&
 			uci.commit('lpac');
 	}
 	catch (e) {

--- a/applications/luci-app-lpac/root/usr/share/rpcd/ucode/luci.lpac
+++ b/applications/luci-app-lpac/root/usr/share/rpcd/ucode/luci.lpac
@@ -1,0 +1,939 @@
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict';
+
+import { chmod, lstat, open } from 'fs';
+import {
+	connect,
+	STATUS_NOT_FOUND,
+	STATUS_NOT_SUPPORTED,
+	STATUS_OK,
+	STATUS_TIMEOUT
+} from 'ubus';
+import { cursor } from 'uci';
+
+const LPAC_PATH = '/usr/bin/lpac';
+const FLOCK_PATH = '/usr/bin/flock';
+const LOCK_PATH = '/var/run/luci-lpac.lock';
+const DEFAULT_AID = 'A0000005591010FFFFFFFF8900000100';
+let read_config;
+
+/*
+ * Keep the connection alive for the lifetime of the rpcd script.  Its nested
+ * call timeout is deliberately longer than rpcd's maximum configurable
+ * 600-second execution timeout, so this client does not abandon the nested
+ * call before file.exec returns a status.
+ */
+const ubus = connect(null, 610);
+
+const INVALID = {};
+
+function success(data) {
+	return {
+		success: true,
+		code: 0,
+		message: 'success',
+		data
+	};
+}
+
+function failure(error, message, code) {
+	const result = {
+		success: false,
+		error,
+		message
+	};
+
+	if (type(code) == 'int')
+		result.code = code;
+
+	return result;
+}
+
+function safe_text(value, max_length) {
+	if (value === null)
+		return null;
+
+	if (type(value) != 'string' || length(value) > max_length ||
+	    match(value, /[[:cntrl:]]/) !== null)
+		return null;
+
+	return value;
+}
+
+function safe_uint(value) {
+	return (type(value) == 'int' && value >= 0) ? value : null;
+}
+
+function safe_text_list(value, max_items, max_length) {
+	const result = [];
+
+	if (type(value) != 'array')
+		return result;
+
+	for (let item in value) {
+		const text = safe_text(item, max_length);
+
+		if (text !== null)
+			push(result, text);
+
+		if (length(result) >= max_items)
+			break;
+	}
+
+	return result;
+}
+
+function safe_hex_list(value, max_items) {
+	const result = [];
+
+	if (type(value) != 'array')
+		return result;
+
+	for (let item in value) {
+		if (type(item) == 'string' && length(item) >= 2 &&
+		    length(item) <= 128 && length(item) % 2 == 0 &&
+		    match(item, /^[0-9A-Fa-f]+$/) !== null)
+			push(result, uc(item));
+
+		if (length(result) >= max_items)
+			break;
+	}
+
+	return result;
+}
+
+function valid_iccid(value) {
+	return type(value) == 'string' &&
+		match(value, /^[0-9]{18,20}$/) !== null;
+}
+
+function valid_profile_id(value) {
+	return valid_iccid(value) ||
+		(type(value) == 'string' &&
+		 match(value, /^[0-9A-Fa-f]{32}$/) !== null);
+}
+
+function valid_aid(value) {
+	return type(value) == 'string' && length(value) == 32 &&
+		match(value, /^[0-9A-Fa-f]+$/) !== null;
+}
+
+function valid_device_path(value) {
+	if (type(value) != 'string' || length(value) < 6 || length(value) > 128 ||
+	    match(value, /^\/dev\/[A-Za-z0-9._:+@,\/-]+$/) === null)
+		return false;
+
+	const parts = split(value, '/');
+
+	for (let i = 2; i < length(parts); i++)
+		if (!length(parts[i]) || parts[i] == '.' || parts[i] == '..')
+			return false;
+
+	return true;
+}
+
+function valid_uqmi_device(value) {
+	return type(value) == 'string' &&
+		match(value, /^\/dev\/cdc-wdm[0-9]+$/) !== null;
+}
+
+function normalize_info(data) {
+	if (type(data) != 'object')
+		return INVALID;
+
+	const addresses_in = (type(data.EuiccConfiguredAddresses) == 'object')
+		? data.EuiccConfiguredAddresses : {};
+	const info2_in = (type(data.EUICCInfo2) == 'object')
+		? data.EUICCInfo2 : {};
+	const resources_in = (type(info2_in.extCardResource) == 'object')
+		? info2_in.extCardResource : {};
+	const certification_in = (type(info2_in.certificationDataObject) == 'object')
+		? info2_in.certificationDataObject : {};
+	const eid = (type(data.eidValue) == 'string' &&
+		match(data.eidValue, /^[0-9]{32}$/) !== null)
+		? data.eidValue : null;
+
+	if (eid === null)
+		return INVALID;
+
+	return {
+		eidValue: eid,
+		EuiccConfiguredAddresses: {
+			defaultDpAddress: safe_text(addresses_in.defaultDpAddress, 255),
+			rootDsAddress: safe_text(addresses_in.rootDsAddress, 255)
+		},
+		EUICCInfo2: {
+			profileVersion: safe_text(info2_in.profileVersion, 64),
+			svn: safe_text(info2_in.svn, 64),
+			euiccFirmwareVer: safe_text(info2_in.euiccFirmwareVer, 128),
+			extCardResource: {
+				installedApplication: safe_uint(resources_in.installedApplication),
+				freeNonVolatileMemory: safe_uint(resources_in.freeNonVolatileMemory),
+				freeVolatileMemory: safe_uint(resources_in.freeVolatileMemory)
+			},
+			uiccCapability: safe_text_list(info2_in.uiccCapability, 64, 64),
+			ts102241Version: safe_text(info2_in.ts102241Version, 64),
+			globalplatformVersion: safe_text(info2_in.globalplatformVersion, 64),
+			rspCapability: safe_text_list(info2_in.rspCapability, 64, 64),
+			euiccCiPKIdListForVerification:
+				safe_hex_list(info2_in.euiccCiPKIdListForVerification, 64),
+			euiccCiPKIdListForSigning:
+				safe_hex_list(info2_in.euiccCiPKIdListForSigning, 64),
+			euiccCategory: safe_text(info2_in.euiccCategory, 64),
+			forbiddenProfilePolicyRules:
+				safe_text_list(info2_in.forbiddenProfilePolicyRules, 64, 64),
+			ppVersion: safe_text(info2_in.ppVersion, 64),
+			sasAcreditationNumber: safe_text(info2_in.sasAcreditationNumber, 128),
+			sasAccreditationNumber: safe_text(info2_in.sasAccreditationNumber, 128),
+			certificationDataObject: {
+				platformLabel: safe_text(certification_in.platformLabel, 255),
+				discoveryBaseURL: safe_text(certification_in.discoveryBaseURL, 255)
+			}
+		}
+	};
+}
+
+function normalize_profiles(data) {
+	const profiles = [];
+
+	if (type(data) != 'array')
+		return INVALID;
+
+	for (let profile in data) {
+		if (type(profile) != 'object')
+			continue;
+
+		const iccid = valid_iccid(profile.iccid) ? profile.iccid : null;
+		const aid = (type(profile.isdpAid) == 'string' &&
+			match(profile.isdpAid, /^[0-9A-Fa-f]{32}$/) !== null)
+			? uc(profile.isdpAid) : null;
+
+		if (iccid === null && aid === null)
+			continue;
+
+		push(profiles, {
+			iccid,
+			isdpAid: aid,
+			profileState: safe_text(profile.profileState, 32),
+			profileNickname: safe_text(profile.profileNickname, 64),
+			serviceProviderName: safe_text(profile.serviceProviderName, 128),
+			profileName: safe_text(profile.profileName, 128),
+			iconType: safe_text(profile.iconType, 16),
+			profileClass: safe_text(profile.profileClass, 32)
+		});
+
+		if (length(profiles) >= 128)
+			break;
+	}
+
+	return profiles;
+}
+
+function normalize_notifications(data) {
+	const notifications = [];
+
+	if (type(data) != 'array')
+		return INVALID;
+
+	for (let notification in data) {
+		if (type(notification) != 'object')
+			continue;
+
+		const seq = safe_uint(notification.seqNumber);
+
+		if (seq === null || seq > 4294967295)
+			continue;
+
+		push(notifications, {
+			seqNumber: seq,
+			profileManagementOperation:
+				safe_text(notification.profileManagementOperation, 32),
+			notificationAddress: safe_text(notification.notificationAddress, 255),
+			iccid: valid_iccid(notification.iccid) ? notification.iccid : null
+		});
+
+		if (length(notifications) >= 256)
+			break;
+	}
+
+	return notifications;
+}
+
+function normalize_driver_list(value, allowed) {
+	const drivers = [];
+
+	if (type(value) != 'array')
+		return drivers;
+
+	for (let driver in value) {
+		if (type(driver) == 'string' && index(allowed, driver) >= 0 &&
+		    index(drivers, driver) < 0)
+			push(drivers, driver);
+	}
+
+	return drivers;
+}
+
+function normalize_drivers(record) {
+	if (type(record?.payload) != 'object' ||
+	    type(record.payload.LPAC_APDU) != 'array' ||
+	    type(record.payload.LPAC_HTTP) != 'array')
+		return failure('invalid_response',
+			'lpac did not return a valid driver list.');
+
+	return success({
+		apdu: normalize_driver_list(record.payload.LPAC_APDU,
+			[ 'uqmi', 'mbim', 'at', 'pcsc' ]),
+		http: normalize_driver_list(record.payload.LPAC_HTTP, [ 'curl' ])
+	});
+}
+
+function operation_error(kind) {
+	switch (kind) {
+	case 'info':
+		return 'Unable to read eUICC information.';
+	case 'profiles':
+		return 'Unable to read eSIM profiles.';
+	case 'notifications':
+		return 'Unable to read eUICC notifications.';
+	case 'enable':
+		return 'Unable to enable the profile.';
+	case 'disable':
+		return 'Unable to disable the profile.';
+	case 'nickname':
+		return 'Unable to update the profile nickname.';
+	case 'delete':
+		return 'Unable to delete the profile.';
+	case 'remove_notification':
+		return 'Unable to remove the notification.';
+	default:
+		return 'The lpac operation failed.';
+	}
+}
+
+function operation_reason(kind, data) {
+	if (type(data) != 'string')
+		return null;
+
+	switch (data) {
+	case 'iccid or aid not found':
+		return (kind == 'enable' || kind == 'disable')
+			? 'profile_not_found' : null;
+	case 'profile not in disabled state':
+		return kind == 'enable' ? 'profile_not_disabled' : null;
+	case 'profile not in enabled state':
+		return kind == 'disable' ? 'profile_not_enabled' : null;
+	case 'disallowed by policy':
+		return 'policy_denied';
+	case 'wrong profile reenabling':
+		return kind == 'enable' ? 'wrong_reenable' : null;
+	case 'internal error, maybe illegal iccid/aid coding':
+		return (kind == 'enable' || kind == 'disable')
+			? 'profile_internal_error' : null;
+	default:
+		return null;
+	}
+}
+
+function normalize_lpa(record, kind) {
+	const payload = record?.payload;
+
+	if (type(payload) != 'object' || type(payload.code) != 'int')
+		return failure('invalid_response',
+			'lpac did not return a valid result envelope.');
+
+	if (payload.code != 0) {
+		const result = failure('lpac_error', operation_error(kind), payload.code);
+		const reason = operation_reason(kind, payload.data);
+
+		if (reason !== null)
+			result.reason = reason;
+
+		return result;
+	}
+
+	let data;
+
+	switch (kind) {
+	case 'version':
+		data = safe_text(payload.data, 128);
+		if (data === null)
+			data = INVALID;
+		break;
+	case 'info':
+		data = normalize_info(payload.data);
+		break;
+	case 'profiles':
+		data = normalize_profiles(payload.data);
+		break;
+	case 'notifications':
+		data = normalize_notifications(payload.data);
+		break;
+	default:
+		/* Mutating lpac commands return null.  Never forward unexpected data. */
+		data = null;
+		break;
+	}
+
+	if (data === INVALID)
+		return failure('invalid_response',
+			'lpac returned data in an unexpected format.');
+
+	return success(data);
+}
+
+function parse_lpac_output(output, kind) {
+	let terminal = null;
+	let driver_record = null;
+
+	if (type(output) != 'string')
+		return failure('invalid_response', 'lpac returned no usable output.');
+
+	for (let line in split(output, '\n')) {
+		line = trim(line);
+
+		if (!length(line))
+			continue;
+
+		let record = null;
+
+		try {
+			record = json(line);
+		}
+		catch (e) {
+			continue;
+		}
+
+		if (type(record) != 'object')
+			continue;
+
+		if (record.type == 'lpa')
+			terminal = record;
+		else if (record.type == 'driver')
+			driver_record = record;
+	}
+
+	if (kind == 'drivers')
+		return driver_record !== null
+			? normalize_drivers(driver_record)
+			: failure('invalid_response',
+				'lpac did not return a driver list.');
+
+	return terminal !== null
+		? normalize_lpa(terminal, kind)
+		: failure('invalid_response',
+			'lpac did not return a terminal JSON result.');
+}
+
+function exec_failure(status, needs_lock) {
+	if (status == STATUS_NOT_FOUND)
+		return needs_lock
+			? failure('lock_failed', 'The flock executable is not installed.')
+			: failure('not_installed', 'The lpac executable is not installed.');
+
+	if (status == STATUS_TIMEOUT)
+		return failure('timeout', 'The lpac operation timed out.');
+
+	if (status == STATUS_NOT_SUPPORTED)
+		return failure('output_too_large',
+			'The lpac output exceeded the rpcd response limit.');
+
+	return failure('execution_failed',
+		'The lpac process could not be executed.');
+}
+
+function release_lock(handle) {
+	if (!handle)
+		return;
+
+	try {
+		handle.close();
+	}
+	catch (e) {
+		/* The kernel will release the lock when rpcd closes the descriptor. */
+	}
+}
+
+function valid_lock_file(stat, require_mode) {
+	return type(stat) == 'object' && stat.type == 'file' && stat.uid == 0 &&
+		stat.nlink == 1 && (!require_mode || stat.mode == 0o600);
+}
+
+function open_lock_file() {
+	let stat;
+	let handle;
+
+	try {
+		stat = lstat(LOCK_PATH);
+
+		/* Never follow or reuse a non-regular or non-root-owned lock path. */
+		if (stat !== null && !valid_lock_file(stat, false))
+			return null;
+
+		handle = open(LOCK_PATH, 'ae', 0o600);
+
+		if (!handle)
+			return null;
+
+		stat = lstat(LOCK_PATH);
+
+		if (!valid_lock_file(stat, false) || chmod(LOCK_PATH, 0o600) !== true ||
+		    !valid_lock_file(lstat(LOCK_PATH), true)) {
+			release_lock(handle);
+			return null;
+		}
+
+		return handle;
+	}
+	catch (e) {
+		release_lock(handle);
+		return null;
+	}
+}
+
+function acquire_lock() {
+	const handle = open_lock_file();
+
+	if (!handle)
+		return {
+			result: failure('lock_failed',
+				'Unable to create the lpac operation lock.')
+		};
+
+	if (!handle.lock('xn')) {
+		release_lock(handle);
+
+		return {
+			result: failure('busy',
+				'Another lpac operation is already running.')
+		};
+	}
+
+	return { handle };
+}
+
+function run_lpac(request, params, kind, needs_lock) {
+	if (kind != 'version' && kind != 'drivers' && read_config() === null)
+		return failure('invalid_config',
+			'The installed lpac configuration is missing or invalid.');
+
+	let command = LPAC_PATH;
+	let exec_params = params;
+
+	if (needs_lock) {
+		const handle = open_lock_file();
+
+		if (!handle)
+			return failure('lock_failed',
+				'Unable to prepare the lpac operation lock.');
+
+		release_lock(handle);
+		command = FLOCK_PATH;
+		exec_params = [ '-n', LOCK_PATH, LPAC_PATH ];
+
+		for (let param in params)
+			push(exec_params, param);
+	}
+
+	let callback_called = false;
+
+	try {
+		const pending = ubus.defer('file', 'exec', {
+			command,
+			params: exec_params
+		}, function(status, reply) {
+			callback_called = true;
+
+			let result;
+
+			try {
+				if (status != STATUS_OK) {
+					result = exec_failure(status, needs_lock);
+				}
+				else if (type(reply) != 'object') {
+					result = failure('execution_failed',
+						'The lpac process returned no execution result.');
+				}
+				else {
+					result = parse_lpac_output(reply.stdout, kind);
+
+					if (type(reply.code) != 'int')
+						result = failure('execution_failed',
+							'The lpac process returned no exit status.');
+					else if (reply.code != 0) {
+						if (needs_lock && reply.code == 1 &&
+						    !result.success && result.error == 'invalid_response')
+							result = failure('busy',
+								'Another lpac operation is already running.');
+						else if (reply.code == 127 &&
+						         !result.success && result.error == 'invalid_response')
+							result = failure('not_installed',
+								'The lpac executable is not installed.');
+						else if (result.success || result.error == 'invalid_response')
+							result = failure('execution_failed',
+								'The lpac process exited unexpectedly.', reply.code);
+					}
+				}
+			}
+			catch (e) {
+				result = failure('invalid_response',
+					'Unable to normalize the lpac response.');
+			}
+
+			/* stderr is intentionally never inspected, logged, or returned. */
+			try {
+				request.reply(result);
+			}
+			catch (e) {
+				/* The outer rpcd request may have reached its guard timeout. */
+			}
+		});
+
+		if (!pending && !callback_called) {
+			return failure('execution_failed',
+				'Unable to start the lpac process.');
+		}
+
+		return pending;
+	}
+	catch (e) {
+		if (!callback_called) {
+			return failure('execution_failed',
+				'Unable to start the lpac process.');
+		}
+
+		/* An immediate defer failure may already have invoked the callback. */
+		return null;
+	}
+}
+
+function has_exact_keys(value, allowed) {
+	if (type(value) != 'object')
+		return false;
+
+	for (let key in value)
+		if (!(key in allowed))
+			return false;
+
+	for (let key in allowed)
+		if (!(key in value))
+			return false;
+
+	return true;
+}
+
+function normalize_flag(value) {
+	if (value === true || value === 1 || value === '1')
+		return '1';
+
+	if (value === false || value === 0 || value === '0')
+		return '0';
+
+	return null;
+}
+
+function normalize_config(config) {
+	if (!has_exact_keys(config, { global: true, at: true, uqmi: true, mbim: true }) ||
+	    !has_exact_keys(config.global, {
+		apdu_backend: true,
+		http_backend: true,
+		apdu_debug: true,
+		http_debug: true,
+		custom_isd_r_aid: true
+	    }) ||
+	    !has_exact_keys(config.at, { device: true, debug: true }) ||
+	    !has_exact_keys(config.uqmi, { device: true, debug: true }) ||
+	    !has_exact_keys(config.mbim, { device: true, proxy: true }))
+		return null;
+
+	const apdu_backend = config.global.apdu_backend;
+	const http_backend = config.global.http_backend;
+	const apdu_debug = normalize_flag(config.global.apdu_debug);
+	const http_debug = normalize_flag(config.global.http_debug);
+	const at_debug = normalize_flag(config.at.debug);
+	const uqmi_debug = normalize_flag(config.uqmi.debug);
+	const mbim_proxy = normalize_flag(config.mbim.proxy);
+	const aid = config.global.custom_isd_r_aid;
+
+	if (type(apdu_backend) != 'string' ||
+	    index([ 'uqmi', 'mbim', 'at', 'pcsc' ], apdu_backend) < 0 ||
+	    http_backend !== 'curl' || apdu_debug === null || http_debug === null ||
+	    at_debug === null || uqmi_debug === null || mbim_proxy === null ||
+	    !valid_aid(aid) ||
+	    !valid_device_path(config.at.device) ||
+	    !valid_device_path(config.uqmi.device) ||
+	    !valid_device_path(config.mbim.device) ||
+	    (apdu_backend == 'uqmi' && !valid_uqmi_device(config.uqmi.device)))
+		return null;
+
+	return {
+		global: {
+			apdu_backend,
+			http_backend: 'curl',
+			apdu_debug,
+			http_debug,
+			custom_isd_r_aid: uc(aid)
+		},
+		at: {
+			device: config.at.device,
+			debug: at_debug
+		},
+		uqmi: {
+			device: config.uqmi.device,
+			debug: uqmi_debug
+		},
+		mbim: {
+			device: config.mbim.device,
+			proxy: mbim_proxy
+		}
+	};
+}
+
+function uci_value(uci, section, option, fallback) {
+	const value = uci.get('lpac', section, option);
+
+	if (value === null)
+		return fallback;
+
+	return type(value) == 'string' ? value : INVALID;
+}
+
+read_config = function() {
+	const uci = cursor();
+	let config = null;
+
+	try {
+		if (!uci || !uci.load('lpac'))
+			return null;
+
+		config = normalize_config({
+			global: {
+				apdu_backend: uci_value(uci, 'global', 'apdu_backend', 'uqmi'),
+				http_backend: uci_value(uci, 'global', 'http_backend', 'curl'),
+				apdu_debug: uci_value(uci, 'global', 'apdu_debug', '0'),
+				http_debug: uci_value(uci, 'global', 'http_debug', '0'),
+				custom_isd_r_aid:
+					uci_value(uci, 'global', 'custom_isd_r_aid', DEFAULT_AID)
+			},
+			at: {
+				device: uci_value(uci, 'at', 'device', '/dev/ttyUSB2'),
+				debug: uci_value(uci, 'at', 'debug', '0')
+			},
+			uqmi: {
+				device: uci_value(uci, 'uqmi', 'device', '/dev/cdc-wdm0'),
+				debug: uci_value(uci, 'uqmi', 'debug', '0')
+			},
+			mbim: {
+				device: uci_value(uci, 'mbim', 'device', '/dev/cdc-wdm0'),
+				proxy: uci_value(uci, 'mbim', 'proxy', '1')
+			}
+		});
+	}
+	catch (e) {
+		config = null;
+	}
+
+	if (uci)
+		uci.unload('lpac');
+
+	return config;
+};
+
+function write_config(config) {
+	const uci = cursor();
+	let written = false;
+
+	try {
+		if (!uci || !uci.load('lpac'))
+			return false;
+
+		written =
+			uci.set('lpac', 'global', 'global') &&
+			uci.set('lpac', 'global', 'apdu_backend', config.global.apdu_backend) &&
+			uci.set('lpac', 'global', 'http_backend', config.global.http_backend) &&
+			uci.set('lpac', 'global', 'apdu_debug', config.global.apdu_debug) &&
+			uci.set('lpac', 'global', 'http_debug', config.global.http_debug) &&
+			uci.set('lpac', 'global', 'custom_isd_r_aid',
+				config.global.custom_isd_r_aid) &&
+			uci.set('lpac', 'at', 'at') &&
+			uci.set('lpac', 'at', 'device', config.at.device) &&
+			uci.set('lpac', 'at', 'debug', config.at.debug) &&
+			uci.set('lpac', 'uqmi', 'uqmi') &&
+			uci.set('lpac', 'uqmi', 'device', config.uqmi.device) &&
+			uci.set('lpac', 'uqmi', 'debug', config.uqmi.debug) &&
+			uci.set('lpac', 'mbim', 'mbim') &&
+			uci.set('lpac', 'mbim', 'device', config.mbim.device) &&
+			uci.set('lpac', 'mbim', 'proxy', config.mbim.proxy) &&
+			uci.commit('lpac');
+	}
+	catch (e) {
+		written = false;
+	}
+
+	if (uci)
+		uci.unload('lpac');
+
+	return written;
+}
+
+const methods = {
+	get_version: {
+		args: {},
+		call: function(request) {
+			return run_lpac(request, [ 'version' ], 'version', false);
+		}
+	},
+
+	get_drivers: {
+		args: {},
+		call: function(request) {
+			return run_lpac(request, [ 'driver', 'list' ], 'drivers', false);
+		}
+	},
+
+	get_info: {
+		args: {},
+		call: function(request) {
+			return run_lpac(request, [ 'chip', 'info' ], 'info', true);
+		}
+	},
+
+	list_profiles: {
+		args: {},
+		call: function(request) {
+			return run_lpac(request, [ 'profile', 'list' ], 'profiles', true);
+		}
+	},
+
+	list_notifications: {
+		args: {},
+		call: function(request) {
+			return run_lpac(request, [ 'notification', 'list' ],
+				'notifications', true);
+		}
+	},
+
+	enable_profile: {
+		args: { iccid: '', refresh: false },
+		call: function(request) {
+			const id = request.args?.iccid;
+			let refresh = request.args?.refresh;
+
+			if (refresh === null)
+				refresh = false;
+
+			if (!valid_profile_id(id) || type(refresh) != 'bool')
+				return failure('invalid_argument',
+					'The profile identifier or refresh flag is invalid.');
+
+			return run_lpac(request,
+				[ 'profile', 'enable', id, refresh ? '1' : '0' ],
+				'enable', true);
+		}
+	},
+
+	disable_profile: {
+		args: { iccid: '', refresh: false },
+		call: function(request) {
+			const id = request.args?.iccid;
+			let refresh = request.args?.refresh;
+
+			if (refresh === null)
+				refresh = false;
+
+			if (!valid_profile_id(id) || type(refresh) != 'bool')
+				return failure('invalid_argument',
+					'The profile identifier or refresh flag is invalid.');
+
+			return run_lpac(request,
+				[ 'profile', 'disable', id, refresh ? '1' : '0' ],
+				'disable', true);
+		}
+	},
+
+	nickname_profile: {
+		args: { iccid: '', nickname: '' },
+		call: function(request) {
+			const iccid = request.args?.iccid;
+			const nickname = request.args?.nickname;
+
+			if (!valid_iccid(iccid) || type(nickname) != 'string' ||
+			    length(nickname) > 64 || match(nickname, /[[:cntrl:]]/) !== null)
+				return failure('invalid_argument',
+					'The ICCID or profile nickname is invalid.');
+
+			return run_lpac(request,
+				[ 'profile', 'nickname', iccid, nickname ], 'nickname', true);
+		}
+	},
+
+	delete_profile: {
+		args: { iccid: '' },
+		call: function(request) {
+			const id = request.args?.iccid;
+
+			if (!valid_profile_id(id))
+				return failure('invalid_argument',
+					'The profile identifier is invalid.');
+
+			return run_lpac(request,
+				[ 'profile', 'delete', id ], 'delete', true);
+		}
+	},
+
+	remove_notification: {
+		args: { seq: '' },
+		call: function(request) {
+			const seq = request.args?.seq;
+			const seq_number = (type(seq) == 'string' &&
+				match(seq, /^[1-9][0-9]{0,9}$/) !== null) ? int(seq) : null;
+
+			if (seq_number === null || seq_number > 4294967295)
+				return failure('invalid_argument',
+					'The notification sequence number is invalid.');
+
+			return run_lpac(request,
+				[ 'notification', 'remove', `${seq_number}` ],
+				'remove_notification', true);
+		}
+	},
+
+	get_config: {
+		args: {},
+		call: function() {
+			const config = read_config();
+
+			return config !== null
+				? success(config)
+				: failure('invalid_config',
+					'The installed lpac configuration is missing or invalid.');
+		}
+	},
+
+	set_config: {
+		args: { config: {} },
+		call: function(request) {
+			const config = normalize_config(request.args?.config);
+
+			if (config === null)
+				return failure('invalid_config',
+					'The supplied lpac configuration is invalid.');
+
+			const lock_state = acquire_lock();
+
+			if (!lock_state.handle)
+				return lock_state.result;
+
+			const written = write_config(config);
+			release_lock(lock_state.handle);
+
+			return written
+				? success(config)
+				: failure('config_write_failed',
+					'Unable to commit the lpac configuration.');
+		}
+	}
+};
+
+return { 'luci.lpac': methods };

--- a/applications/luci-app-lpac/tests/backend.uc
+++ b/applications/luci-app-lpac/tests/backend.uc
@@ -21,7 +21,8 @@ function default_config() {
 		},
 		mbim: {
 			device: '/dev/cdc-wdm0',
-			proxy: '1'
+			proxy: '1',
+			skip_slot_mapping: '0'
 		}
 	};
 }
@@ -103,6 +104,17 @@ check(result.success && result.data == 'v2.3.0', 'version response is normalized
 check(global.TEST_LAST_CALL.request.command == '/usr/bin/lpac',
 	'packaged lpac entrypoint is executed directly for non-eUICC commands');
 same(global.TEST_LAST_CALL.request.params, [ 'version' ], 'version argv is fixed');
+
+reset();
+result = invoke('get_config');
+same(result.data, default_config(),
+	'configuration reads expose the normalized MBIM slot-mapping preference');
+
+reset();
+delete global.TEST_UCI.mbim.skip_slot_mapping;
+result = invoke('get_config');
+check(result.success && result.data.mbim.skip_slot_mapping == '0',
+	'missing MBIM slot-mapping preference falls back to disabled');
 
 reset();
 global.TEST_EXEC_REPLY = {
@@ -336,10 +348,24 @@ check(!result.success && result.error == 'invalid_config',
 	'device paths containing traversal components are rejected');
 
 reset();
-global.TEST_UCI.mbim.skip_slot_mapping = '1';
-result = invoke('set_config', { config: default_config() });
+config = default_config();
+config.mbim.skip_slot_mapping = '1';
+result = invoke('set_config', { config });
 check(result.success && global.TEST_UCI.mbim.skip_slot_mapping == '1',
+	'MBIM slot-mapping preference is validated and committed');
+
+reset();
+global.TEST_UCI.mbim.vendor_mode = 'keep';
+result = invoke('set_config', { config: default_config() });
+check(result.success && global.TEST_UCI.mbim.vendor_mode == 'keep',
 	'unmanaged vendor options are preserved by settings writes');
+
+reset();
+config = default_config();
+config.mbim.skip_slot_mapping = 'yes';
+result = invoke('set_config', { config });
+check(!result.success && result.error == 'invalid_config',
+	'invalid MBIM slot-mapping flags are rejected');
 
 reset();
 global.TEST_UCI_LOAD_FAIL = true;

--- a/applications/luci-app-lpac/tests/backend.uc
+++ b/applications/luci-app-lpac/tests/backend.uc
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+
+'use strict';
+
+function default_config() {
+	return {
+		global: {
+			apdu_backend: 'uqmi',
+			http_backend: 'curl',
+			apdu_debug: '0',
+			http_debug: '0',
+			custom_isd_r_aid: 'A0000005591010FFFFFFFF8900000100'
+		},
+		at: {
+			device: '/dev/ttyUSB2',
+			debug: '0'
+		},
+		uqmi: {
+			device: '/dev/cdc-wdm0',
+			debug: '0'
+		},
+		mbim: {
+			device: '/dev/cdc-wdm0',
+			proxy: '1'
+		}
+	};
+}
+
+function reset() {
+	global.TEST_UCI = default_config();
+	global.TEST_UCI_LOAD_FAIL = false;
+	global.TEST_COMMIT_OK = true;
+	global.TEST_LOCK_EXISTS = false;
+	global.TEST_LOCK_TYPE = 'file';
+	global.TEST_LOCK_UID = 0;
+	global.TEST_LOCK_NLINK = 1;
+	global.TEST_LOCK_MODE = 0o600;
+	global.TEST_LOCK_OPEN_FAIL = false;
+	global.TEST_LOCK_CHMOD_FAIL = false;
+	global.TEST_LOCK_BUSY = false;
+	global.TEST_LOCK_CLOSED = false;
+	global.TEST_DEFER_THROW = false;
+	global.TEST_DEFER_NULL = false;
+	global.TEST_EXEC_STATUS = 0;
+	global.TEST_EXEC_REPLY = null;
+	global.TEST_LAST_CALL = null;
+}
+
+let checks = 0;
+
+function check(condition, message) {
+	checks++;
+
+	if (!condition)
+		die(`not ok ${checks} - ${message}\n`);
+
+	printf(`ok ${checks} - ${message}\n`);
+}
+
+function same(actual, expected, message) {
+	check(sprintf('%J', actual) == sprintf('%J', expected), message);
+}
+
+reset();
+
+const plugin = loadfile('./root/usr/share/rpcd/ucode/luci.lpac', {
+	module_search_path: [ '../../../../../tests/lib/*.uc' ]
+})();
+const methods = plugin['luci.lpac'];
+
+function invoke(name, args) {
+	let replied = false;
+	let response = null;
+	const request = {
+		args: args || {},
+		reply: function(result) {
+			replied = true;
+			response = result;
+		}
+	};
+	const returned = methods[name].call(request);
+
+	return replied ? response : returned;
+}
+
+function terminal(data, code) {
+	if (type(code) != 'int')
+		code = 0;
+
+	return sprintf('%J\n', {
+		type: 'lpa',
+		payload: {
+			code,
+			message: code == 0 ? 'success' : 'failure',
+			data
+		}
+	});
+}
+
+global.TEST_EXEC_REPLY = { code: 0, stdout: terminal('v2.3.0') };
+let result = invoke('get_version');
+check(result.success && result.data == 'v2.3.0', 'version response is normalized');
+check(global.TEST_LAST_CALL.request.command == '/usr/bin/lpac',
+	'packaged lpac entrypoint is executed directly for non-eUICC commands');
+same(global.TEST_LAST_CALL.request.params, [ 'version' ], 'version argv is fixed');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 0,
+	stdout: sprintf('%J\n', {
+		type: 'driver',
+		payload: {
+			LPAC_APDU: [ 'uqmi', 'stdio', 'mbim', 'uqmi' ],
+			LPAC_HTTP: [ 'curl', 'stdio' ]
+		}
+	})
+};
+result = invoke('get_drivers');
+same(result.data, { apdu: [ 'uqmi', 'mbim' ], http: [ 'curl' ] },
+	'driver response is allowlisted and deduplicated');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 0,
+	stdout: sprintf('%J\n', { type: 'driver', payload: { LPAC_APDU: [] } })
+};
+result = invoke('get_drivers');
+check(!result.success && result.error == 'invalid_response',
+	'incomplete driver schemas are rejected');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 0,
+	stdout: terminal({
+		eidValue: '89012345678901234567890123456789',
+		EuiccConfiguredAddresses: {},
+		EUICCInfo2: {}
+	})
+};
+result = invoke('get_info');
+check(result.success && result.data.eidValue == '89012345678901234567890123456789',
+	'chip information requires and preserves a valid EID');
+
+reset();
+global.TEST_EXEC_REPLY = { code: 0, stdout: terminal({ EUICCInfo2: {} }) };
+result = invoke('get_info');
+check(!result.success && result.error == 'invalid_response',
+	'chip information without a valid EID is rejected');
+
+reset();
+global.TEST_EXEC_REPLY = { code: 0, stdout: terminal([]) };
+result = invoke('list_profiles');
+check(result.success && global.TEST_LOCK_EXISTS &&
+	global.TEST_LOCK_MODE == 0o600 && global.TEST_CHMOD?.mode == 0o600,
+	'eUICC operations create and enforce a mode-0600 lock file');
+
+reset();
+global.TEST_LOCK_EXISTS = true;
+global.TEST_LOCK_MODE = 0o644;
+global.TEST_EXEC_REPLY = { code: 0, stdout: terminal([]) };
+result = invoke('list_profiles');
+check(result.success && global.TEST_LOCK_MODE == 0o600,
+	'a pre-existing permissive lock file is repaired before execution');
+
+reset();
+global.TEST_LOCK_EXISTS = true;
+global.TEST_LOCK_TYPE = 'symlink';
+result = invoke('list_profiles');
+check(!result.success && result.error == 'lock_failed' &&
+	global.TEST_LAST_CALL === null,
+	'non-regular lock paths are rejected before process execution');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 0,
+	stdout: terminal([
+		{
+			iccid: '8912345678901234567',
+			isdpAid: 'A0000005591010FFFFFFFF8900001000',
+			profileState: 'disabled',
+			profileNickname: 'Test',
+			serviceProviderName: 'Carrier',
+			profileName: 'Plan',
+			iconType: 'png',
+			icon: 'sensitive-base64-icon',
+			profileClass: 'operational'
+		},
+		{ iccid: '../../invalid', isdpAid: null }
+	])
+};
+result = invoke('list_profiles');
+check(result.success && length(result.data) == 1, 'invalid profile records are discarded');
+check(!('icon' in result.data[0]), 'profile icons are never returned to LuCI');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 0,
+	stdout: terminal([
+		{ seqNumber: 0, profileManagementOperation: 'install' },
+		{ seqNumber: 4294967295, profileManagementOperation: 'delete' }
+	])
+};
+result = invoke('list_notifications');
+check(result.success && length(result.data) == 2 &&
+	result.data[0].seqNumber == 0 && result.data[1].seqNumber == 4294967295,
+	'notification list preserves the full uint32 sequence range');
+
+reset();
+global.TEST_EXEC_REPLY = { code: 0, stdout: terminal(null) };
+result = invoke('remove_notification', { seq: '4294967295' });
+check(result.success, 'UINT32_MAX notification can be removed');
+	same(global.TEST_LAST_CALL.request.params,
+		[ '-n', '/var/run/luci-lpac.lock', '/usr/bin/lpac',
+		'notification', 'remove', '4294967295' ],
+	'flock and notification arguments remain separate argv elements');
+check(!invoke('remove_notification', { seq: '0' }).success &&
+	!invoke('remove_notification', { seq: '01' }).success &&
+	!invoke('remove_notification', { seq: '4294967296' }).success,
+	'invalid notification sequences are rejected');
+
+reset();
+result = invoke('enable_profile', {
+	iccid: 'A0000005591010FFFFFFFF8900001000',
+	refresh: true
+});
+check(!result.success && result.error == 'execution_failed',
+	'missing lpac output is handled without exposing process data');
+same(global.TEST_LAST_CALL.request.params, [
+	'-n', '/var/run/luci-lpac.lock', '/usr/bin/lpac', 'profile', 'enable',
+	'A0000005591010FFFFFFFF8900001000', '1'
+], 'flock, profile AID, and refresh flag remain separate argv elements');
+check(!invoke('enable_profile', {
+	iccid: '891234567890123456789',
+	refresh: false
+}).success, 'ICCID longer than the lpac 20-digit buffer is rejected');
+check(!invoke('nickname_profile', {
+	iccid: 'A0000005591010FFFFFFFF8900001000',
+	nickname: 'Alias'
+}).success, 'nickname operation requires an ICCID');
+
+reset();
+global.TEST_EXEC_REPLY = { code: 1, stdout: '' };
+result = invoke('list_profiles');
+check(!result.success && result.error == 'busy', 'concurrent eUICC access is rejected');
+check(global.TEST_LAST_CALL.request.command == '/usr/bin/flock',
+	'eUICC operations are serialized by inherited flock');
+
+reset();
+global.TEST_LOCK_BUSY = true;
+result = invoke('set_config', { config: default_config() });
+check(!result.success && result.error == 'busy',
+	'configuration writes share the eUICC operation lock');
+check(global.TEST_LOCK_CLOSED, 'busy configuration lock handle is closed');
+
+reset();
+global.TEST_EXEC_STATUS = 7;
+result = invoke('list_profiles');
+check(!result.success && result.error == 'timeout', 'file.exec timeout is normalized');
+
+reset();
+global.TEST_EXEC_REPLY = { code: 1, stdout: terminal('private detail', -1) };
+result = invoke('delete_profile', { iccid: '8912345678901234567' });
+check(!result.success && result.error == 'lpac_error' &&
+	!('data' in result) && !('reason' in result),
+	'unknown lpac error payload is not returned');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 255,
+	stdout: terminal('profile not in disabled state', -1)
+};
+result = invoke('enable_profile', {
+	iccid: '8912345678901234567',
+	refresh: false
+});
+check(!result.success && result.error == 'lpac_error' &&
+	result.reason == 'profile_not_disabled' && !('data' in result),
+	'known profile errors are mapped to safe reason codes');
+
+reset();
+global.TEST_EXEC_REPLY = {
+	code: 255,
+	stdout: terminal('iccid or aid not found', -1)
+};
+result = invoke('delete_profile', { iccid: '8912345678901234567' });
+check(!result.success && result.error == 'lpac_error' &&
+	!('reason' in result) && !('data' in result),
+	'identifier hints are limited to operations that offer both identifiers');
+
+reset();
+let config = default_config();
+config.at.device = '/dev/ttyUSB2;reboot';
+result = invoke('set_config', { config });
+check(!result.success && result.error == 'invalid_config',
+	'shell-like device paths are rejected');
+
+reset();
+config = default_config();
+config.global.custom_isd_r_aid = 'A000000559';
+result = invoke('set_config', { config });
+check(!result.success && result.error == 'invalid_config',
+	'short custom ISD-R AIDs are rejected');
+
+reset();
+config = default_config();
+config.global.apdu_backend = 'mbim';
+config.global.custom_isd_r_aid = 'a0000005591010ffffffff8900000100';
+result = invoke('set_config', { config });
+check(result.success && global.TEST_UCI.global.apdu_backend == 'mbim' &&
+	global.TEST_UCI.global.custom_isd_r_aid == 'A0000005591010FFFFFFFF8900000100',
+	'validated settings are committed and canonicalized');
+
+reset();
+config = default_config();
+config.global.apdu_backend = 'at';
+config.at.device = '/dev/serial/by-id/usb-Test_Modem-if00';
+config.uqmi.device = '/dev/wwan0qmi0';
+result = invoke('set_config', { config });
+check(result.success && global.TEST_UCI.at.device == config.at.device,
+	'safe serial symlinks and inactive backend device paths are accepted');
+
+reset();
+config = default_config();
+config.global.apdu_backend = 'uqmi';
+config.uqmi.device = '/dev/wwan0qmi0';
+result = invoke('set_config', { config });
+check(!result.success && result.error == 'invalid_config',
+	'active uqmi backend retains its strict control-device allowlist');
+
+reset();
+config = default_config();
+config.global.apdu_backend = 'at';
+config.at.device = '/dev/serial/../ttyUSB0';
+result = invoke('set_config', { config });
+check(!result.success && result.error == 'invalid_config',
+	'device paths containing traversal components are rejected');
+
+reset();
+global.TEST_UCI.mbim.skip_slot_mapping = '1';
+result = invoke('set_config', { config: default_config() });
+check(result.success && global.TEST_UCI.mbim.skip_slot_mapping == '1',
+	'unmanaged vendor options are preserved by settings writes');
+
+reset();
+global.TEST_UCI_LOAD_FAIL = true;
+result = invoke('list_profiles');
+check(!result.success && result.error == 'invalid_config' &&
+	global.TEST_LAST_CALL === null,
+	'invalid UCI prevents eUICC process execution');
+
+reset();
+global.TEST_UCI_LOAD_FAIL = true;
+global.TEST_EXEC_REPLY = { code: 0, stdout: terminal('v2.3.0') };
+result = invoke('get_version');
+check(result.success && result.data == 'v2.3.0',
+	'backend does not pre-block version queries when UCI cannot load');
+
+reset();
+global.TEST_UCI.uqmi.device = [ '/dev/cdc-wdm0', '/dev/cdc-wdm0;reboot' ];
+result = invoke('list_profiles');
+check(!result.success && result.error == 'invalid_config' &&
+	global.TEST_LAST_CALL === null,
+	'UCI list values cannot bypass scalar path validation');
+
+printf(`1..${checks}\n`);

--- a/applications/luci-app-lpac/tests/frontend.js
+++ b/applications/luci-app-lpac/tests/frontend.js
@@ -293,7 +293,7 @@ const settingsPage = settingsView.render([
 			},
 			at: { device: '/dev/ttyUSB2', debug: '0' },
 			uqmi: { device: '/dev/cdc-wdm0', debug: '0' },
-			mbim: { device: '/dev/cdc-wdm0', proxy: '0' }
+			mbim: { device: '/dev/cdc-wdm0', proxy: '0', skip_slot_mapping: '0' }
 		}
 	},
 	{ success: true, data: { apdu: [ 'mbim', 'at' ], http: [ 'curl' ] } }
@@ -309,6 +309,8 @@ assert.ok(findById('lpac-http-debug').attrs.checked != null,
 	'true HTTP debug must render checked');
 assert.ok(findById('lpac-mbim-proxy').attrs.checked == null,
 	'false MBIM proxy must render unchecked');
+assert.ok(findById('lpac-mbim-skip-slot-mapping').attrs.checked == null,
+	'false MBIM slot-mapping bypass must render unchecked');
 
 const backend = findById('lpac-apdu-backend');
 const backendOptions = findAll(backend, function(node) { return node.tag === 'option'; });
@@ -326,6 +328,10 @@ assert.strictEqual(findAll(settingsPage, function(node) {
 	return node.attrs?.class === 'cbi-value-description' &&
 		textContent(node).startsWith('Use the /dev/cdc-wdmN device');
 }).length, 1, 'uqmi device guidance should render as field help');
+assert.strictEqual(findAll(settingsPage, function(node) {
+	return node.attrs?.class === 'cbi-value-description' &&
+		textContent(node).startsWith("Use the modem's currently selected slot");
+}).length, 1, 'MBIM slot-mapping guidance should render as field help');
 assert.strictEqual(findAll(settingsPage, function(node) {
 	return node.attrs?.class === 'cbi-value-description' &&
 		textContent(node).startsWith('The AT backend is timing-sensitive');

--- a/applications/luci-app-lpac/tests/frontend.js
+++ b/applications/luci-app-lpac/tests/frontend.js
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+/* global require, __dirname, global */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const appRoot = path.resolve(__dirname, '..');
+let modal = null;
+
+if (!String.prototype.format) {
+	Object.defineProperty(String.prototype, 'format', {
+		value: function() {
+			const args = arguments;
+			let index = 0;
+
+			return String(this).replace(/%[sd]/g, function() {
+				return String(args[index++]);
+			});
+		}
+	});
+}
+
+function element(tag, attrs, children) {
+	if (Array.isArray(tag)) {
+		children = tag;
+		attrs = {};
+		tag = null;
+	}
+	else if (attrs == null || Array.isArray(attrs) || typeof attrs !== 'object') {
+		children = attrs;
+		attrs = {};
+	}
+
+	return {
+		tag,
+		attrs: attrs || {},
+		children: children == null ? [] : (Array.isArray(children) ? children : [ children ]),
+		appendChild: function(child) {
+			this.children.push(child);
+		},
+		getAttribute: function(name) {
+			return this.attrs[name] ?? null;
+		}
+	};
+}
+
+function walk(value, callback) {
+	if (Array.isArray(value)) {
+		value.forEach(function(item) { walk(item, callback); });
+		return;
+	}
+
+	if (!value || typeof value !== 'object')
+		return;
+
+	callback(value);
+	walk(value.children, callback);
+	walk(value.rows, callback);
+}
+
+function findAll(root, predicate) {
+	const matches = [];
+
+	walk(root, function(node) {
+		if (predicate(node))
+			matches.push(node);
+	});
+
+	return matches;
+}
+
+function textContent(node) {
+	if (typeof node === 'string')
+		return node;
+
+	if (!node || typeof node !== 'object')
+		return '';
+
+	return (node.children || []).map(textContent).join('');
+}
+
+global._ = function(value) { return value; };
+global.E = element;
+global.L = {
+	hasViewPermission: function() { return true; },
+	resolveDefault: function(value) { return value; },
+	resource: function(value) { return `/luci-static/resources/${value}`; }
+};
+global.cbi_update_table = function(table, rows, empty) {
+	table.rows = rows;
+	table.empty = empty;
+};
+global.document = {};
+global.window = { location: { reload: function() {} } };
+
+const view = { extend: function(spec) { return spec; } };
+const ui = {
+	showModal: function(title, content) { modal = { title, content }; },
+	hideModal: function() {},
+	addNotification: function() {},
+	createHandlerFn: function(context, handler) {
+		const args = Array.prototype.slice.call(arguments, 2);
+
+		return function() {
+			return typeof handler === 'string'
+				? context[handler].apply(context, args)
+				: handler.apply(context, args);
+		};
+	}
+};
+const lpac = {
+	dataOr: function(result, fallback) {
+		return result && result.success ? result.data : fallback;
+	},
+	errorMessage: function(result) { return result?.error || 'error'; }
+};
+
+function loadView(relativePath) {
+	const source = fs.readFileSync(path.join(appRoot, 'htdocs/luci-static/resources/view/lpac', relativePath), 'utf8');
+	return Function('view', 'ui', 'lpac', source)(view, ui, lpac);
+}
+
+function byText(root, tag, label) {
+	return findAll(root, function(node) {
+		return node.tag === tag && textContent(node) === label;
+	});
+}
+
+const profile = {
+	iccid: '8912345678901234567',
+	isdpAid: 'A0000005591010FFFFFFFF8900001000',
+	profileState: 'disabled',
+	profileNickname: 'Test profile',
+	serviceProviderName: 'Test provider'
+};
+const profilesView = loadView('profiles.js');
+const profilesPage = profilesView.render({ success: true, data: [ profile ] });
+const profileTable = findAll(profilesPage, function(node) {
+	return node.attrs?.id === 'lpac-profile-table';
+})[0];
+assert.ok(profileTable, 'the profile table should have a scoped layout identifier');
+assert.ok(profileTable.attrs.class.split(/\s+/).includes('lpac-profile-table'),
+	'the profile table should expose its scoped stylesheet class');
+assert.strictEqual(findAll(profilesPage, function(node) {
+	return node.tag === 'link' && node.attrs?.rel === 'stylesheet' &&
+		node.attrs?.href === '/luci-static/resources/view/lpac/profiles.css';
+}).length, 1, 'the profile view should load its scoped responsive stylesheet');
+assert.deepStrictEqual(findAll(profilesPage, function(node) {
+	return node.attrs?.class === 'lpac-profile-key';
+}).map(textContent), [ 'Profile:', 'Provider:', 'ICCID:', 'State:' ],
+	'mobile profile fields should provide inline labels with colons');
+const profileActionsHeader = byText(profilesPage, 'th', 'Actions')[0];
+assert.ok(profileActionsHeader.attrs.class.split(/\s+/).includes('cbi-section-actions'),
+	'the Actions heading should make its generated mobile cell full-width');
+
+[ 'Enable', 'Rename', 'Delete' ].forEach(function(label) {
+	const buttons = byText(profilesPage, 'button', label);
+	assert.strictEqual(buttons.length, 1, `${label} button should exist`);
+	assert.ok(buttons[0].attrs.disabled == null,
+		`${label} button must omit the disabled attribute when writable`);
+});
+const profileActionGroups = findAll(profilesPage, function(node) {
+	return node.tag === 'div' && node.attrs?.class === 'lpac-profile-actions' &&
+		[ 'Enable', 'Rename', 'Delete' ].every(function(label) {
+		return byText(node, 'button', label).length === 1;
+	});
+});
+assert.strictEqual(profileActionGroups.length, 1,
+	'profile actions should share one standard action wrapper');
+assert.strictEqual(profileActionGroups[0].children.length, 3,
+	'the action wrapper should contain only three buttons without spacers');
+assert.ok(profileActionGroups[0].children.every(function(node) {
+	return node.tag === 'button';
+}), 'the clean action row should contain only button elements');
+assert.strictEqual(findAll(profilesPage, function(node) {
+	return node.tag === 'span' && node.attrs?.class === 'label' &&
+		textContent(node) === 'Disabled';
+}).length, 1, 'a disabled profile should use the neutral state badge');
+
+const enabledProfile = Object.assign({}, profile, {
+	iccid: '8912345678901234568',
+	profileState: 'enabled'
+});
+const enabledProfilesPage = profilesView.render({
+	success: true,
+	data: [ enabledProfile ]
+});
+assert.strictEqual(findAll(enabledProfilesPage, function(node) {
+	return node.tag === 'span' && node.attrs?.class === 'label success' &&
+		textContent(node) === 'Enabled';
+}).length, 1, 'an enabled profile should use the standard LuCI success badge');
+
+const disableButtons = byText(enabledProfilesPage, 'button', 'Disable');
+assert.strictEqual(disableButtons.length, 1,
+	'an enabled profile should retain its Disable action');
+assert.ok(disableButtons[0].attrs.disabled == null,
+	'the Disable action should be writable for an enabled profile');
+assert.ok(byText(enabledProfilesPage, 'button', 'Delete')[0].attrs.disabled != null,
+	'an enabled profile must not be deletable');
+disableButtons[0].attrs.click();
+assert.strictEqual(modal.title, 'Disable profile',
+	'Disable should open a confirmation modal before any operation');
+
+const unknownProfile = Object.assign({}, profile, {
+	iccid: '8912345678901234569',
+	profileState: 'unknown'
+});
+const unknownProfilesPage = profilesView.render({
+	success: true,
+	data: [ unknownProfile ]
+});
+assert.strictEqual(findAll(unknownProfilesPage, function(node) {
+	return node.tag === 'span' && node.attrs?.class === 'label warning' &&
+		textContent(node) === 'Unknown';
+}).length, 1, 'an unknown profile state should use a warning badge');
+assert.ok(byText(unknownProfilesPage, 'button', 'Unavailable')[0].attrs.disabled != null,
+	'an unknown profile state must not offer a state mutation');
+
+profilesView.showStateModal(profile, true);
+assert.ok(modal, 'profile state modal should render');
+
+const refresh = findAll(modal.content, function(node) {
+	return node.attrs?.id === 'lpac-profile-refresh';
+})[0];
+assert.ok(refresh, 'refresh checkbox should exist');
+assert.ok(refresh.attrs.checked == null,
+	'refresh should be unchecked for the first attempt');
+assert.strictEqual(findAll(modal.content, function(node) {
+	return node.attrs?.class === 'cbi-value-description' &&
+		textContent(node).startsWith('Requests a logical UICC refresh');
+}).length, 1, 'refresh help should distinguish the eUICC request from a modem reboot');
+
+[ 'Changing the active profile', 'lpac may create a provider notification' ].forEach(function(text) {
+	const notes = findAll(modal.content, function(node) {
+		return node.attrs?.class === 'cbi-value-description' &&
+			textContent(node).startsWith(text);
+	});
+	assert.strictEqual(notes.length, 1,
+		`${text} guidance should use the standard help-note presentation`);
+	assert.strictEqual(notes[0].attrs.role, 'note',
+		`${text} guidance should retain explicit note semantics`);
+});
+assert.strictEqual(findAll(modal.content, function(node) {
+	return node.attrs?.class === 'alert-message warning';
+}).length, 0, 'profile state guidance should not use oversized warning boxes');
+
+const identifier = findAll(modal.content, function(node) {
+	return node.attrs?.id === 'lpac-profile-identifier';
+})[0];
+assert.ok(identifier, 'identifier selector should exist');
+const identifierOptions = findAll(identifier, function(node) {
+	return node.tag === 'option';
+});
+assert.strictEqual(identifierOptions.length, 2,
+	'ICCID and ISD-P AID choices should both be offered');
+assert.strictEqual(identifierOptions.filter(function(node) {
+	return node.attrs.selected != null;
+}).length, 1, 'exactly one profile identifier should be selected');
+
+const notificationsView = loadView('notifications.js');
+const notificationsPage = notificationsView.render({
+	success: true,
+	data: [ {
+		seqNumber: 1,
+		profileManagementOperation: 'enable',
+		iccid: profile.iccid,
+		notificationAddress: 'example.invalid'
+	} ]
+});
+const removeButtons = byText(notificationsPage, 'button', 'Remove');
+assert.strictEqual(removeButtons.length, 1, 'Remove button should exist');
+assert.ok(removeButtons[0].attrs.disabled == null,
+	'Remove button must omit the disabled attribute for a writable nonzero sequence');
+assert.strictEqual(findAll(notificationsPage, function(node) {
+	return node.attrs?.class === 'alert-message warning' &&
+		textContent(node).startsWith('Sending notifications is disabled');
+}).length, 1, 'the page-wide TLS limitation should remain a prominent warning');
+
+const settingsView = loadView('settings.js');
+const settingsPage = settingsView.render([
+	{
+		success: true,
+		data: {
+			global: {
+				apdu_backend: 'mbim',
+				http_backend: 'curl',
+				apdu_debug: '0',
+				http_debug: '1',
+				custom_isd_r_aid: 'A0000005591010FFFFFFFF8900000100'
+			},
+			at: { device: '/dev/ttyUSB2', debug: '0' },
+			uqmi: { device: '/dev/cdc-wdm0', debug: '0' },
+			mbim: { device: '/dev/cdc-wdm0', proxy: '0' }
+		}
+	},
+	{ success: true, data: { apdu: [ 'mbim', 'at' ], http: [ 'curl' ] } }
+]);
+
+function findById(id) {
+	return findAll(settingsPage, function(node) { return node.attrs?.id === id; })[0];
+}
+
+assert.ok(findById('lpac-apdu-debug').attrs.checked == null,
+	'false APDU debug must render unchecked');
+assert.ok(findById('lpac-http-debug').attrs.checked != null,
+	'true HTTP debug must render checked');
+assert.ok(findById('lpac-mbim-proxy').attrs.checked == null,
+	'false MBIM proxy must render unchecked');
+
+const backend = findById('lpac-apdu-backend');
+const backendOptions = findAll(backend, function(node) { return node.tag === 'option'; });
+const selectedBackends = backendOptions.filter(function(node) {
+	return node.attrs.selected != null;
+});
+assert.strictEqual(selectedBackends.length, 1,
+	'exactly one APDU backend should carry the selected attribute');
+assert.strictEqual(selectedBackends[0].attrs.value, 'mbim',
+	'the configured APDU backend should be selected');
+assert.strictEqual(findAll(settingsPage, function(node) {
+	return node.attrs?.class === 'alert-message warning';
+}).length, 0, 'inactive backend caveats should not render as page-wide warnings');
+assert.strictEqual(findAll(settingsPage, function(node) {
+	return node.attrs?.class === 'cbi-value-description' &&
+		textContent(node).startsWith('Use the /dev/cdc-wdmN device');
+}).length, 1, 'uqmi device guidance should render as field help');
+assert.strictEqual(findAll(settingsPage, function(node) {
+	return node.attrs?.class === 'cbi-value-description' &&
+		textContent(node).startsWith('The AT backend is timing-sensitive');
+}).length, 1, 'AT compatibility guidance should render as field help');
+
+const menu = JSON.parse(fs.readFileSync(path.join(appRoot,
+	'root/usr/share/luci/menu.d/luci-app-lpac.json'), 'utf8'));
+assert.strictEqual(menu['admin/network/lpac'].title, 'eSIM Manager',
+	'eSIM Manager should live below the Network menu');
+assert.strictEqual(menu['admin/network/lpac'].action.type, 'firstchild',
+	'eSIM Manager should open its first tab');
+assert.strictEqual(menu['admin/network/lpac'].order, 90,
+	'eSIM Manager should avoid the built-in Network menu order range');
+assert.deepStrictEqual(menu['admin/network/lpac'].depends.acl, [ 'luci-app-lpac' ],
+	'the application root should require its ACL');
+[ 'overview', 'profiles', 'notifications', 'settings' ].forEach(function(page) {
+	assert.ok(menu[`admin/network/lpac/${page}`],
+		`${page} should remain a child tab below eSIM Manager`);
+});
+assert.strictEqual(Object.keys(menu).some(function(path) {
+	return path.startsWith('admin/modem');
+}), false, 'the upstream package should not create a top-level Modem menu');
+
+const profileCss = fs.readFileSync(path.join(appRoot,
+	'htdocs/luci-static/resources/view/lpac/profiles.css'), 'utf8');
+assert.ok(profileCss.includes('#lpac-profile-table,\n\t#lpac-profile-table > tbody {\n\t\tdisplay: block;'),
+	'the responsive layout should not depend on a theme table display mode');
+assert.ok(profileCss.includes('#lpac-profile-table .tr.table-titles {\n\t\tdisplay: none;'),
+	'the custom responsive grid should hide its redundant table heading');
+assert.match(profileCss, /#lpac-profile-table \.tr[^{]+{\s*display: grid;/,
+	'the mobile profile rows should use a scoped grid layout');
+assert.match(profileCss, /grid-template-columns:\s*minmax\(0, 2fr\) minmax\(7rem, 1fr\)/,
+	'the mobile grid should reserve more space for profile names and ICCIDs');
+assert.match(profileCss, /#lpac-profile-table \.td\[data-title\][^{]*::before/,
+	'the stylesheet should replace only the profile table theme labels');
+assert.match(profileCss, /#lpac-profile-table \.td\[data-title\][^{]*::after/,
+	'the stylesheet should remove scoped theme decoration from profile cells');
+assert.ok(profileCss.includes('\t\tborder-top: 0;'),
+	'the responsive grid should suppress theme borders on individual cells');
+assert.ok(profileCss.includes('#lpac-profile-table .tr.placeholder > .td {'),
+	'the block table should retain a normalized empty-profile placeholder');
+assert.match(profileCss, /\.lpac-profile-field[^{]*{[^}]*font-size:\s*1em;/s,
+	'profile details should retain the normal table font size on mobile');
+assert.match(profileCss, /\.lpac-profile-actions > \.btn[^{]*{[^}]*font-size:\s*13px !important;[^}]*line-height:\s*1\.8em;/s,
+	'action buttons should use compact typography without changing their columns');
+assert.doesNotMatch(profileCss, /^\s*\.table\s+\.td/m,
+	'the responsive override must not alter unrelated LuCI tables');
+
+console.log('ok - frontend controls, responsive layout, menu, and safety states');

--- a/applications/luci-app-lpac/tests/lib/fs.uc
+++ b/applications/luci-app-lpac/tests/lib/fs.uc
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export function lstat(path) {
+	global.TEST_LSTAT_PATH = path;
+
+	if (!global.TEST_LOCK_EXISTS)
+		return null;
+
+	return {
+		type: global.TEST_LOCK_TYPE,
+		uid: global.TEST_LOCK_UID,
+		nlink: global.TEST_LOCK_NLINK,
+		mode: global.TEST_LOCK_MODE
+	};
+};
+
+export function open(path, mode, permissions) {
+	global.TEST_OPEN = { path, mode, permissions };
+
+	if (global.TEST_LOCK_OPEN_FAIL)
+		return null;
+
+	if (!global.TEST_LOCK_EXISTS) {
+		global.TEST_LOCK_EXISTS = true;
+		global.TEST_LOCK_MODE = permissions;
+	}
+
+	return {
+		lock: function(flags) {
+			global.TEST_LOCK_FLAGS = flags;
+			return !global.TEST_LOCK_BUSY;
+		},
+
+		close: function() {
+			global.TEST_LOCK_CLOSED = true;
+			return true;
+		}
+	};
+};
+
+export function chmod(path, mode) {
+	global.TEST_CHMOD = { path, mode };
+
+	if (global.TEST_LOCK_CHMOD_FAIL)
+		return null;
+
+	global.TEST_LOCK_MODE = mode;
+	return true;
+};

--- a/applications/luci-app-lpac/tests/lib/ubus.uc
+++ b/applications/luci-app-lpac/tests/lib/ubus.uc
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export let STATUS_OK = 0;
+export let STATUS_NOT_FOUND = 4;
+export let STATUS_TIMEOUT = 7;
+export let STATUS_NOT_SUPPORTED = 8;
+
+export function connect() {
+	return {
+		defer: function(object, method, request, callback) {
+			global.TEST_LAST_CALL = { object, method, request };
+
+			if (global.TEST_DEFER_THROW)
+				die('defer failed');
+
+			if (global.TEST_DEFER_NULL)
+				return null;
+
+			let status = global.TEST_EXEC_STATUS;
+
+			if (type(status) != 'int')
+				status = STATUS_OK;
+
+			callback(status, global.TEST_EXEC_REPLY);
+
+			return {};
+		}
+	};
+};

--- a/applications/luci-app-lpac/tests/lib/uci.uc
+++ b/applications/luci-app-lpac/tests/lib/uci.uc
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export function cursor() {
+	return {
+		load: function(config) {
+			return config == 'lpac' && !global.TEST_UCI_LOAD_FAIL;
+		},
+
+		get: function(config, section, option) {
+			const values = global.TEST_UCI?.[section];
+			return config == 'lpac' && type(values) == 'object'
+				? values[option]
+				: null;
+		},
+
+		set: function(...args) {
+			if (args[0] != 'lpac' || length(args) < 3)
+				return null;
+
+			const section = args[1];
+
+			if (type(global.TEST_UCI[section]) != 'object')
+				global.TEST_UCI[section] = {};
+
+			if (length(args) == 4)
+				global.TEST_UCI[section][args[2]] = args[3];
+
+			return true;
+		},
+
+		commit: function(config) {
+			return config == 'lpac' && global.TEST_COMMIT_OK !== false;
+		},
+
+		unload: function() {
+			return true;
+		}
+	};
+};

--- a/applications/luci-app-lpac/tests/run-tests.sh
+++ b/applications/luci-app-lpac/tests/run-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+cd "$(dirname "$0")/.."
+exec ucode -S -L ./tests/lib ./tests/backend.uc


### PR DESCRIPTION
## Pull request details

### Status

This PR is intentionally kept as a draft because the MBIM slot-mapping
setting depends on
[openwrt/packages#30021](https://github.com/openwrt/packages/pull/30021).
That package PR provides `lpac 2.3.0-r3`, the UCI option, and the wrapper
environment export consumed here. This PR can be marked ready after the
package dependency is merged.

### Description

Add `luci-app-lpac`, a native LuCI frontend for the packaged OpenWrt `lpac`
backend, under **Network → eSIM Manager**.

The interface provides:

- installed lpac version, compiled drivers, and eUICC information;
- profile listing, enable, disable, rename, and delete operations;
- listing and explicit removal of local eUICC notifications;
- validated configuration for the AT, uqmi, MBIM, and PC/SC backends;
- an opt-in MBIM slot-mapping bypass for devices that cannot use normal
  Microsoft UICC slot mapping.

The browser uses a typed rpcd/ucode facade. The backend validates RPC and UCI
arguments, executes only `/usr/bin/lpac` with fixed argv arrays, normalizes
lpac JSON responses, and serializes eUICC access with a root-owned mode-0600
lock.

The package requires `lpac >= 2.3.0-r3`. It does not bundle or patch lpac and
does not perform modem resets, network-interface control, or modem lifecycle
orchestration.

[openwrt/packages#30021](https://github.com/openwrt/packages/pull/30021)
backports two changes already merged by lpac upstream:

- the environment boolean parser fix from
  [estkme-group/lpac#308](https://github.com/estkme-group/lpac/pull/308);
- the Microsoft UICC compatibility work and slot-mapping bypass from
  [estkme-group/lpac#438](https://github.com/estkme-group/lpac/pull/438).

The checkbox writes `lpac.mbim.skip_slot_mapping` and remains disabled by
default, matching lpac upstream and the OpenWrt package. Enabling it uses the
modem's currently selected slot without querying or changing MBIM Device Slot
Mapping, so the configured MBIM UIM slot is ignored.

Network RSP operations such as profile download, SM-DS discovery, and
notification processing are intentionally not exposed. lpac v2.3.0 disables
curl peer and hostname verification
([source](https://github.com/estkme-group/lpac/blob/v2.3.0/driver/http/curl.c#L90-L91)).
The Notifications page therefore only lists and explicitly removes local
eUICC records, while explaining that removal does not contact the provider
and may leave provider state out of sync.

Known backend limitation: alternate uqmi control devices are affected by
[openwrt/packages#29061](https://github.com/openwrt/packages/issues/29061);
`/dev/cdc-wdm0` is the currently supported path. The real-device validation
below covered MBIM, not uqmi.

Validation performed:

- LuCI ESLint, JavaScript syntax, JSON, ShellCheck, gettext, and reproducible
  POT checks;
- 42 mocked rpcd/ucode backend checks using the router's native ucode;
- frontend DOM, action-control, responsive-layout, and menu regression tests;
- package builds using OpenWrt 25.12.5 and snapshot SDKs in the review repo.

The exact package dependency commit
`9df1dcf4967a69b970db4c960b7e7af5d3e2aa1b` passed package, source-hash,
patch-refresh, and multi-target compile preflights:

- https://github.com/As-tsaqib/packages/actions/runs/29615968026
- https://github.com/As-tsaqib/packages/actions/runs/29616656159

An additional cross-repository preflight combined LuCI commit
`5d0d039f1355c13064a2fef7ad85d58972296757` with that exact packages commit
and built both `lpac` and `luci-app-lpac` successfully for:

- OpenWrt snapshot `x86_64`;
- OpenWrt 25.12.5 `arm_cortex-a7_neon-vfpv4`.

Run: https://github.com/As-tsaqib/luci/actions/runs/29618414617

Current head `78985a486711f79856cb6ff14cac3ef8b71cd710` differs from the tested LuCI tree only by accepting an indentation-only review comment in `overview.js`; all 42 backend tests, the frontend regression test, JavaScript syntax, ESLint, and whitespace checks were rerun successfully.\n\nBoth generated package metadata records contain exactly
`lpac>=2.3.0-r3` as the lpac dependency.

Real-device validation used OpenWrt 25.12.5 with a Fibocom L850-GL connected
to a removable physical eUICC; the modem does not contain an integrated eSIM.
The exact `lpac-2.3.0-r3` artifact from the packages PR was already installed.
The combined-preflight LuCI APK was then installed as
`luci-app-lpac-26.198.81094~da531f1` with SHA-256
`38f349c995bf479e51bedb1e4aeae4b8f8ff1fc55338fba312827a4d137e14f9`.

Runtime validation confirmed:

- `get_config` returned the existing MBIM configuration with
  `skip_slot_mapping: "1"`, so the checkbox reflects the current UCI value;
- three consecutive read-only chip-information calls succeeded;
- profile and notification reads succeeded without printing sensitive data;
- ModemManager remained running, the WWAN carrier and modem interface stayed
  up, and no lpac process remained;
- all tested LuCI static assets returned HTTP 200.

Earlier end-to-end validation on the same system covered profile switching
with the explicit eUICC refresh option. No profile, notification, or eUICC
mutation was performed during the latest `r3` and LuCI integration tests.
This validation does not claim that every APDU backend, modem, eUICC, or
firmware has been tested.

### Screenshot or video of changes _(if applicable)_

| Responsive Profiles view | Profile action confirmation |
| --- | --- |
| ![Profiles on a mobile viewport](https://raw.githubusercontent.com/As-tsaqib/luci/3366442d65d34ead3b243e8fd28926751c6240c4/01-profiles-mobile.png) | ![Profile action confirmation](https://raw.githubusercontent.com/As-tsaqib/luci/3366442d65d34ead3b243e8fd28926751c6240c4/03-profile-action-modal.png) |

<details>
<summary>Additional screenshots</summary>

| Desktop Profiles view | Notification TLS guidance |
| --- | --- |
| ![Profiles on a desktop viewport](https://raw.githubusercontent.com/As-tsaqib/luci/3366442d65d34ead3b243e8fd28926751c6240c4/02-profiles-desktop.png) | ![Notification TLS limitation](https://raw.githubusercontent.com/As-tsaqib/luci/3366442d65d34ead3b243e8fd28926751c6240c4/04-notifications-tls.png) |

</details>

### Maintainer _(preferred)_

@As-tsaqib

---

## Tested on

**OpenWrt version:** OpenWrt 25.12.5 (`r33051-f5dae5ece4`)  
**LuCI package:** `luci-app-lpac-26.198.81094~da531f1`  
**Web browser(s):** Quetta Browser 1.9.5 on Android

---

## Checklist

<!-- This PR remains a draft while openwrt/packages#30021 is pending. -->
