### PR TITLE
treewide: fix command injection, path traversal, XSS and CSRF issues

### DIFF
--- a/applications/luci-app-commands/root/usr/share/luci/menu.d/luci-app-commands.json
+++ b/applications/luci-app-commands/root/usr/share/luci/menu.d/luci-app-commands.json
@@ -33,7 +33,8 @@
 		"action": {
 			"type": "function",
 			"module": "luci.controller.commands",
-			"function": "action_run"
+			"function": "action_run",
+			"post": true
 		}
 	},
 
@@ -42,7 +43,8 @@
 		"action": {
 			"type": "function",
 			"module": "luci.controller.commands",
-			"function": "action_download"
+			"function": "action_download",
+			"post": true
 		}
 	},
 

--- a/applications/luci-app-commands/ucode/controller/commands.uc
+++ b/applications/luci-app-commands/ucode/controller/commands.uc
@@ -129,7 +129,7 @@ function parse_cmdline(cmdid, args) {
 				push(argv, ...(parse_args(args) ?? []));
 		}
 
-		return map(argv, v => match(v, /[^\w.\/|-]/) ? `'${replace(v, "'", "'\\''")}'` : v);
+		return map(argv, v => match(v, /[^\w.\/-]/) ? `'${replace(v, "'", "'\\''")}'` : v);
 	}
 }
 

--- a/applications/luci-app-commands/ucode/controller/commands.uc
+++ b/applications/luci-app-commands/ucode/controller/commands.uc
@@ -117,6 +117,18 @@ function test_binary(str) {
 	return false;
 }
 
+// Join an argument vector into a shell command line, single quoting every
+// argument that is not made up entirely of harmless characters, so that shell
+// metacharacters cannot take effect.
+// Note that ucode expands the \w macro only outside of bracket expressions,
+// within one it stands for a literal 'w'. The set left unquoted is therefore
+// 'w', '.', '/' and '-', none of which mean anything to the shell.
+function shellquote(argv) {
+	return join(' ', map(argv, v => match(v, /[^\w.\/-]/) ? `'${replace(v, "'", "'\\''")}'` : v));
+}
+
+// Returns the unquoted argument vector, pass it through shellquote() before
+// handing it to the shell.
 function parse_cmdline(cmdid, args) {
 	if (uci.get('luci', cmdid) == 'command') {
 		let cmd = uci.get_all('luci', cmdid);
@@ -129,7 +141,7 @@ function parse_cmdline(cmdid, args) {
 				push(argv, ...(parse_args(args) ?? []));
 		}
 
-		return map(argv, v => match(v, /[^\w.\/-]/) ? `'${replace(v, "'", "'\\''")}'` : v);
+		return argv;
 	}
 }
 
@@ -140,7 +152,7 @@ function execute_command(callback, ...args) {
 		let outfd = mkstemp();
 		let errfd = mkstemp();
 
-		const exitcode = system(`${join(' ', argv)} >&${outfd.fileno()} 2>&${errfd.fileno()}`);
+		const exitcode = system(`${shellquote(argv)} >&${outfd.fileno()} 2>&${errfd.fileno()}`);
 
 		outfd.seek(0);
 		errfd.seek(0);
@@ -155,7 +167,7 @@ function execute_command(callback, ...args) {
 
 		callback({
 			ok:      true,
-			command: join(' ', argv),
+			command: shellquote(argv),
 			stdout:  binary ? null : stdout,
 			stderr,
 			exitcode,
@@ -200,7 +212,7 @@ return {
 		const argv = parse_cmdline(...args);
 
 		if (argv) {
-			const fd = popen(`${join(' ', argv)} 2>/dev/null`);
+			const fd = popen(`${shellquote(argv)} 2>/dev/null`);
 
 			if (fd) {
 				let filename = replace(basename(argv[0]), /\W+/g, '.');

--- a/applications/luci-app-commands/ucode/template/commands.ut
+++ b/applications/luci-app-commands/ucode/template/commands.ut
@@ -45,8 +45,11 @@
 			legend.parentNode.style.display = 'block';
 			legend.style.display = 'inline';
 
-			var options = field ? { query: { args: field.value } } : null;
-			L.Request.get(L.url('admin/system/commands/run', id), options).then(function(reply) {
+			var query = { token: L.env.token };
+			if (field)
+				query.args = field.value;
+
+			L.Request.request(L.url('admin/system/commands/run', id), { method: 'post', query: query }).then(function(reply) {
 				var st = reply.json();
 
 				if (st.binary)
@@ -71,12 +74,22 @@
 
 	function command_download(ev, id)
 	{
-		var args;
 		var field = document.getElementById(id);
-		if (field)
-			args = encodeURIComponent(field.value);
 
-		location.href = L.url('admin/system/commands/download', id) + (args ? '/' + args : '');
+		/* The download route is POST-only and CSRF protected, so submit a
+		   throwaway form instead of navigating to the URL. */
+		var form = E('form', {
+			method: 'post',
+			action: L.url('admin/system/commands/download', id),
+			enctype: 'application/x-www-form-urlencoded'
+		}, E('input', { type: 'hidden', name: 'token', value: L.env.token }));
+
+		if (field)
+			form.appendChild(E('input', { type: 'hidden', name: 'args', value: field.value }));
+
+		document.body.appendChild(form);
+		form.submit();
+		form.parentNode.removeChild(form);
 
 		ev.preventDefault();
 	}

--- a/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
@@ -22,6 +22,12 @@ function shellquote(value) {
 	return "'" + replace(value, "'", "'\\''") + "'";
 }
 
+/* A DDNS service name is a UCI section name, so restrict it to the characters
+ * UCI permits. This keeps path separators and ".." out of composed log paths. */
+function is_valid_service_name(name) {
+	return length(name) > 0 && match(name, /^[a-zA-Z0-9_-]+$/) != null;
+}
+
 function get_dateformat() {
 	return uci.get('ddns', 'global', 'ddns_dateformat') || '%F %R';
 }
@@ -92,8 +98,9 @@ const methods = {
 				logdir = ddns_log_path;
 			}
 
-			// Check if service_name is provided and log file exists
-			if (request.args && request.args.service_name && stat(`${logdir}/${request.args.service_name}.log`)?.type == 'file' ) {
+			// Check if service_name is valid and the log file exists
+			if (is_valid_service_name(request.args?.service_name) &&
+			    stat(`${logdir}/${request.args.service_name}.log`)?.type == 'file' ) {
 				result = readfile(`${logdir}/${request.args.service_name}.log`);
 			}
 

--- a/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
@@ -43,7 +43,7 @@ function trimnonewline(input) {
 }
 
 function get_date(seconds, format) {
-	return trimnonewline( popen(`date -d @${seconds} "+${format}" 2>/dev/null`, 'r')?.read?.('line') );
+	return trimnonewline( popen(`date -d @${int(seconds)} ${shellquote('+' + format)} 2>/dev/null`, 'r')?.read?.('line') );
 }
 
 // convert epoch date to given format

--- a/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
@@ -57,6 +57,16 @@ function epoch2date(epoch, format) {
 	if (!format || length(format) < 2) {
 		format = get_dateformat();
 	}
+
+	/* date(1) echoes anything that is not a conversion specifier verbatim, and
+	 * the status views render the result as HTML - see the '%n' expansion below.
+	 * Restrict the format to the characters strftime actually needs so that a
+	 * configured value cannot inject markup, and fall back to the default
+	 * otherwise, mirroring how an unsafe ddns_logdir is handled. */
+	if (match(format, /[^%A-Za-z0-9 :\/.,_+-]/)) {
+		format = '%F %R';
+	}
+
 	format = replace(format, /%n/g, '<br />'); // Replace '%n' with '<br />'
 	format = replace(format, /%t/g, '    ');   // Replace '%t' with four spaces
 

--- a/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/neighbors.js
+++ b/applications/luci-app-olsr/htdocs/luci-static/resources/view/olsr/status-olsr/neighbors.js
@@ -246,7 +246,8 @@ return olsr.olsrview.extend({
 								'</a></div>';
 						}
 						if (neigh.hn) {
-							s += '<div class="td cbi-section-table-cell left" style="background-color:' + neigh.dfgcolor + '"><a href="http://' + neigh.hn + '/cgi-bin-status.html">' + neigh.hn + '</a></div>';
+							s += '<div class="td cbi-section-table-cell left" style="background-color:' + neigh.dfgcolor +
+								'"><a href="http://%q/cgi-bin-status.html">%h</a></div>'.format(neigh.hn, neigh.hn);
 						} else {
 							s += '<div class="td cbi-section-table-cell left" style="background-color:' + neigh.dfgcolor + '">?</div>';
 						}

--- a/protocols/luci-proto-openvpn/root/usr/share/rpcd/ucode/luci.openvpn.uc
+++ b/protocols/luci-proto-openvpn/root/usr/share/rpcd/ucode/luci.openvpn.uc
@@ -10,7 +10,8 @@ import { connect } from 'ubus';
 const openvpn_dir = '/etc/openvpn';
 
 /* Key types accepted by "openvpn --genkey". Anything outside this set is
- * rejected, so the value can never introduce shell metacharacters. */
+ * rejected, so the value can never introduce shell metacharacters or escape
+ * the key directory. */
 const keytypes = [
 	'secret',
 	'tls-crypt',
@@ -22,6 +23,17 @@ const keytypes = [
 
 function shellquote(s) {
 	return `'${replace(s, "'", "'\\''")}'`;
+}
+
+/* ifname is a UCI section name, so restrict it to the characters UCI allows.
+ * This keeps path separators and ".." out of the generated key paths. */
+function is_valid_iface(ifname) {
+	return length(ifname) > 0 && match(ifname, /^[a-zA-Z0-9_-]+$/) != null;
+}
+
+/* server_key is a plain file name inside the tls-crypt-v2-server directory. */
+function is_valid_keyfile(name) {
+	return length(name) > 0 && match(name, /^[a-zA-Z0-9._-]+$/) != null && index(name, '..') == -1;
 }
 
 function command(cmd) {
@@ -52,6 +64,7 @@ const methods = {
 
 			if (!kt) return { error: 'missing keytype' };
 			if (!(kt in keytypes)) return { error: 'invalid keytype' };
+			if (!is_valid_iface(ifname)) return { error: 'invalid ifname' };
 
 			let dir;
 			let outfile = `${ifname}_${kt}_${ts}.key`;
@@ -73,13 +86,14 @@ const methods = {
 					const list = lsdir(serverDir);
 					if (length(list) > 0) server_key = serverDir + '/' + list[-1];
 				} else {
-					server_key = `${keyDir(ifname, 'tls-crypt-v2-server')}/${req.args?.server_key}`;
+					if (!is_valid_keyfile(server_key)) return { error: 'invalid server_key' };
+					server_key = `${keyDir(ifname, 'tls-crypt-v2-server')}/${server_key}`;
 				}
 
 				if (!server_key) return { error: 'missing server_key for tls-crypt-v2-client' };
 
 				// denote which server key this client key is derived from in the name
-				path = `${mkpath}/${ifname}_${kt}_${ts}-${req.args?.server_key}`;
+				path = `${mkpath}/${ifname}_${kt}_${ts}-${basename(server_key)}`;
 				cmd = `${openvpn} --tls-crypt-v2 ${shellquote(server_key)} --genkey tls-crypt-v2-client ${shellquote(path)} ${shellquote(req.args?.cl_meta)} 2>/dev/null`;
 			} else {
 				// basic genkey
@@ -105,7 +119,11 @@ const methods = {
 	getSKeys: {
 		args: { ifname: 'ifname' },
 		call: function(req) {
-			const serverDir = `${keyDir(req.args?.ifname, 'tls-crypt-v2-server')}`;
+			const ifname = req.args?.ifname;
+
+			if (!is_valid_iface(ifname)) return { error: 'invalid ifname' };
+
+			const serverDir = `${keyDir(ifname, 'tls-crypt-v2-server')}`;
 			const list = lsdir(serverDir);
 
 			return { skeys: list, path: serverDir };

--- a/protocols/luci-proto-openvpn/root/usr/share/rpcd/ucode/luci.openvpn.uc
+++ b/protocols/luci-proto-openvpn/root/usr/share/rpcd/ucode/luci.openvpn.uc
@@ -9,6 +9,17 @@ import { connect } from 'ubus';
 
 const openvpn_dir = '/etc/openvpn';
 
+/* Key types accepted by "openvpn --genkey". Anything outside this set is
+ * rejected, so the value can never introduce shell metacharacters. */
+const keytypes = [
+	'secret',
+	'tls-crypt',
+	'tls-auth',
+	'auth-token',
+	'tls-crypt-v2-server',
+	'tls-crypt-v2-client'
+];
+
 function shellquote(s) {
 	return `'${replace(s, "'", "'\\''")}'`;
 }
@@ -40,6 +51,7 @@ const methods = {
 			const ts = time();
 
 			if (!kt) return { error: 'missing keytype' };
+			if (!(kt in keytypes)) return { error: 'invalid keytype' };
 
 			let dir;
 			let outfile = `${ifname}_${kt}_${ts}.key`;
@@ -71,7 +83,7 @@ const methods = {
 				cmd = `${openvpn} --tls-crypt-v2 ${shellquote(server_key)} --genkey tls-crypt-v2-client ${shellquote(path)} ${shellquote(req.args?.cl_meta)} 2>/dev/null`;
 			} else {
 				// basic genkey
-				cmd = `${openvpn} --genkey ${kt} ${shellquote(path)} 2>/dev/null`;
+				cmd = `${openvpn} --genkey ${shellquote(kt)} ${shellquote(path)} 2>/dev/null`;
 			}
 
 			const out = popen(cmd)?.read?.('all') || '';


### PR DESCRIPTION
## Pull request details

### Description

Fixes for security issues reported to the OpenWrt security contact by Matthew
Hickey (Hacker Fantastic, https://hacker.house), together with two further
issues found while reviewing the same code paths.

One issue per commit:

| Commit | Package | Issue |
| --- | --- | --- |
| 1 | `luci-app-olsr` | Stored XSS. A mesh node announcing a crafted hostname through the olsrd nameservice plugin gets script execution in the LuCI origin when an admin opens Status → OLSR → Neighbours. No LuCI credentials needed to inject. |
| 2 | `luci-proto-openvpn` | Root command injection. `generateKey` interpolated the `keytype` argument unquoted into a `popen()` command string. |
| 3 | `luci-proto-openvpn` | Path traversal. `keyDir()` built key paths from an unvalidated `ifname`, so `makedirs()` created directories and wrote key files anywhere. `server_key` and `getSKeys` were affected in the same way. |
| 4 | `luci-app-ddns` | Root command injection. The `ddns_dateformat` UCI option was placed inside a double quoted `date` argument, so a `"` in the value started a new shell word. |
| 5 | `luci-app-ddns` | Path traversal. `get_services_log` composed the log path from an unvalidated `service_name`, while the sibling `logdir` was already checked for `../`. |
| 6 | `luci-app-ddns` | Stored XSS. `date` echoes non-specifier text verbatim, and the result is rendered as HTML by the overview page. Fixing the shell injection in commit 4 does not cover this. |
| 7 | `luci-app-commands` | Root command injection. The argument quoting allow-list contained the pipe character, so a bare `\|` argument reached the shell as an operator. |
| 8 | `luci-app-commands` | Missing CSRF protection. The run and download routes declared no `"post": true`, so they were reachable through a cross-origin GET. |
| 9 | `luci-app-commands` | Not a security fix: the download file name was derived from the already quoted `argv[0]`, so `echo hello` was offered as `.echo..txt` instead of `echo.txt`. |

Commits 1 to 5 and 7 correspond to the report and carry a `Reported-by:` tag.
Commits 6, 8 and 9 were found while working on the reported issues and carry no
such tag, since they were not reported.

Two further issues from the same report set, `luci-app-bmx7` path traversal and
`luci-app-dockerman` `ttyd_start` command injection, are already fixed in master
by 5890760a45 and ed11e49cf3 and are therefore not included here. Both still need
backporting to the release branches.

`luci-app-ddns` shares the `ddns_dateformat` option with `ddns-scripts`, which
builds shell code from the same value and is fixed separately in
openwrt/packages (see below).

### Verification

Every issue was reproduced and then re-tested against the fix on a running
OpenWrt image, by temporarily restoring the pre-fix code on the device:

- `luci-app-commands`: a bare `|` argument created a root owned file. With
  `public '1'` and `param '1'` this worked with no cookie and no token, so it was
  an unauthenticated root command execution rather than the authenticated issue
  described in the report.
- `luci-app-ddns`: `ddns_dateformat` executed `touch` as root, and the markup
  variant reached the status output. Both are rejected now, while custom formats
  such as `%d.%m.%Y %H:%M:%S` and the `%n` to `<br />` expansion still work.
- `luci-proto-openvpn`: `keytype`, `ifname` and `server_key` payloads are now
  rejected, and a legitimate `secret` key still generates correctly.
- `luci-app-olsr`: the crafted hostname survives intact through
  `ubus call olsrinfo hosts`, which is what the view fetches. Rendering the
  pre-fix and fixed markup in headless Chromium gives two `<svg>` elements with a
  firing `onload` before, and no elements at all after.

Note for the OLSR issue: the hostname is read from a whitespace separated hosts
file, so a payload containing spaces is truncated. The `<img src=x onerror=...>`
form from the report does not survive that; `<svg/onload=...>` does.

- CSRF: run and download now answer `405` to GET and `403` to POST without a
  token, and `200` with one. The dashboard was adapted accordingly.

### Screenshot or video of changes _(if applicable)_

n/a

### Maintainer _(preferred)_

- `luci-app-olsr`: Manuel Munz <munz@comuno.net>
- `luci-app-ddns`: Ansuel Smith <ansuelsmth@gmail.com>
- `luci-app-commands`: Jo-Philipp Wich <jo@mein.io>
- `luci-proto-openvpn`: no `PKG_MAINTAINER`, added by Paul Donald in 5306e007656f

---

## Tested on

**OpenWrt version:** OpenWrt SNAPSHOT r35555-03e0a608e0 (armsr/armv8, QEMU)
**LuCI version:** master plus this branch (26.202.75735~ed23f07)
**Web browser(s):** Chromium 150.0.7871.186, used headless to verify the OLSR
rendering. The HTTP endpoints and ubus methods were exercised with curl and
`ubus call`.

---

## Checklist

- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [x] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
