### PR TITLE
luci-app-nlbwmon: use colour blind safe pie chart colours instead of shades of red

### DIFF
--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -14,6 +14,22 @@ const callNetworkRrdnsLookup = rpc.declare({
 	expect: { '': {} }
 });
 
+/* Okabe-Ito colour blind safe qualitative palette (minus its black entry,
+ * which would be a poor choice on the dark theme). Its colours are clearly
+ * distinguishable for most forms of colour blindness and are also a
+ * solid choice for everyone else. They will be re-used sequentially,
+ * which is standard practice for pie charts.
+ * See https://jfly.uni-koeln.de/color/ */
+const chartColors = [
+	'#e69f00', '#56b4e9', '#009e73', '#f0e442',
+	'#0072b2', '#d55e00', '#cc79a7'
+];
+
+/* We calculate the highlight colour for the table rows by appending an
+ * alpha channel to the segment colour, 0x59 translating to approx 35%
+ * opacity. */
+const chartRowAlpha = '59';
+
 const chartRegistry = {};
 let trafficPeriods = [];
 let trafficData = { columns: [], data: [] };
@@ -132,9 +148,15 @@ return view.extend({
 
 		for (let i = 0; i < data.length; i++) {
 			if (!data[i].color) {
-				const hue = 120 / (data.length-1) * i;
-				data[i].color = 'hsl(%u, 80%%, 50%%)'.format(hue);
-				data[i].label.push(hue);
+				let color = chartColors[i % chartColors.length];
+
+				/* Avoid repeating adjacent colours in the pie chart where
+				 * they would otherwise occur. */
+				if (i > 0 && i === data.length - 1 && color === data[0].color)
+					color = chartColors[(i + 1) % chartColors.length];
+
+				data[i].color = color;
+				data[i].label.push(color + chartRowAlpha);
 			}
 		}
 
@@ -747,10 +769,10 @@ return view.extend({
 			tooltipEl.style.top = pos[1] + tooltip.y - tooltip.caretHeight - tooltip.caretPadding + 'px';
 
 			const row = findParent(tooltip.text[1], '.tr');
-			const hue = tooltip.text[2];
+			const highlight = tooltip.text[2];
 
-			if (row && !isNaN(hue)) {
-				row.style.backgroundColor = 'hsl(%u, 100%%, 80%%)'.format(hue);
+			if (row && highlight) {
+				row.style.backgroundColor = highlight;
 				tooltipEl.row = row;
 			}
 		}, this);


### PR DESCRIPTION
## Pull request details

### Description

The current **Netlink Bandwidth Monitor** pie chart colours for _Traffic Distribution_ as well as _Application Protocols_ are a poor fit for just about anyone, in practice they render as indistinguishable shades of red.

I am proposing replacing them with the so-called [Okabe-Ito](https://jfly.uni-koeln.de/color/) palette which is one of the best palettes for users with colour blindness and also a big improvement over the status quo.

No trademark protections apply to these colours.

The two IPv6 pie charts retain their current colours as they are hard-coded and do not suffer from the same issue.

### Screenshot or video of changes

Before:
<img width="1512" height="441" alt="Screenshot 2026-07-29 at 15 36 29" src="https://github.com/user-attachments/assets/ff9cda34-fa18-4a5c-b1c4-78504894a229" />
<img width="1512" height="441" alt="Screenshot 2026-07-29 at 15 36 37" src="https://github.com/user-attachments/assets/3e081a64-b8a0-4136-83d1-4705f40aad7f" />

After:
<img width="1512" height="441" alt="Screenshot 2026-07-29 at 15 39 30" src="https://github.com/user-attachments/assets/f26c76d9-ee32-4cb2-a34b-fb1e1fb49ba5" />
<img width="1512" height="441" alt="Screenshot 2026-07-29 at 15 39 40" src="https://github.com/user-attachments/assets/50d4eaa5-3c47-4f50-9126-a680bdc65b1c" />

### Maintainer _(preferred)_
@jow- 

---

## Tested on
**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4)
**LuCI version:** LuCI (HEAD detached at 128a7812) branch (26.180.75667~128a781)
**Web browser(s):** Chrome 150
**Platform:** amd64

---

## Checklist
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).