### PR TITLE
luci-app-{snmpd,nut}: add missing ldd dependency for glibc builds

### DIFF
--- a/applications/luci-app-nut/Makefile
+++ b/applications/luci-app-nut/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Network UPS Tools Configuration
-LUCI_DEPENDS:=+luci-base +nut +nut-upsmon +nut-server +nut-upsc +nut-web-cgi +nut-upscmd
+LUCI_DEPENDS:=+luci-base +nut +nut-upsmon +nut-server +nut-upsc +nut-web-cgi +nut-upscmd +USE_GLIBC:ldd
 
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca> \

--- a/applications/luci-app-snmpd/Makefile
+++ b/applications/luci-app-snmpd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:= Net-SNMP LuCI interface
-LUCI_DEPENDS:=+luci-base +snmpd
+LUCI_DEPENDS:=+luci-base +snmpd +USE_GLIBC:ldd
 LUCI_DESCRIPTION:=Some common net-snmp config items. In no way is this comprehensive.
 
 PKG_MAINTAINER:= Christian Korber <ck@dev.tdt.de>


### PR DESCRIPTION
## Pull request details

### Description

Both `luci-app-snmpd` and `luci-app-nut` invoke `/usr/bin/ldd` at runtime
to probe optional library features:

- `luci-app-snmpd` — `testlibsslv3()` in `snmpd.js` runs
  `ldd /usr/sbin/snmpd` and looks for `libssl` in its output.
- `luci-app-nut` — `nut_server.js` and `nut_monitor.js` run `ldd` on
  `upsd`/`upsmon` to detect optional linked features.

Both packages already grant exec permission on `/usr/bin/ldd` via their
respective rpcd ACL files, but neither package declares a dependency on
`ldd`.

On musl builds this is harmless because `ldd` is a shim provided by the
C library itself and is always present. On glibc builds `ldd` is a
separate package produced by the toolchain that is not pulled in
automatically. In `luci-app-nut` the probes are wrapped in
`L.resolveDefault(..., [])` and degrade to "no optional features"; in
`luci-app-snmpd` there is no fallback, so a missing `/usr/bin/ldd`
rejects the view's `load()` promise and the whole SNMP settings page
fails to render.

Add `+USE_GLIBC:ldd` to `LUCI_DEPENDS` in both Makefiles so the
dependency is enforced only where it is actually required.

### Maintainer

`luci-app-snmpd`: @ckorber
`luci-app-nut`: @danielfdickinson @systemcrash

---

## Tested on

**OpenWrt version:** internal glibc-based build (aarch64)
**Result:** With `USE_GLIBC=y`, both packages now correctly pull in
the `ldd` package; the SSLv3 and upsd/upsmon feature probes work as
expected. No change on musl builds.

---

## Checklist

- [x] I have tested the changes locally.
- [x] Signed-off-by present, matching the commit author.