### PR TITLE
luci-mod-system: add option for force HTTP authentication

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js
@@ -14,6 +14,9 @@ return view.extend({
 		o = s.option(form.Flag, 'redirect_https', _('Redirect to HTTPS'), _('Enable automatic redirection of <abbr title="Hypertext Transfer Protocol">HTTP</abbr> requests to <abbr title="Hypertext Transfer Protocol Secure">HTTPS</abbr> port.'));
 		o.rmempty = false;
 
+		o = s.option(form.Flag, 'force_http_auth', _('Force HTTP Authentication'), _('Enforce <abbr title="Hypertext Transfer Protocol">HTTP</abbr> basic authentication for all pages using the root account.'));
+		o.rmempty = false;
+
 		return m.render();
 	}
 });


### PR DESCRIPTION


<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
Inspired by
https://github.com/openwrt/luci/security/advisories/GHSA-8qcq-jgrj-gvmj

Currently, LuCI lacks restrictions on CGI programs bundled with plugins. It is absurd that if a LuCI plugin installs a CGI program, it can bypass the unified authentication with no way to mitigate this.

Adding this option to luci-mod-system allows users to at least use HTTP auth to prevent unauthorized access via LuCI.

While this can be accomplished via the command line, providing a WebUI option significantly improves user-friendliness and security hardening. This feature is not enabled by default and will not affect existing users.

### Screenshot or video of changes 
<img width="848" height="600" alt="2026-07-21 232949" src="https://github.com/user-attachments/assets/d1298b4c-01d3-461a-8439-ada36cf188ce" />




## Tested on

**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4)
**LuCI version:** LuCI openwrt-25.12 branch (26.183.16146~6aacb73)
**Web browser(s):** Firefox 152.0.6

---
