### PR TITLE
luci-mod-status: add button role on HIDE buttons

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/index.js
@@ -133,6 +133,7 @@ return view.extend({
 						title || '-',
 						E('span', {
 							'class': includes[i].hide ? 'label notice' : 'label',
+							'role': 'button',
 							'style': 'display: flex; align-items: center; justify-content: center; min-width: 4em',
 							'data-style': includes[i].hide ? 'active' : 'inactive',
 							'data-indicator': 'poll-status',


### PR DESCRIPTION
This change helps to identify the HIDE span elements as clickable buttons for screen readers. Before this change it was not obvious that the sections on the status panel can be hidden, and clean interfaces are key for easy screen reader navigation.

## Tested on
OpenWRT 25.12 + latest Chrome on Windows + JAWS screen reader (change is universal as it utilizes ARIA)
