### PR TITLE
luci-base: bind rollback confirmation to the owning session

### DIFF
--- a/modules/luci-base/ucode/template/footer.ut
+++ b/modules/luci-base/ucode/template/footer.ut
@@ -3,8 +3,9 @@
  Licensed to the public under the Apache License 2.0.
 -#}
 
-{% const rollback = dispatcher.rollback_pending() %}
-{% if (rollback || trigger_apply || trigger_revert): %}
+{% const rollback = dispatcher.rollback_pending();
+	const own_rollback = (rollback && rollback.session === ctx.authsession) %}
+{% if (own_rollback || trigger_apply || trigger_revert): %}
 	<script>
 		document.addEventListener("luci-loaded", function() {
 			{% if (trigger_apply): %}


### PR DESCRIPTION
Minimal fix to emit the confirmation script only
when the requesting session is the one that initiated the rollback.

Reported-by: TA-MU-TA
Fixes: GHSA-76w2-p5qr-9vjv
Signed-off-by: Dirk Brenken <dev@brenken.org>
