### PR TITLE
luci-base: dispatcher: derive session token from /dev/urandom

### DIFF
--- a/applications/luci-app-ddns/Makefile
+++ b/applications/luci-app-ddns/Makefile
@@ -12,7 +12,7 @@ PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
 
 LUCI_TITLE:=LuCI Support for Dynamic DNS Client (ddns-scripts)
-LUCI_DEPENDS:=+luci-base +ddns-scripts
+LUCI_DEPENDS:=+luci-base +ddns-scripts +ucode-mod-math
 
 include ../../luci.mk
 

--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -24,7 +24,6 @@ LUCI_DEPENDS:=\
 	+ucode-mod-log \
 	+ucode-mod-uci \
 	+ucode-mod-ubus \
-	+ucode-mod-math \
 	+ucode-mod-html \
 	+liblucihttp-ucode
 

--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -1,11 +1,10 @@
 // Copyright 2022 Jo-Philipp Wich <jo@mein.io>
 // Licensed to the public under the Apache License 2.0.
 
-import { open, stat, glob, lsdir, unlink, basename } from 'fs';
+import { open, readfile, stat, glob, lsdir, unlink, basename } from 'fs';
 import { striptags, entityencode } from 'html';
 import { connect } from 'ubus';
 import { cursor } from 'uci';
-import { rand } from 'math';
 import { openlog, syslog, closelog, LOG_INFO, LOG_WARNING, LOG_AUTHPRIV } from 'log';
 
 import { hash, load_catalog, change_catalog, translate, ntranslate, getuid } from 'luci.core';
@@ -487,12 +486,12 @@ function session_retrieve(sid, allowed_users) {
 }
 
 function randomid(num_bytes) {
-	let bytes = [];
+	let data = readfile('/dev/urandom', num_bytes);
 
-	while (num_bytes-- > 0)
-		push(bytes, sprintf('%02x', rand() % 256));
+	if (length(data) != num_bytes)
+		return null;
 
-	return join('', bytes);
+	return hexenc(data);
 }
 
 function session_setup(user, pass, path) {


### PR DESCRIPTION
`randomid()` built the LuCI session token from `math.rand()`. ucode seeds that generator on first use with the wall-clock time in milliseconds and then uses libc `rand()` — `lib/math.c`:

```c
if (!ucv_boolean_get(uc_vm_registry_get(vm, "math.srand_called"))) {
    gettimeofday(&tv, NULL);
    srand((tv.tv_sec * 1000) + (tv.tv_usec / 1000));
```

Each request is served by a fresh process, so the seed is simply the millisecond the request was handled — and `randomid()` is the first consumer of the generator in that process, so no state is burned before it. The resulting token is predictable to anyone who knows the approximate time it was issued.

Two consumers: the CSRF token (`dispatcher.uc`, checked in `test_post_security()`) and the config-rollback confirm token (`controller/admin/uci.uc`).

This patch reads the bytes from `/dev/urandom` instead, and returns `null` on failure so callers fail closed rather than fall back to a weak value — `session_retrieve()` requires a string token, so a session created without one is rejected.

For contrast, rpcd already generates its session IDs from `/dev/urandom` (`session.c` `rpc_random()`); this closes the gap on LuCI's own token.

### Testing

Patched `dispatcher.uc` installed on an IPQ8074 router running OpenWrt 6.18.39, with the device's LuCI copy verified byte-identical to upstream `master` before patching. Full login round-trip over HTTPS:

```
GET  /cgi-bin/luci/               -> 403 (login form)
POST /cgi-bin/luci/ (real creds)  -> 302 + Set-Cookie sysauth_https=...
GET  /admin/status/overview       -> token present, 32 hex chars
```

Isolated check of the new `randomid()` under the shipped ucode interpreter: two successive 16-byte reads, both 32 characters, hex-only, distinct. Device restored to stock afterwards (sha256 matched `/rom`), LuCI healthy.
