### PR TITLE
luci-app-attendedsysupgrade: add i18n translation support for UI strings

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -622,9 +622,9 @@ return view.extend({
 					'request',
 					'',
 					'',
-					'Use defaults for the safest update'
+					_('Use defaults for the safest update')
 				);
-				o = s.option(form.ListValue, 'version', 'Select firmware version');
+				o = s.option(form.ListValue, 'version', _('Select firmware version'));
 				for (let candidate of candidates) {
 					if (candidate[0] == version && candidate[1] == revision) {
 						o.value(


### PR DESCRIPTION
## Pull request details

### Description
Wrap strings with the _() translation function to enable proper internationalization (i18n).

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** SNAPSHOT
**LuCI version:** master
**Web browser(s):** Chrome

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).