### PR TITLE
[24.10] luci-app-https-dns-proxy: update to 2026.05.06-1

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -6,8 +6,9 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2026.03.18
+PKG_VERSION:=2026.05.06
 PKG_RELEASE:=1
+PKG_CPE_ID:=cpe:/a:mossdef:luci-app-https-dns-proxy
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-https-dns-proxy/

--- a/applications/luci-app-https-dns-proxy/README.md
+++ b/applications/luci-app-https-dns-proxy/README.md
@@ -1,8 +1,8 @@
 # luci-app-https-dns-proxy
 
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-Compatible-blueviolet)](https://openwrt.org)
-[![Web UI](https://img.shields.io/badge/Web_UI-Available-blue)](https://docs.openwrt.melmac.ca/https-dns-proxy/)
-[![Resolvers](https://img.shields.io/badge/Resolvers-40%2B%20Built--in-brightgreen)](https://docs.openwrt.melmac.ca/https-dns-proxy/)
+[![Web UI](https://img.shields.io/badge/Web_UI-Available-blue)](https://docs.mossdef.org/https-dns-proxy/)
+[![Resolvers](https://img.shields.io/badge/Resolvers-40%2B%20Built--in-brightgreen)](https://docs.mossdef.org/https-dns-proxy/)
 [![Minimal Footprint](https://img.shields.io/badge/Size-~40KB-green)](https://github.com/stangri/https-dns-proxy)
 [![License](https://img.shields.io/badge/License-MIT-lightgrey)](https://github.com/stangri/https-dns-proxy/blob/master/LICENSE)
 
@@ -17,6 +17,6 @@ Includes optional integration with `dnsmasq`, automatic fallback, and canary dom
 
 **Full documentation:**
 
-[https://docs.openwrt.melmac.ca/https-dns-proxy/](https://docs.openwrt.melmac.ca/https-dns-proxy/)
+[https://docs.mossdef.org/https-dns-proxy/](https://docs.mossdef.org/https-dns-proxy/)
 
 Based on [@aarond10](https://github.com/aarond10)'s excellent [https_dns_proxy](https://github.com/aarond10/https_dns_proxy)

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
@@ -18,7 +18,7 @@ var pkg = {
 	},
 	get URL() {
 		return (
-			"https://docs.openwrt.melmac.ca/" +
+			"https://docs.mossdef.org/" +
 			pkg.Name +
 			"/" +
 			(pkg.ReadmeCompat ? pkg.ReadmeCompat + "/" : "")
@@ -26,7 +26,7 @@ var pkg = {
 	},
 	get DonateURL() {
 		return (
-			"https://docs.openwrt.melmac.ca/" +
+			"https://docs.mossdef.org/" +
 			pkg.Name +
 			"/" +
 			(pkg.ReadmeCompat ? pkg.ReadmeCompat + "/" : "") +
@@ -52,6 +52,12 @@ var pkg = {
 	templateToResolver: function (template, args) {
 		if (template) return template.replace(/{(\w+)}/g, (_, v) => args[v]);
 		return null;
+	},
+	// HTML-escape an untrusted scalar value with LuCI's %h format specifier so
+	// config-derived text (listen address, resolver URL) reflected into status
+	// cannot inject markup when appended via innerHTML by E()/dom.create.
+	escapeInfo: function (info) {
+		return info != null && info !== "" ? "%h".format(info) : info;
 	},
 };
 
@@ -266,18 +272,18 @@ var status = baseclass.extend({
 					if (address === "127.0.0.1")
 						text += _("%s%s%s proxy on port %s.%s").format(
 							"<strong>",
-							name,
+							pkg.escapeInfo(name),
 							"</strong>",
-							port,
+							pkg.escapeInfo(port),
 							"<br />"
 						);
 					else
 						text += _("%s%s%s proxy at %s on port %s.%s").format(
 							"<strong>",
-							name,
+							pkg.escapeInfo(name),
 							"</strong>",
-							address,
-							port,
+							pkg.escapeInfo(address),
+							pkg.escapeInfo(port),
 							"<br />"
 						);
 				});

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -186,7 +186,7 @@ return view.extend({
 			)
 		);
 		o.optional = true;
-		o.placeholder = "heartbeat.melmac.ca";
+		o.placeholder = "heartbeat.mossdef.org";
 
 		o = s.taboption(
 			"service",
@@ -238,14 +238,14 @@ return view.extend({
 		o = s.taboption(
 			"global",
 			form.ListValue,
-			"force_ipv6_resolvers",
-			_("Use IPv6 resolvers")
+			"force_ip_family",
+			_("DNS resolver IP family")
 		);
 		o.optional = true;
-		o.rmempty = true;
-		o.value("", _("Use any family DNS resolvers"));
-		o.value("1", _("Force use of IPv6 DNS resolvers"));
-		o.default = "";
+		o.value("auto", _("Automatic (dual-stack)"));
+		o.value("ipv4", _("IPv4 only"));
+		o.value("ipv6", _("IPv6 only"));
+		o.default = "auto";
 
 		o = s.taboption("global", form.ListValue, "verbosity", _("Logging Verbosity Level"));
 		o.optional = true;
@@ -669,12 +669,13 @@ return view.extend({
 		o.default = "";
 		o.depends("force_http1", "");
 
-		o = s.option(form.ListValue, "force_ipv6_resolvers", _("Use IPv6 resolvers"));
+		o = s.option(form.ListValue, "force_ip_family", _("DNS resolver IP family"));
 		o.modalonly = true;
 		o.optional = true;
-		o.rmempty = true;
-		o.value("", _("Use any family DNS resolvers"));
-		o.value("1", _("Force use of IPv6 DNS resolvers"));
+		o.value("", _("Use global setting"));
+		o.value("auto", _("Automatic (dual-stack)"));
+		o.value("ipv4", _("IPv4 only"));
+		o.value("ipv6", _("IPv6 only"));
 		o.default = "";
 
 		return Promise.all([status.render(), m.render()]);

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json
@@ -1,7 +1,7 @@
 {
 	"title": "AdGuard",
 	"template": "https://{option}.adguard-dns.com/dns-query",
-	"bootstrap_dns": "94.140.14.140,94.140.14.141",
+	"bootstrap_dns": "94.140.14.140,94.140.14.141,2a10:50c0::1:ff,2a10:50c0::2:ff",
 	"help_link": "https://adguard-dns.io/en/public-dns.html",
 	"params": {
 		"option": {

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.dnsforfamily.dns-doh.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.dnsforfamily.dns-doh.json
@@ -1,6 +1,6 @@
 {
 	"title": "DNS For Family",
 	"template": "https://dns-doh.dnsforfamily.com/dns-query",
-	"bootstrap_dns": "94.130.180.225,78.47.64.161",
+	"bootstrap_dns": "94.130.180.225,78.47.64.161,2a01:4f8:1c0c:40db::1,2a01:4f8:1c17:4df8::1",
 	"help_link": "https://dnsforfamily.com/#DNS_Servers_DNS_Over_HTTPS"
 }

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json
@@ -1,7 +1,7 @@
 {
 	"title": "OpenDNS",
 	"template": "https://doh.{option}opendns.com/dns-query",
-	"bootstrap_dns": "208.67.222.222,208.67.220.220",
+	"bootstrap_dns": "208.67.222.222,208.67.220.220,2620:119:35::35,2620:119:53::53",
 	"help_link": "https://support.opendns.com/hc/en-us/articles/360038086532-Using-DNS-over-HTTPS-DoH-with-OpenDNS",
 	"params": {
 		"option": {

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/cz.nic.odvr.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/cz.nic.odvr.json
@@ -1,5 +1,5 @@
 {
 	"title": "ODVR (CZ)",
 	"template": "https://odvr.nic.cz/doh",
-	"bootstrap_dns": "193.17.47.1,185.43.135.1"
+	"bootstrap_dns": "193.17.47.1,185.43.135.1,2001:148f:ffff::1,2001:148f:fffe::1"
 }

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/google.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/google.dns.json
@@ -1,6 +1,6 @@
 {
 	"title": "Google",
 	"template": "https://dns.google/dns-query",
-	"bootstrap_dns": "8.8.8.8,8.8.4.4",
+	"bootstrap_dns": "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
 	"default": true
 }

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json
@@ -1,7 +1,7 @@
 {
 	"title": "LibreDNS (GR)",
 	"template": "https://doh.libredns.gr/{option}",
-	"bootstrap_dns": "116.202.176.26",
+	"bootstrap_dns": "116.202.176.26,2a01:4f8:1c0c:8274::1",
 	"help_link": "https://libredns.gr/",
 	"params": {
 		"option": {

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/io.nextdns.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/io.nextdns.dns.json
@@ -1,7 +1,7 @@
 {
 	"title": "NextDNS.io",
 	"template": "https://dns.nextdns.io/{option}",
-	"bootstrap_dns": "45.90.28.49,45.90.30.49",
+	"bootstrap_dns": "45.90.28.49,45.90.30.49,2a07:a8c0::,2a07:a8c1::",
 	"help_link": "https://my.nextdns.io",
 	"params": {
 		"option": {

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.idnet.doh.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.idnet.doh.json
@@ -1,5 +1,5 @@
 {
 	"title": "IDNet (UK)",
 	"template": "https://doh.idnet.net/dns-query",
-	"bootstrap_dns": "212.69.36.23,212.69.40.23"
+	"bootstrap_dns": "212.69.36.23,212.69.40.23,2a02:390:1::64:6e73,2a02:390:2::64:6e73"
 }

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json
@@ -1,7 +1,7 @@
 {
 	"title": "CleanBrowsing",
 	"template": "https://doh.cleanbrowsing.org/doh/{option}-filter/",
-	"bootstrap_dns": "185.228.168.168",
+	"bootstrap_dns": "185.228.168.168,2a0d:2a00:1::,2a0d:2a00:2::",
 	"help_link": "https://cleanbrowsing.org/guides/dnsoverhttps",
 	"params": {
 		"option": {

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/pub.doh.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/pub.doh.json
@@ -1,5 +1,5 @@
 {
 	"title": "DNSPod Public DNS (CN)",
 	"template": "https://doh.pub/dns-query",
-	"bootstrap_dns": "119.29.29.29,119.28.28.28"
+	"bootstrap_dns": "119.29.29.29,119.28.28.28,2402:4e00::,2402:4e00:1::"
 }

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/recipes.v.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/recipes.v.json
@@ -1,7 +1,7 @@
 {
 	"title": "v.recipes",
 	"template": "https://v.recipes/dns-{option}",
-	"bootstrap_dns": "1.1.1.1,1.0.0.1,8.8.8.8,8.8.4.4",
+	"bootstrap_dns": "1.1.1.1,1.0.0.1,8.8.8.8,8.8.4.4,2606:4700:4700::1111,2606:4700:4700::1001,2001:4860:4860::8888,2001:4860:4860::8844",
 	"help_link": "https://v.recipes/dns/",
 	"params": {
 		"option": {

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/sb.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/sb.dns.json
@@ -1,7 +1,7 @@
 {
 	"title": "DoH DNS (SB)",
 	"template": "https://doh.dns.sb/dns-query",
-	"bootstrap_dns": "185.222.222.222,185.184.222.222",
+	"bootstrap_dns": "185.222.222.222,45.11.45.11,2a09::,2a11::",
 	"help_link": "https://dns.sb/doh/",
 	"http2_only": true
 }

--- a/applications/luci-app-https-dns-proxy/tests/run_tests.sh
+++ b/applications/luci-app-https-dns-proxy/tests/run_tests.sh
@@ -6,7 +6,7 @@
 #   02: JavaScript template functions (templateToRegexp, templateToResolver)
 #   03: RPC backend script validation
 #
-# Usage: cd source.openwrt.melmac.ca/luci-app-https-dns-proxy && bash tests/run_tests.sh
+# Usage: cd source.mossdef.org/luci-app-https-dns-proxy && bash tests/run_tests.sh
 
 set -o pipefail
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
Update version, add IPv6 bootstrap IPs

  - Update PKG_VERSION to 2026.05.06.
  - Add PKG_CPE_ID.

README.md:
  - Update documentation URLs to mossdef.org domain.

htdocs/luci-static/resources/https-dns-proxy/status.js:
  - Update documentation URLs to mossdef.org domain.
  - Add HTML-escaping for config-derived text in status UI.
  - Apply HTML-escaping to proxy name, address, and port in status UI.

htdocs/luci-static/resources/view/https-dns-proxy/overview.js:
  - Update heartbeat placeholder to heartbeat.mossdef.org.
  - Replace 'Use IPv6 resolvers' option with 'DNS resolver IP family'.
  - Update global and modal-only resolver IP family options.

root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/com.dnsforfamily.dns-doh.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/cz.nic.odvr.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/google.dns.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/io.nextdns.dns.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/net.idnet.doh.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/pub.doh.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/recipes.v.json:
  - Add IPv6 bootstrap DNS servers.

root/usr/share/https-dns-proxy/providers/sb.dns.json:
  - Add IPv6 bootstrap DNS servers.

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 3a405210148dcac5a26d670478939ab983f8f072)