### PR TITLE
[25.12]: luci-app-ddns: fix syntax error

### DIFF
--- a/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
@@ -228,7 +228,7 @@ const methods = {
 
 			const hasWget = () => {
 				return cache.has_wget ??= hasCommand('wget');
-			}
+			};
 
 			const hasWgetSsl = () => {
 				return cache.has_wgetssl ??= hasWget() && system(`wget 2>&1 | grep -iqF 'https'`) == 0 ? true : false;


### PR DESCRIPTION
fix syntax error

fixes: https://forum.openwrt.org/t/ddns-broken-in-25-12-5-latest-update/252154

fixes: https://github.com/openwrt/luci/issues/8872

(cherry picked from commit 6f849a7)