### PR TITLE
luci-app-ddns: quote the date format passed to the shell

### DIFF
--- a/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
+++ b/applications/luci-app-ddns/root/usr/share/rpcd/ucode/ddns.uc
@@ -43,7 +43,7 @@ function trimnonewline(input) {
 }
 
 function get_date(seconds, format) {
-	return trimnonewline( popen(`date -d @${seconds} "+${format}" 2>/dev/null`, 'r')?.read?.('line') );
+	return trimnonewline( popen(`date -d @${seconds} +${shellquote(format)} 2>/dev/null`, 'r')?.read?.('line') );
 }
 
 // convert epoch date to given format


### PR DESCRIPTION
`get_date()` interpolated the configured date format into a shell command run as root, inside double quotes and without escaping:

```js
popen(`date -d @${seconds} "+${format}" 2>/dev/null`, 'r')
```

`format` comes from uci `ddns.global.ddns_dateformat` and is reached on every status poll via `get_ddns_state()` → `epoch2date()`. A value containing a double quote closes the quoted argument and runs arbitrary commands as root.

The file already carries a `shellquote()` helper and uses it correctly for `lookup_host`, `section` and `dns_server` in `get_services_status()` — this one call site was missed. This patch uses it here too.

Worth noting: the injection is invisible in the UI. The expected date is still printed, so nothing looks wrong.

### Severity

I'd rather state this honestly than overclaim. The `luci-app-ddns` ACL grants `"write": { "uci": ["ddns"] }` and read access to `get_ddns_state`, so on paper a LuCI account holding only that ACL group can escalate to root command execution. How much that matters depends on how common restricted (non-root) LuCI accounts actually are in practice.

Either way the fix is a one-line use of a helper the file already has, so the severity question needn't block it.

### Testing

Both directions confirmed on an IPQ8074 router running OpenWrt 6.18.39, as root:

```
before:  sh -c 'date -d @1767225600 "+%F" ; id > /tmp/pwn ; "" 2>/dev/null'
         -> prints 2026-01-01, and /tmp/pwn contains uid=0(root) gid=0(root) groups=0(root)

after:   sh -c "date -d @1767225600 +'%F\" ; id > /tmp/pwn ; \"' 2>/dev/null"
         -> prints 2026-01-01" ; id > /tmp/pwn ; "   -- literal, no injection
```

