### PR TITLE
luci-app-banip: (feat) add a feed selector to the GeoIP map

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/map.html
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/map.html
@@ -9,8 +9,42 @@
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
 		integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
 	<style>
+		html,
+		body {
+			height: 100%;
+			margin: 0;
+			color-scheme: light dark;
+		}
+
+		body {
+			display: flex;
+			flex-direction: column;
+		}
+
+		#toolbar {
+			flex: 0 0 auto;
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: 0.6em;
+			padding: 0.4em 0.8em;
+			box-sizing: border-box;
+			background: Canvas;
+			color: CanvasText;
+			border-bottom: 1px solid ButtonBorder;
+			font-family: sans-serif;
+			font-size: 14px;
+		}
+
+		#feedSelect {
+			min-width: 260px;
+			max-width: 70vw;
+			padding: 0.25em;
+		}
+
 		#map {
-			height: 97vh;
+			flex: 1 1 auto;
+			min-height: 0;
 			width: 100%;
 		}
 
@@ -24,6 +58,12 @@
 </head>
 
 <body>
+	<div id="toolbar">
+		<label for="feedSelect">Feed:</label>
+		<select id="feedSelect" disabled>
+			<option value="">All feeds</option>
+		</select>
+	</div>
 	<div id="map"></div>
 
 	<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
@@ -44,6 +84,7 @@
 
 		/* get mapData */
 		const mapData = sessionStorage.getItem('mapData');
+		const feedSelect = document.getElementById('feedSelect');
 		if (mapData) {
 			let uniqueCoordinates = [];
 			let homeCoordinates = [];
@@ -90,25 +131,51 @@
 					"</p>");
 			});
 
-			/* render markers for blocked IPs */
+			/* populate the feed selector, one entry per banIP Set */
+			let feedCounts = {};
 			uniqueCoordinates.forEach(function (coordObj) {
-				let key = coordObj.key.slice(0, -3);
-				let lat = coordObj.lat;
-				let lon = coordObj.lon;
-				let ip = coordObj.query.slice(0, 38);
-				let as = coordObj.as.slice(0, 38);
-				let city = coordObj.city.slice(0, 33);
-				let cc = coordObj.cc;
-				let circle = L.circleMarker([lat, lon]).addTo(map);
-				circle.setStyle({ color: '#C22121', opacity: 1.0, fillColor: '#C22121', fillOpacity: 0.5, radius: 2 });
-				circle.bindPopup("<b><center>blocked IP by " + key + "</center></b>" +
-					"<p class=\"mono\">" +
-					"City: " + city + " (" + cc + ")" +
-					"<br />Latitude : " + lat +
-					"<br />Longitude: " + lon +
-					"<br />IP: " + ip +
-					"<br />AS: " + as +
-					"</p>");
+				feedCounts[coordObj.key] = (feedCounts[coordObj.key] || 0) + 1;
+			});
+			Object.keys(feedCounts).sort().forEach(function (feed) {
+				let option = document.createElement('option');
+				option.value = feed;
+				option.textContent = feed + " (" + feedCounts[feed] + ")";
+				feedSelect.appendChild(option);
+			});
+			feedSelect.options[0].textContent = "All feeds (" + uniqueCoordinates.length + ")";
+			feedSelect.disabled = uniqueCoordinates.length === 0;
+
+			/* render markers for blocked IPs, an empty feed renders all of them */
+			let blockedLayer = L.layerGroup().addTo(map);
+			function renderBlockedMarkers(selectedFeed) {
+				blockedLayer.clearLayers();
+				uniqueCoordinates.forEach(function (coordObj) {
+					if (selectedFeed && coordObj.key !== selectedFeed) {
+						return;
+					}
+					let key = coordObj.key.slice(0, -3);
+					let lat = coordObj.lat;
+					let lon = coordObj.lon;
+					let ip = coordObj.query.slice(0, 38);
+					let as = coordObj.as.slice(0, 38);
+					let city = coordObj.city.slice(0, 33);
+					let cc = coordObj.cc;
+					let circle = L.circleMarker([lat, lon]).addTo(blockedLayer);
+					circle.setStyle({ color: '#C22121', opacity: 1.0, fillColor: '#C22121', fillOpacity: 0.5, radius: 2 });
+					circle.bindPopup("<b><center>blocked IP by " + key + "</center></b>" +
+						"<p class=\"mono\">" +
+						"City: " + city + " (" + cc + ")" +
+						"<br />Latitude : " + lat +
+						"<br />Longitude: " + lon +
+						"<br />IP: " + ip +
+						"<br />AS: " + as +
+						"</p>");
+				});
+			}
+
+			renderBlockedMarkers("");
+			feedSelect.addEventListener('change', function (event) {
+				renderBlockedMarkers(event.target.value);
 			});
 		}
 	</script>


### PR DESCRIPTION
The map plotted every blocked IP as one red layer. With several feeds active there was no way to  tell which Set an IP came from, or to look at one set in isolation.

Add a toolbar above the map holding a single select:

* One option per banIP Set present in ban_map.jsn, sorted by name, each showing how many map points that Set contributes. The default option reports the total and keeps the previous behaviour of plotting everything.
* Options carry the full Set name including the .v4 / .v6 suffix, so the two address families of a feed remain distinguishable in the list.
* Selecting a Set plots every mapped point of that Set, not a subset. No cap is applied, so the rendering does not depend on how f_report() orders or truncates set_elements.
* Blocked markers now live in an L.layerGroup, which makes redrawing on change a clearLayers() call instead of tracking and removing individual markers.
* The select is disabled in the markup and enabled only once at least one mappable point exists, which covers both an absent and an empty mapData without an extra branch.

Layout and theming of the new element:

* Replace the fixed 97vh map height with a flex column, so the toolbar and the map together fill the viewport exactly. This also drops the default 8px body margin that made 97vh overflow.
* Style the toolbar with the CSS system colors Canvas, CanvasText and ButtonBorder under color-scheme: light dark, instead of hardcoded values that would only suit a light theme. These follow the browser or OS preference rather than the active LuCI theme.

Everything else is untouched: coordinate deduplication, the entry validation, popup markup, the home marker code path and the key.slice(0, -3) title. In the unfiltered view the map renders exactly the same markers as before this change.

[Assisted by Anthropic Claude Opus 5.0]

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
Added a toolbar on the map to filter by feed

### Screenshot or video of changes _(if applicable)_
<img width="475" height="521" alt="image" src="https://github.com/user-attachments/assets/1893f99a-dc9d-4b24-afbc-209a42a0a462" />


### Maintainer _(preferred)_
@dibdot 

---

## Tested on
[LuCI openwrt-25.12 branch (26.180.75667~128a781)]
[OpenWrt 25.12.5 (r33051-f5dae5ece4)]
Safari 26.5.2 (21624.2.5.11.8)

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
