### PR TITLE
luci-base: drop init_action() and the luci.setInitAction ubus method

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -33,10 +33,10 @@ return view.extend({
 	}),
 
 	callInitAction: rpc.declare({
-		object: 'luci',
-		method: 'setInitAction',
+		object: 'rc',
+		method: 'init',
 		params: [ 'name', 'action' ],
-		expect: { result: false }
+		reject: true
 	}),
 
 	callDDnsGetStatus: rpc.declare({
@@ -187,7 +187,8 @@ return view.extend({
 
 	handleRestartDDns(m, ev) {
 		return this.callInitAction('ddns', 'restart')
-			.then(L.bind(m.render, m));
+			.then(L.bind(m.render, m))
+			.catch(function(e) { ui.addNotification(null, E('p', e.message)) });
 	},
 
 	poll_status(map, data) {

--- a/applications/luci-app-ddns/root/usr/share/rpcd/acl.d/luci-app-ddns.json
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/acl.d/luci-app-ddns.json
@@ -3,8 +3,7 @@
 		"description": "Grant access to ddns procedures",
 		"read": {
 			"ubus": {
-				"luci.ddns": [ "get_services_status", "get_ddns_state", "get_env", "get_services_log" ],
-				"luci": [ "setInitAction" ]
+				"luci.ddns": [ "get_services_status", "get_ddns_state", "get_env", "get_services_log" ]
 			},
 			"file": {
 				"/usr/share/ddns/default": [ "list" ],
@@ -18,7 +17,10 @@
 			"uci": [ "ddns" ]
 		},
 		"write": {
-			"uci": [ "ddns" ]
+			"uci": [ "ddns" ],
+			"ubus": {
+				"rc": [ "init" ]
+			}
 		}
 	}
 }

--- a/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/config.js
+++ b/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/config.js
@@ -10,6 +10,7 @@
 'require form';
 'require lldpd';
 'require network';
+'require ui';
 'require uci';
 'require tools.widgets as widgets';
 
@@ -26,11 +27,14 @@ const callInitList = rpc.declare({
 });
 
 const callInitAction = rpc.declare({
-	object: 'luci',
-	method: 'setInitAction',
+	object: 'rc',
+	method: 'init',
 	params: [ 'name', 'action' ],
-	expect: { result: false }
+	reject: true
 });
+
+const reportInitFailure = (err) => ui.addNotification(null,
+	E('p', _('Failed to control the lldpd initscript: %s').format(err.message)), 'error');
 
 const usage = _('See syntax <a %s>here</a>.').format('href=https://lldpd.github.io/usage.html target="_blank"');
 
@@ -99,13 +103,13 @@ return L.view.extend({
 				// Enable and start
 				callInitAction('lldpd', 'enable').then(() => {
 					return callInitAction('lldpd', 'start');
-				});
+				}).catch(reportInitFailure);
 			}
 			else {
 				// Stop and disable
 				callInitAction('lldpd', 'stop').then(() => {
 					return callInitAction('lldpd', 'disable');
-				});
+				}).catch(reportInitFailure);
 			}
 		};
 

--- a/applications/luci-app-lldpd/root/usr/share/rpcd/acl.d/luci-app-lldpd.json
+++ b/applications/luci-app-lldpd/root/usr/share/rpcd/acl.d/luci-app-lldpd.json
@@ -34,8 +34,8 @@
 				"lldpd"
 			],
 			"ubus": {
-				"luci": [
-					"setInitAction"
+				"rc": [
+					"init"
 				]
 			}
 		}

--- a/applications/luci-app-rustdesk-server/root/usr/share/rpcd/ucode/rustdesk-server.uc
+++ b/applications/luci-app-rustdesk-server/root/usr/share/rpcd/ucode/rustdesk-server.uc
@@ -2,7 +2,7 @@
 'use strict';
 
 import { popen, access, readfile, unlink } from 'fs';
-import { process_list, init_enabled, init_action } from 'luci.sys';
+import { process_list, init_enabled } from 'luci.sys';
 
 const BIN_DIR = '/usr/bin';
 const KEY_DIR = '/etc/rustdesk';
@@ -109,8 +109,7 @@ const methods = {
 				};
 			}
 
-			// Use luci.sys.init_action() for service control
-			let result = init_action('rustdesk-server', action);
+			let result = system([ '/etc/init.d/rustdesk-server', action ]);
 
 			return {
 				success: (result === 0),
@@ -135,8 +134,8 @@ const methods = {
 			let key_pub = KEY_DIR + '/id_ed25519.pub';
 
 			// Step 1: Stop the service first so keys are not in use
-			// init_action is synchronous - waits for service to fully stop
-			init_action('rustdesk-server', 'stop');
+			// system() is synchronous - waits for service to fully stop
+			system([ '/etc/init.d/rustdesk-server', 'stop' ]);
 
 			// Step 2: Remove existing keys
 			let priv_deleted = safeUnlink(key_priv);

--- a/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
+++ b/applications/luci-app-sqm/htdocs/luci-static/resources/view/network/sqm.js
@@ -16,10 +16,10 @@ return view.extend({
 	},
 
 	handleEnableSQM: rpc.declare({
-		object: 'luci',
-		method: 'setInitAction',
-		params: [ 'sqm', 'enable' ],
-		expect: { result: false }
+		object: 'rc',
+		method: 'init',
+		params: [ 'name', 'action' ],
+		reject: true
 	}),
 
 	load: function() {
@@ -49,10 +49,12 @@ return view.extend({
 				E('button', {
 					'class': 'btn cbi-button-active',
 					'click': ui.createHandlerFn(this, function() {
-						return fs.exec('/etc/init.d/sqm', ['enable']).then(function() {
-							return fs.exec('/etc/init.d/sqm', ['start']);
-						}).then(function() {
+						return this.handleEnableSQM('sqm', 'enable').then(L.bind(function() {
+							return this.handleEnableSQM('sqm', 'start');
+						}, this)).then(function() {
 							location.reload();
+						}).catch(function(err) {
+							ui.addNotification(null, E('p', _("Failed to enable the sqm initscript: %s").format(err.message)), 'error');
 						});
 					})
 				}, _('Enable SQM'))
@@ -79,8 +81,11 @@ return view.extend({
 		o.rmempty = false;
 		o.write = L.bind(function(section, value) {
 			if (value == "1") {
-				this.handleEnableSQM();
-				ui.addNotification(null, E('p', _("The SQM GUI has just enabled the sqm initscript on your behalf. Remember to disable the sqm initscript manually under System Startup menu in case this change was not wished for.")));
+				this.handleEnableSQM('sqm', 'enable').then(function() {
+					ui.addNotification(null, E('p', _("The SQM GUI has just enabled the sqm initscript on your behalf. Remember to disable the sqm initscript manually under System Startup menu in case this change was not wished for.")));
+				}).catch(function(err) {
+					ui.addNotification(null, E('p', _("Failed to enable the sqm initscript: %s").format(err.message)), 'error');
+				});
 			}
 
 			return uci.set("sqm", section, "enabled", value);

--- a/applications/luci-app-sqm/root/usr/share/rpcd/acl.d/luci-app-sqm.json
+++ b/applications/luci-app-sqm/root/usr/share/rpcd/acl.d/luci-app-sqm.json
@@ -4,18 +4,18 @@
 		"read": {
 			"file": {
 				"/var/run/sqm/available_qdiscs": [ "list" ],
-				"/usr/lib/sqm/*.qos.help": [ "read" ],
-				"/etc/init.d/sqm enable" : [ "exec" ],
-				"/etc/init.d/sqm start" : [ "exec" ]
+				"/usr/lib/sqm/*.qos.help": [ "read" ]
 			},
 			"uci": [ "sqm" ],
 			"ubus": {
-				"file": [ "read", "list" ],
-				"luci": [ "setInitAction" ]
+				"file": [ "read", "list" ]
 			}
 		},
 		"write": {
-			"uci": [ "sqm" ]
+			"uci": [ "sqm" ],
+			"ubus": {
+				"rc": [ "init" ]
+			}
 		}
 	}
 }

--- a/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
+++ b/applications/luci-app-upnp/htdocs/luci-static/resources/view/upnp/upnp.js
@@ -6,13 +6,6 @@
 'require rpc';
 'require form';
 
-const callInitAction = rpc.declare({
-	object: 'luci',
-	method: 'setInitAction',
-	params: [ 'name', 'action' ],
-	expect: { result: false }
-});
-
 const callUpnpGetStatus = rpc.declare({
 	object: 'luci.upnp',
 	method: 'get_status',

--- a/applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json
@@ -3,8 +3,7 @@
 		"description": "Grant access to UPnP IGD & PCP/NAT-PMP",
 		"read": {
 			"ubus": {
-				"luci.upnp": [ "get_status" ],
-				"luci": [ "setInitAction" ]
+				"luci.upnp": [ "get_status" ]
 			},
 			"uci": [ "upnpd" ]
 		},

--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -6,7 +6,7 @@
 import { stdin, access, dirname, basename, open, popen, glob, lsdir, readfile, readlink, realpath, error } from 'fs';
 import { cursor } from 'uci';
 
-import { init_list, init_index, init_enabled, init_action, conntrack_list, process_list } from 'luci.sys';
+import { init_list, init_index, init_enabled, conntrack_list, process_list } from 'luci.sys';
 import { revision, branch } from 'luci.version';
 import { statvfs, uname } from 'luci.core';
 import { connect } from 'ubus';
@@ -132,29 +132,6 @@ const methods = {
 			}
 
 			return length(scripts) ? scripts : { error: 'No such init script' };
-		}
-	},
-
-	setInitAction: {
-		args: { name: 'name', action: 'action' },
-		call: function(request) {
-			switch (request.args.action) {
-			case 'enable':
-			case 'disable':
-			case 'start':
-			case 'stop':
-			case 'restart':
-			case 'reload':
-				const rc = init_action(request.args.name, request.args.action);
-
-				if (rc === false)
-					return { error: 'No such init script' };
-
-				return { result: rc == 0 };
-
-			default:
-				return { error: 'Invalid action' };
-			}
 		}
 	},
 

--- a/modules/luci-base/ucode/sys.uc
+++ b/modules/luci-base/ucode/sys.uc
@@ -149,12 +149,3 @@ export function init_enabled(name) {
 
 	return false;
 };
-
-export function init_action(name, action) {
-	const s = stat(`/etc/init.d/${basename(name)}`);
-
-	if (s?.type != 'file' || s?.user_exec == false)
-		return false;
-
-	return system(`env -i /etc/init.d/${basename(name)} ${action} >/dev/null`);
-};


### PR DESCRIPTION
`init_action()` and the `luci.setInitAction` ubus method both duplicate rpcd's `rc` namespace, which is what downstream code wishing to control services should be using. `rc.init` accepts the same `enable|disable|start|stop|restart|reload` set, and is the stronger of the two:

| | `luci.setInitAction` | `rc.init` |
|---|---|---|
| how the script runs | `system()` → `/bin/sh -c "env -i /etc/init.d/<name> <action> >/dev/null"` | `execl()`, no shell |
| script must be root-owned | no | yes |
| script must not be world-writable | no | yes |

That shell is why this PR started out as an argument-validation patch. `init_action()` interpolated both of its arguments into the command line, and `basename()` keeps `name` inside `/etc/init.d` but strips directory components only — `;`, backticks, `$(`, `|` and newlines survive it — while `action` reached the shell with nothing checking it at all. Nothing untrusted got there: `setInitAction` switched on a fixed action list, and for `name` the `stat()` check required the interpolated string to exist as a file under `/etc/init.d`, an existence test rather than a validation. But the helper was exported from luci-base, so any future caller forwarding an RPC argument straight through inherited root command execution. Removing it removes that for good, rather than papering over it with a regex.

### The five in-tree users

Ported first, one commit each, so every commit in the series builds:

* **luci-app-ddns**, **luci-app-lldpd** — mechanical: `object: 'rc'`, `method: 'init'`. `rc.init` has no reply payload, so the `expect: { result: false }` unwrapping goes with it; every call site already ignores the return value.
* **luci-app-sqm** — same, plus three things around it. The call now reaches the router at all: `params` names the positional arguments of the declared method, but the declaration passed the intended *values* there (`params: [ 'sqm', 'enable' ]`) and `handleEnableSQM()` was then invoked with no arguments, so every request went out as an empty argument object and was rejected — while the UI told the user the sqm init script had just been enabled on its behalf. The notification is now chained onto the call with `reject: true`, so a refused `rc.init` reports the failure instead of the success text. And the "Enable SQM" button reached the init script a second way, through `fs.exec()` and a pair of `/etc/init.d/sqm` exec grants; it takes `rc.init` too and both grants go.
* **luci-app-upnp** — nothing calls `callInitAction()`; the view drives upnpd through uci and `luci.upnp` alone. Dropped the dead declaration together with the ACL grant that came with it, which let a session holding read access to this app run any init script under `/etc/init.d`.
* **luci-app-rustdesk-server** — its rpcd backend cannot reach for the `rc` namespace the way a view can, since it runs inside rpcd itself, so it execs the init script directly. Passing `system()` an array execs without a shell, which is precisely what `init_action()` did not do; the action is whitelisted immediately above and the script name is a literal. The array form also drops the `env -i` and the `>/dev/null` that `init_action()` wrapped around the command line, since both belong to the `system()` form being removed; rpcd's environment is the boot environment rather than anything a caller supplies, but the init script does inherit rpcd's own descriptors, where `rc.init` redirects all three before `execl()`.

`luci-app-pbr`, `luci-app-adblock-fast`, `luci-app-https-dns-proxy` and `luci-app-simple-adblock` carry `setInitAction` methods of their own on their own ubus objects and are untouched.

### ACL scope

Every `rc.init` grant in the series sits in the **write** scope. rpcd matches ubus ACLs on object and method only, with no per-argument filtering, so a read-scope `rc.init` would let a session with read-only access to one app drive any init script on the box — which is the same property the upnp commit removes on privilege grounds, and what `luci-mod-system` already does with `rc.list` under read and `rc.init` under write.

### Testing

`init_action` is gone from the module's exports and the other five are intact:

```
$ ucode -R -L 'mods/*.uc' -e 'import * as sys from "luci.sys"; print(join(" ", sort(keys(sys))), "\n")'
conntrack_list init_enabled init_index init_list process_list
```

Both rpcd backends parse, the four modified ACL files are valid JSON, and `system(["/bin/false"])` returns `1`, which is the exit status the rustdesk backend now reports.

