### PR TITLE
[24.10] luci-app-adblock-fast: update to 1.2.4-4

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -7,7 +7,8 @@ PKG_NAME:=luci-app-adblock-fast
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=1.2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=4
+PKG_CPE_ID:=cpe:/a:mossdef:luci-app-adblock-fast
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-adblock-fast/

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -40,6 +40,15 @@ var pkg = {
 	isVersionMismatch: function (luci, pkg, rpcd) {
 		return luci !== pkg || pkg !== rpcd || luci !== rpcd;
 	},
+	// HTML-escape an untrusted scalar value with LuCI's %h format specifier so
+	// config-derived text reflected into status messages cannot inject markup
+	// when appended via innerHTML by E()/dom.create. Trusted array infos built
+	// in this file (e.g. anchor tags) are passed through unchanged.
+	escapeInfo: function (info) {
+		return Array.isArray(info)
+			? info
+			: info != null && info !== "" ? "%h".format(info) : info;
+	},
 	formatMessage: function (info, template) {
 		if (!template) return _("Unknown message") + "<br />";
 		return (
@@ -391,8 +400,12 @@ var status = baseclass.extend({
 							},
 				ubus: {
 					packageCompat: initData.packageCompat || 0,
-					errors: initData.errors ? [...initData.errors] : [],
-					warnings: initData.warnings ? [...initData.warnings] : [],
+					errors: (initData.errors || []).map(function (e) {
+						return Object.assign({}, e, { info: pkg.escapeInfo(e.info) });
+					}),
+					warnings: (initData.warnings || []).map(function (e) {
+						return Object.assign({}, e, { info: pkg.escapeInfo(e.info) });
+					}),
 				},
 				cron: cronStatus?.[pkg.Name] || {
 					auto_update_enabled: false,

--- a/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json
+++ b/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json
@@ -2,17 +2,12 @@
 	"luci-app-adblock-fast": {
 		"description": "Grant UCI and file access for luci-app-adblock-fast",
 		"read": {
-			"file": {
-				"/dev/shm/adblock-fast": [ "list", "read" ],
-				"/dev/shm/adblock-fast.status.json": [ "list", "read" ]
-			},
 			"ubus": {
 				"luci.adblock-fast": [
 					"getFileUrlFilesizes",
 					"getInitList",
 					"getInitStatus",
 					"getCronStatus",
-					"getCronEntry",
 					"getPlatformSupport",
 					"getQueryLogStatus"
 				],
@@ -26,16 +21,12 @@
 			"uci": [
 				"adblock-fast",
 				"dhcp",
-				"smartdns",
-				"unbound"
+				"smartdns"
 			]
 		},
 		"write": {
 			"uci": [
-				"adblock-fast",
-				"dhcp",
-				"smartdns",
-				"unbound"
+				"adblock-fast"
 			],
 			"ubus": {
 				"luci.adblock-fast": [


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
Update to PKG_RELEASE 4

  - Bump PKG_RELEASE from 2 to 4.
  - Add PKG_CPE_ID.

htdocs/luci-static/resources/adblock-fast/status.js:
  - Add escapeInfo function to HTML-escape untrusted scalar values.
  - Apply escapeInfo to error and warning messages.

root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json:
  - Remove file access rules for /dev/shm/adblock-fast files.
  - Remove getCronEntry from ubus read access.
  - Remove unbound from uci read access.
  - Remove dhcp, smartdns, and unbound from uci write access.
  - Adjust ubus luci.adblock-fast write access for stop/start.

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 4e1b2c4ee28f59c442388494edade2dee926c550)