### PR TITLE
luci-base: fix sendclientid option

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
+++ b/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
@@ -34,12 +34,8 @@ return network.registerProtocol('dhcp', {
 		o = s.taboption('advanced', form.Flag, 'broadcast', _('Use broadcast flag'), _('Required for certain ISPs, e.g. Charter with DOCSIS 3'));
 		o.default = o.disabled;
 
-		o = s.taboption('advanced', form.Flag, 'sendclientid', _('Send Client ID'), _('Send the DHCP client identifier (option 61). Disable for ISPs that reject requests containing it'));
-		o.default = o.enabled;
-
 		o = s.taboption('advanced', form.Value, 'clientid', _('Client ID to send when requesting DHCP'));
 		o.datatype  = 'hexstring';
-		o.depends('sendclientid', '1');
 
 		s.taboption('advanced', form.Value, 'vendorid', _('Vendor Class to send when requesting DHCP'));
 	}

--- a/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
+++ b/modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js
@@ -34,8 +34,21 @@ return network.registerProtocol('dhcp', {
 		o = s.taboption('advanced', form.Flag, 'broadcast', _('Use broadcast flag'), _('Required for certain ISPs, e.g. Charter with DOCSIS 3'));
 		o.default = o.disabled;
 
+		o = s.taboption('advanced', form.ListValue, 'sendclientid', _('Preferred client ID'),
+			_('Selects the client identifier (DHCP option 61) to send when requesting DHCP.') + '<br />' +
+			_('<em>Automatic</em> uses the client ID configured below, else the default DUID of this device, else the MAC address of this interface.') + '<br />' +
+			_('<em>Default DUID</em> always uses the default DUID of this device, even if a client ID is configured below.') + '<br />' +
+			_('<em>Hardware address</em> always uses the MAC address of this interface.') + '<br />' +
+			_('<em>None</em> sends no client identifier at all.'));
+		o.value('auto', _('Automatic'));
+		o.value('global', _('Default DUID'));
+		o.value('hardware', _('Hardware address'));
+		o.value('none', _('None'));
+		o.default = 'auto';
+
 		o = s.taboption('advanced', form.Value, 'clientid', _('Client ID to send when requesting DHCP'));
 		o.datatype  = 'hexstring';
+		o.depends('sendclientid', 'auto');
 
 		s.taboption('advanced', form.Value, 'vendorid', _('Vendor Class to send when requesting DHCP'));
 	}

--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
@@ -38,7 +38,18 @@ return network.registerProtocol('dhcpv6', {
 		o.default = '1';
 		o.rmempty = false;
 
+		o = s.taboption('advanced', form.ListValue, 'sendclientid', _('Preferred client ID'),
+			_('Selects the <abbr title="DHCP Unique Identifier">DUID</abbr> to send when requesting DHCPv6.') + '<br />' +
+			_('<em>Automatic</em> uses the client ID configured below, else the default DUID of this device, else a DUID-LL derived from the MAC address of this interface.') + '<br />' +
+			_('<em>Default DUID</em> always uses the default DUID of this device, even if a client ID is configured below.') + '<br />' +
+			_('<em>Hardware address</em> always uses a DUID-LL derived from the MAC address of this interface.'));
+		o.value('auto', _('Automatic'));
+		o.value('global', _('Default DUID'));
+		o.value('hardware', _('Hardware address'));
+		o.default = 'auto';
+
 		o = s.taboption('advanced', form.Value, 'clientid', _('Client ID to send when requesting DHCP'));
 		o.datatype  = 'hexstring';
+		o.depends('sendclientid', 'auto');
 	}
 });


### PR DESCRIPTION
<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
Add the options from https://github.com/openwrt/openwrt/pull/24107 to LuCI.

This reverts https://github.com/openwrt/luci/pull/8798, which was the LuCI part for a different version of this change. The OpenWrt part was never implemented like this. 


### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@<github-user>

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
