### PR TITLE
luci-theme-bootstrap: fix hidden down arrow on submenus for accessibility

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1147,7 +1147,7 @@ a.menu:after {
 	width: 0;
 	height: 0;
 	display: inline-block;
-	content: "&darr;";
+	content: "\2193";
 	text-indent: -99999px;
 	vertical-align: top;
 	margin-top: 8px;

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1147,7 +1147,7 @@ a.menu:after {
 	width: 0;
 	height: 0;
 	display: inline-block;
-	content: "&darr;";
+	content: "\2193"; /* screen reader accessible down arrow character */
 	text-indent: -99999px;
 	vertical-align: top;
 	margin-top: 8px;


### PR DESCRIPTION
This PR is an improvement for LuCI screen reader accessibility for blind and visually impaired people. It should not affect the visual look of the page.
The down arrow displayed next to submenus is a CSS-drawn triangle, but in its content: field it had a hidden down arrow encoded as &darr; Since these HTML-encoded symbols aren't converted into real characters in CSS fields, screen readers read this out loud even if it is visually hidden. Therefore next to all submenus, screen readers announced: and darr semicolon. This change fixes the symbol encoding so that screen readers correctly announce "down arrow" when navigating onto a submenu. The visually drawn triangle is completely ignored by the screen reader, that is why some indication is needed. Later this could be improved with proper ARIA attributes, but this was the quickest fix for now to improve LuCI usability until I manage to test it further.
Change is tested on OpenWrt 25.12.5 but as this is a CSS modification it should be universal anywhere LuCI is used.

