### PR TITLE
[24.10]: backport security fixes.

### DIFF
--- a/applications/luci-app-samba4/root/usr/share/rpcd/acl.d/luci-app-samba4.json
+++ b/applications/luci-app-samba4/root/usr/share/rpcd/acl.d/luci-app-samba4.json
@@ -4,7 +4,7 @@
 		"read": {
 			"file": {
 				"/etc/samba/smb.conf.template": [ "read" ],
-				"/usr/sbin/smbd": [ "exec" ]
+				"/usr/sbin/smbd -V": [ "exec" ]
 			},
 			"uci": [ "samba4" ]
 		},

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/status/include/80_upnp.js
@@ -69,7 +69,7 @@ return baseclass.extend({
 				rule.extport,
 				rule.proto,
 				expires_str,
-				rule.descr,
+				'%h'.format(rule.descr),
 				E('button', {
 					'class': 'btn cbi-button-remove',
 					'click': L.bind(handleDelRule, this, rule.num)

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -65,7 +65,7 @@ return view.extend({
 				rule.extport,
 				rule.proto,
 				expires_str,
-				rule.descr,
+				'%h'.format(rule.descr),
 				E('button', {
 					'class': 'btn cbi-button-remove',
 					'click': L.bind(handleDelRule, this, rule.num)
@@ -115,7 +115,7 @@ return view.extend({
 					rule.intport,
 					rule.extport,
 					rule.proto,
-					rule.descr,
+					'%h'.format(rule.descr),
 					E('button', {
 						'class': 'btn cbi-button-remove',
 						'click': L.bind(handleDelRule, this, rule.num)

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1382,7 +1382,7 @@ return view.extend({
 								host = lease.hostname;
 
 							return [
-								host || '-',
+								'%h'.format(host || '-'),
 								lease.ipaddr,
 								lease.macaddr,
 								exp
@@ -1414,7 +1414,7 @@ return view.extend({
 									host = name;
 
 								return [
-									host || '-',
+									'%h'.format(host || '-'),
 									lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
 									lease.duid,
 									exp

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -111,7 +111,7 @@ return baseclass.extend({
 				host = lease.hostname;
 
 			rows = [
-				host || '-',
+				'%h'.format(host || '-'),
 				lease.ipaddr,
 				lease.macaddr,
 				exp
@@ -160,7 +160,7 @@ return baseclass.extend({
 				host = hint[1];
 
 			rows = [
-				host || '-',
+				'%h'.format(host || '-'),
 				lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
 				lease.duid,
 				exp


### PR DESCRIPTION
## Pull request details

### Description
cherry pick multiple secruity fixes to 24.10 branch


 * luci-mod-status: escape hostname in DHCP lease status tables
    
    Avoid stored XSS by HTML escaping backend provided hostname
    since underlying services to not sanitize.
    
    Signed-off-by: Jo-Philipp Wich <jo@mein.io>
    (cherry picked from commit 55379d04fcc3c605003a5001d6135cf02ae6048a)
    (cherry picked from commit ec518ef37d3160d3d69443707a06f8fd746d39a5)
    [ hauke: adapted to the pre-ES2016 cbi_update_table lease tables on this
      branch; only the hostname cell is escaped as the MAC column carries no
      concatenated vendor string here ]
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

 * luci-app-upnp: escape description field in output
    
    Since underlying upnpd does not sanitize, ensure to HTML escape
    UPnP lease description to prevent XSS.
    
    Signed-off-by: Jo-Philipp Wich <jo@mein.io>
    (cherry picked from commit 08ce6fe64372cb3794612c050fe99ea969cbec6e)
    (cherry picked from commit 128a7812f4be233c5dd7f7466f534fd888785caf)
    [ hauke: also escape rule.descr in the second active-rules table that
      still exists in the render() path of upnp.js on this branch ]
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

 * luci-app-samba4: tighten read exec access
    
    Only grant exec permission to `smbd -V`, not smbd in general in order
    to prevent arbitrary command execution for readonly users.
    
    Signed-off-by: Jo-Philipp Wich <jo@mein.io>
    (cherry picked from commit 2a58b5c6c23678fb64f85456f2b8ff5416626a4b)
    (cherry picked from commit dcee5f1d69e503c61550413241be3220ac1761ec)
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>


### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@<github-user>

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
