### PR TITLE
[openwrt-25.12] luci-base: dispatcher.uc: escape URL path and username when logging

### DIFF
--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -11,7 +11,7 @@ import { openlog, syslog, closelog, LOG_INFO, LOG_WARNING, LOG_AUTHPRIV } from '
 import { hash, load_catalog, change_catalog, translate, ntranslate, getuid } from 'luci.core';
 import { revision as luciversion, branch as luciname } from 'luci.version';
 import { default as LuCIRuntime } from 'luci.runtime';
-import { urldecode } from 'luci.http';
+import { urldecode, urlencode } from 'luci.http';
 
 let ubus = connect();
 let uci = cursor();
@@ -508,14 +508,14 @@ function session_setup(user, pass, path) {
 			ubus_rpc_session: login.ubus_rpc_session,
 			values: { token: randomid(16) }
 		});
-		syslog(LOG_INFO|LOG_AUTHPRIV, sprintf("luci: accepted login on /%s for %s from %s",
-			join('/', path), user || "?", http.getenv("REMOTE_ADDR") || "?"));
+		syslog(LOG_INFO|LOG_AUTHPRIV, "luci: accepted login on /%s for %s from %s",
+			join('/', map(path, p => urlencode(p))), urlencode(user || "?"), http.getenv("REMOTE_ADDR") || "?");
 
 		return session_retrieve(login.ubus_rpc_session);
 	}
 
-	syslog(LOG_WARNING|LOG_AUTHPRIV, sprintf("luci: failed login on /%s for %s from %s",
-		join('/', path), user || "?", http.getenv("REMOTE_ADDR") || "?"));
+	syslog(LOG_WARNING|LOG_AUTHPRIV, "luci: failed login on /%s for %s from %s",
+		join('/', map(path, p => urlencode(p))), urlencode(user || "?"), http.getenv("REMOTE_ADDR") || "?");
 
 	closelog();
 }


### PR DESCRIPTION
Prevent maliciously crafted login requests from polluting the logs.


(cherry picked from commit 4021b549d77bf197923aecb6329381304c99d34d)

This is a backport of https://github.com/openwrt/luci/pull/8768

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->


## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
https://github.com/openwrt/luci/security/advisories/GHSA-r6hx-4f83-vp8m has not been fully fixed.

Suppose a user has configured a dropbear rule in `banip`, such as `dropbear\[\d+\]: Bad password attempt for 'root' from ([\d.]+):\d+`. An attacker can construct a LuCI request to pollute the logs and trigger the dropbear rule.

POC:
```
curl 'http://192.168.59.66/cgi-bin/luci/' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'Accept-Language: zh-CN,zh;q=0.9,en;q=0.8' \
  -H 'Cache-Control: max-age=0' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Origin: http://192.168.59.66' \
  -H 'Referer: http://192.168.59.66/cgi-bin/luci/' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36' \
  --data-raw 'luci_username=dropbear%5B28869%5D%3A+Bad+password+attempt+for+%27root%27+from+33.3.3.3%3A56672&luci_password=' \
  --insecure

```

Logs:
```
[2026年7月1日 GMT+8 21:37:58] authpriv.warn: dispatcher.uc: luci: failed login on / for dropbear[28869]: Bad password attempt for 'root' from 33.3.3.3:56672 from 192.168.59.1
```

`banip` may block `33.3.3.3`.

Logs after patch:
```
[2026年7月1日 GMT+8 21:40:32] authpriv.warn: dispatcher.uc: luci: failed login on / for dropbear%5B28869%5D%3A%20Bad%20password%20attempt%20for%20'root'%20from%2033.3.3.3%3A56672 from 192.168.59.1
```


### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@jow- <github-user>

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.5 r33051-f5dae5ece4<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** LuCI openwrt-25.12 branch 26.180.75667~128a781<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Not related<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Optional)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Optional)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
