### PR TITLE
luci-app-commands: add optional persistent id for public URLs

### DIFF
--- a/applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js
+++ b/applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js
@@ -2,6 +2,7 @@
 
 'require view';
 'require form';
+'require uci';
 
 return view.extend({
 	render: function(data) {
@@ -22,6 +23,24 @@ return view.extend({
 		o = s.option(form.Value, 'description', _('Description'),
 			_('An optional longer description to display on the execution page'));
 		o.optional = true;
+
+		o = s.option(form.Value, 'id', _('Persistent ID'),
+			_('An optional, fixed identifier to use in the public command URL. Once set, the URL keeps working even if other commands are added, removed or reordered. Leave empty to keep relying on the automatically generated, unstable identifier. The identifier must not end with the letter "s".'));
+		o.optional = true;
+		o.datatype = 'uciname';
+		o.validate = function(section_id, value) {
+			if (value == null || value == '')
+				return true;
+
+			if (/s$/.test(value))
+				return _('The identifier must not end with the letter "s"');
+
+			let dup = uci.sections('luci', 'command').some(function(cmd) {
+				return cmd['.name'] != section_id && (cmd.id == value || cmd['.name'] == value);
+			});
+
+			return dup ? _('This identifier is already used by another command') : true;
+		};
 
 		o = s.option(form.Value, 'command', _('Command'), _('Command line to execute'));
 		o.textvalue = function(section_id) {

--- a/applications/luci-app-commands/ucode/controller/commands.uc
+++ b/applications/luci-app-commands/ucode/controller/commands.uc
@@ -117,20 +117,53 @@ function test_binary(str) {
 	return false;
 }
 
+// Resolve a command identifier as seen in a URL to the actual UCI
+// section name. If a "command" section carries a stable, user assigned
+// "id" option matching the requested identifier, that section is used.
+// Otherwise the identifier is tried verbatim, for backward compatibility
+// with links generated before the "id" option existed (it will match
+// the automatically assigned, but potentially unstable, section name).
+// An "id" ending in "s" is never honored here: the public URL handler
+// (action_public) uses a trailing "s" to distinguish its display and
+// download modes, so allowing a custom id to end in "s" would make
+// that encoding ambiguous.
+function resolve_command_id(cmdid) {
+	if (!cmdid)
+		return null;
+
+	let found = null;
+
+	uci.foreach('luci', 'command', s => {
+		if (found == null && s.id && substr(s.id, -1) != 's' && s.id == cmdid)
+			found = s['.name'];
+	});
+
+	if (found != null)
+		return found;
+
+	if (uci.get('luci', cmdid) == 'command')
+		return cmdid;
+
+	return null;
+}
+
 function parse_cmdline(cmdid, args) {
-	if (uci.get('luci', cmdid) == 'command') {
-		let cmd = uci.get_all('luci', cmdid);
-		let argv = parse_args(cmd?.command);
+	cmdid = resolve_command_id(cmdid);
 
-		if (cmd?.param == '1') {
-			if (length(args))
-				push(argv, ...(parse_args(urldecode(args)) ?? []));
-			else if (length(args = http.formvalue('args')))
-				push(argv, ...(parse_args(args) ?? []));
-		}
+	if (cmdid == null)
+		return;
 
-		return map(argv, v => match(v, /[^\w.\/|-]/) ? `'${replace(v, "'", "'\\''")}'` : v);
+	let cmd = uci.get_all('luci', cmdid);
+	let argv = parse_args(cmd?.command);
+
+	if (cmd?.param == '1') {
+		if (length(args))
+			push(argv, ...(parse_args(urldecode(args)) ?? []));
+		else if (length(args = http.formvalue('args')))
+			push(argv, ...(parse_args(args) ?? []));
 	}
+
+	return map(argv, v => match(v, /[^\w.\/|-]/) ? `'${replace(v, "'", "'\\''")}'` : v);
 }
 
 function execute_command(callback, ...args) {
@@ -240,9 +273,9 @@ return {
 			cmdid = substr(cmdid, 0, -1);
 		}
 
-		if (cmdid &&
-		    uci.get('luci', cmdid) == 'command' &&
-		    uci.get('luci', cmdid, 'public') == '1')
+		cmdid = resolve_command_id(cmdid);
+
+		if (cmdid != null && uci.get('luci', cmdid, 'public') == '1')
 		{
 			if (disp)
 				execute_command(return_html, cmdid, ...args);

--- a/applications/luci-app-commands/ucode/template/commands.ut
+++ b/applications/luci-app-commands/ucode/template/commands.ut
@@ -138,6 +138,9 @@
 		{% else %}
 			<div class="commands">
 				{% for (let command in commands): %}
+					{%
+						const cmdid = (match(command.id, /^[A-Za-z0-9_]+$/) && !match(command.id, /s$/)) ? command.id : command['.name'];
+					-%}
 				<div class="commandbox">
 					<h3>{{ entityencode(command.name) }}</h3>
 					<p>{{ _('Command:') }} <code>{{ entityencode(command.command) }}</code></p>
@@ -145,13 +148,13 @@
 						<p><em>{{ entityencode(command.description) }}</em></p>
 					{% endif %}
 					{% if (command.param == "1"): %}
-						<p>{{ _('Arguments:') }} <input type="text" id="{{ command['.name'] }}" /></p>
+						<p>{{ _('Arguments:') }} <input type="text" id="{{ cmdid }}" /></p>
 					{% endif %}
 					<div>
-						<button class="cbi-button cbi-button-apply" onclick="command_run(event, '{{ command['.name'] }}')">{{ _('Run') }}</button>
-						<button class="cbi-button cbi-button-download" onclick="command_download(event, '{{ command['.name'] }}')">{{ _('Download') }}</button>
+						<button class="cbi-button cbi-button-apply" onclick="command_run(event, '{{ cmdid }}')">{{ _('Run') }}</button>
+						<button class="cbi-button cbi-button-download" onclick="command_download(event, '{{ cmdid }}')">{{ _('Download') }}</button>
 						{% if (command.public == "1"): %}
-							<button class="cbi-button cbi-button-link" onclick="command_link(event, '{{ command['.name'] }}')">{{ _('Link') }}</button>
+							<button class="cbi-button cbi-button-link" onclick="command_link(event, '{{ cmdid }}')">{{ _('Link') }}</button>
 						{% endif %}
 					</div>
 				</div>


### PR DESCRIPTION
## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
Command sections are stored as anonymous UCI sections, so each command's internal identifier is automatically (re-)assigned and is not guaranteed to stay the same when other commands are removed. Since this identifier is also used to build the "Run", "Download" and public "Link" URLs, previously bookmarked or published URLs can silently start pointing at a different command.

Add an optional 'id' option that lets the user assign a fixed, URL-safe identifier to a command. When set, this identifier is preferred over the internal section name when resolving a command from a URL, so the URL keeps working regardless of what happens to other commands. Existing commands and previously generated URLs keep working unchanged, since the new option is optional and falls back to the current behavior when unset.

Fixes: https://github.com/openwrt/luci/issues/6703

---

## Tested on
**OpenWrt version:** 25.12.5 r33051-f5dae5ece4
**LuCI version:** openwrt-25.12 branch 26.187.49110~99464ec
**Web browser(s):** Firefox 152.0.6 (aarch64)

I asked Claude-san to create a patch for the issue, and once the patch was ready,
I applied it to the three `commands` files in the `master` branch, then overrode
the files on the live 25.12.5 production server and verified that it worked.
---
