### PR TITLE
luci-app-strongswan-swanctl: rename swanctl section and update I18N

### DIFF
--- a/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
+++ b/applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js
@@ -66,8 +66,8 @@ return view.extend({
 		if (error)
 			ui.addNotification(null, E('p', _('Some options are unavailable because swanctl failed to load: %s').format(error)), 'warning');
 
-		m = new form.Map('ipsec', _('Remote/Tunnel configuration'),
-			_('On this page, you can configure the IPsec tunnels and remotes.'));
+		m = new form.Map('ipsec', _('Connection configurations'),
+			_('On this page, you can configure the IPsec connections.'));
 		m.tabbed = true;
 
 		// Remote Configuration

--- a/applications/luci-app-strongswan-swanctl/po/az/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/az/strongswan-swanctl.po
@@ -14,15 +14,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -31,22 +31,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr ""
 
@@ -58,16 +70,16 @@ msgstr ""
 msgid "Bytes out"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -83,7 +95,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -91,7 +103,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -104,23 +116,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr ""
 
@@ -140,7 +157,7 @@ msgstr ""
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -158,7 +175,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -167,19 +184,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -188,7 +205,7 @@ msgid "Enabled"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr ""
 
@@ -196,7 +213,7 @@ msgstr ""
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -204,12 +221,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr ""
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr ""
 
@@ -221,7 +234,7 @@ msgstr ""
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -229,7 +242,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr ""
 
@@ -245,29 +258,38 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -275,7 +297,7 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -287,41 +309,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -337,39 +368,27 @@ msgstr ""
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr ""
 
@@ -378,28 +397,32 @@ msgstr ""
 msgid "Local Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -413,10 +436,6 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:99
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
@@ -434,19 +453,27 @@ msgstr ""
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -454,45 +481,45 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -509,8 +536,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -531,11 +566,19 @@ msgstr ""
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr ""
 
@@ -543,7 +586,7 @@ msgstr ""
 msgid "Remote Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr ""
 
@@ -552,32 +595,28 @@ msgstr ""
 msgid "Remote Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -600,6 +639,20 @@ msgstr ""
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -619,7 +672,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -635,23 +688,35 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 
@@ -659,7 +724,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -667,7 +732,20 @@ msgstr ""
 msgid "Uptime"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -675,7 +753,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -684,28 +768,36 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 

--- a/applications/luci-app-strongswan-swanctl/po/cs/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/cs/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d sekund"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Akce při počátečním načtení nastavení"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Akce při zavření CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Akce pokud nastane překročení časového limitu DPD"
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr "Aktivní IKE_SAs"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Algoritmy označené znakem * (hvězdička) jsou považovány za nebezpečné"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Ověřování se"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Metoda ověřování se"
 
@@ -61,18 +73,18 @@ msgstr "Bajtů do"
 msgid "Bytes out"
 msgstr "Bajtů ven"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "Certifikát cert. autority"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "Certifikát cert. autority které potřebuje lhát v řetězci důvěry certifikátu "
 "na vzdáleném protějšku"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Popis umístění certifikátu který použít pro ověřování se"
 
@@ -88,7 +100,7 @@ msgstr "Podřízení"
 msgid "Class"
 msgstr "Třída"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Akce zavřít"
 
@@ -96,7 +108,7 @@ msgstr "Akce zavřít"
 msgid "Configuration is enabled or not"
 msgstr "Nastavení je zapnuté nebo ne"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -110,23 +122,28 @@ msgstr "Připojení"
 msgid "Connection Details"
 msgstr "Podrobnosti o připojení"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Spojení"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Návrh šifrování"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Návrh šifrování (fáze 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "DPD akce"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "DPD prodleva"
 
@@ -146,7 +163,7 @@ msgstr "Dnů"
 msgid "Debug Level"
 msgstr "Stupeň podrobnosti ladících informací"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -165,7 +182,7 @@ msgstr "Definovat nastavení vzdáleného IKE."
 msgid "Details"
 msgstr "Podrobnosti"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Diffie-Hellman skupina"
 
@@ -174,19 +191,19 @@ msgstr "Diffie-Hellman skupina"
 msgid "Dismiss"
 msgstr "Zahodit"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Doba trvání CHILD_SA před znovuopatřením klíči"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "ESP návrh"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Povolit předávání zpracovávání do hardware"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Povolit ipcomp compresi"
 
@@ -195,7 +212,7 @@ msgid "Enabled"
 msgstr "Povoleno"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Šifrovací algoritmus"
 
@@ -203,7 +220,7 @@ msgstr "Šifrovací algoritmus"
 msgid "Encryption Keysize"
 msgstr "Délka šifrovacího klíče"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Návrhy šifrování"
 
@@ -211,12 +228,8 @@ msgstr "Návrhy šifrování"
 msgid "Established"
 msgstr "Navázáno"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Brána (vzdálený koncový bod)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Obecné"
 
@@ -228,7 +241,7 @@ msgstr "Obecná nastavení"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Udělit přístup k luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Předávání na hardware"
 
@@ -236,7 +249,7 @@ msgstr "Předávání na hardware"
 msgid "Half-Open IKE_SAs"
 msgstr "Polootevřená IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Algoritmus vytváření otisků"
 
@@ -252,39 +265,48 @@ msgstr "Hodiny"
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "IKE fragmentace"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "IKE ověřování se (fáze 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "IKEv2 interval pro obnovení materiálu klíčů (také použito pro spočítání "
 "životnosti)"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "IP adresa nebo FQDN název vzdáleného koncového bodu tunelu"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "IP adresa nebo FQDN lokálního koncového bodu tunelu"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Neaktivní"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Neaktivita"
 
@@ -296,35 +318,44 @@ msgstr "Čas instalace"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Rozhraní která akceptují VPN provoz."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Interval před zavřením neaktivního CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Interval pro kontrolu toho, zda je protějšek aktivní"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Výměna klíčů"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Opakovaných pokusů o opatření klíči"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Životnost"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Životnost"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "Omezit dobu pro úplné znovuopatření klíči / opětovné ověření se"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -332,7 +363,7 @@ msgstr ""
 "Seznam ESP (fáze dva) návrhů. Vybrat je možné pouze návrhy, u kterých je "
 "zaškrtnutý příznak ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Seznam IKE (fáze 1) návrhů které použít pro ověření se"
 
@@ -348,39 +379,27 @@ msgstr "Lokální adresy"
 msgid "Local Auth"
 msgstr "Lokální ověř."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Lokální certifikát"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Lokální brána"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "Lokální IP adresa"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Lokální identifikátor"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Lokální klíč"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "Lokální NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Místní port"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "Lokální zdrojová IP adresa"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Lokální podsíť"
 
@@ -389,29 +408,33 @@ msgstr "Lokální podsíť"
 msgid "Local Traffic Selectors"
 msgstr "Výběry lokálního provozu"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Lokální adresa/adresy které použít při IKE vyjednávání"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Lokální identifikátor pro IKE (fáze 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Lokální síť(e)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Nejdelší doba trvání CHILD_SA před zavřením"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -425,10 +448,6 @@ msgstr "Minuty"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Režim"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "NAT rozsah pro tunely s překrývajícími se IP adresami"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -445,19 +464,27 @@ msgstr "Délka názvu by neměla překročit 15 znaků"
 msgid "Number must have suffix s, m, h or d"
 msgstr "Je třeba, aby číslo mělo příponu s, m, h nebo d"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Počet pokusů o opakované přenosy při úvodním vyjednávání"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "Na této stránce je možné nastavovat službu IPsec."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr "Na této stránce je možné nastavovat IPsec tunely a vzdálené."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Přesčas"
 
@@ -465,11 +492,11 @@ msgstr "Přesčas"
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "PRF algoritmus"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -477,36 +504,36 @@ msgstr ""
 "Při používání algoritmu ověřeného se šifrování je třeba, aby byl nastavený "
 "PRF algoritmus"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 "Popis umístění skriptu který spouštět při událostech CHILD_SA nahoře/dole"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Nejprve vytvořte návrh"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Nejprve vytvořte tunel"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Nejprve vytvořte ESP návrh"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Předsdílený klíč"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Priorita"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Priorita CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 "Popis umístění soukromého klíče který použít společně s výše uvedeným "
@@ -525,8 +552,16 @@ msgstr "Dotazování se strongSwan se nezdařilo"
 msgid "Reauthentication Interval"
 msgstr "Interval opětovného ověření se"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Čas znovuopatření klíči"
 
@@ -547,11 +582,19 @@ msgstr "Vzdálené adresy"
 msgid "Remote Auth"
 msgstr "Vzdálené ověř."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Nastavení vzdáleného"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Vzdálený identifikátor"
 
@@ -559,7 +602,7 @@ msgstr "Vzdálený identifikátor"
 msgid "Remote Port"
 msgstr "Vzdálený port"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Vzdálená podsíť"
 
@@ -568,33 +611,29 @@ msgstr "Vzdálená podsíť"
 msgid "Remote Traffic Selectors"
 msgstr "Výběry vzdáleného provozu"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Vzdálený identifikátor pro IKE (fáze 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Vzdálené sítě"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "Vzdálené/tunel"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Nastavení vzdálené/tunel"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr "Vzdálené, návrhy šifrování a tunely nemohou být nazvány stejně."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Okno opětovného použití"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Okno opětovného použití pro CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -615,6 +654,20 @@ msgstr "sekundy"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:19
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "Vyberte rozhraní nebo, pokud mají být všechna rozhraní, nevyplňujte."
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
@@ -637,7 +690,7 @@ msgstr ""
 msgid "Start"
 msgstr "Spustit"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Spustit akci"
 
@@ -653,23 +706,35 @@ msgstr "Stav"
 msgid "Stop"
 msgstr "Zastavit"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "Tunel obsahující ESP sekci (fáze 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "Předsdílený klíč pro tunel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "Stupeň trace: 0 pro nejmenší výřečnost, 4 pro největší"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "Tunel"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Nastavení tunelu"
 
@@ -677,7 +742,7 @@ msgstr "Nastavení tunelu"
 msgid "Unique ID"
 msgstr "Neopakující se identif."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Popis umístění skriptu pro nahoře/dole"
 
@@ -685,7 +750,20 @@ msgstr "Popis umístění skriptu pro nahoře/dole"
 msgid "Uptime"
 msgstr "Doba chodu"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Použít IKE fragmentaci"
 
@@ -695,7 +773,13 @@ msgstr ""
 "Použijte kombinace jako například tunel_faze1, které nejsou delší než 15 "
 "znaků."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "Hodnoty vyšší než 32 jsou podporovány pouze podpůrnou vrstvou Netlink"
 
@@ -704,29 +788,37 @@ msgstr "Hodnoty vyšší než 32 jsou podporovány pouze podpůrnou vrstvou Netl
 msgid "Version"
 msgstr "Verze"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "Verze IKE pro vyjednání"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
-msgstr "Virtuální IP adresa/adresy které vyžádat v požadavcích IKEv2 nastavení"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Zda toto je ESP návrh (fáze 2) nebo ne"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 "Nastavit identifikátor XFRM rozhraní na vstupních a výstupních rozhraních"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "obojí"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "zastaralé"
 
@@ -738,6 +830,55 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "Stav strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Doba trvání CHILD_SA před znovuopatřením klíči"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Brána (vzdálený koncový bod)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "IP adresa nebo FQDN název vzdáleného koncového bodu tunelu"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "IP adresa nebo FQDN lokálního koncového bodu tunelu"
+
+#~ msgid "Lifetime"
+#~ msgstr "Životnost"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Lokální brána"
+
+#~ msgid "Local IP"
+#~ msgstr "Lokální IP adresa"
+
+#~ msgid "Local NAT"
+#~ msgstr "Lokální NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "Lokální zdrojová IP adresa"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Lokální adresa/adresy které použít při IKE vyjednávání"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Nejdelší doba trvání CHILD_SA před zavřením"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "NAT rozsah pro tunely s překrývajícími se IP adresami"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr "Na této stránce je možné nastavovat IPsec tunely a vzdálené."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "Vzdálené/tunel"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Nastavení vzdálené/tunel"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr ""
+#~ "Virtuální IP adresa/adresy které vyžádat v požadavcích IKEv2 nastavení"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "Nastavit strongSwan pro zabezpečená VPN spojení."

--- a/applications/luci-app-strongswan-swanctl/po/de/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/de/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d Sekunden"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Aktion beim Laden der Erstkonfiguration"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Aktion beim Schließen von CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Aktion bei Ablauf der DPD-Zeitüberschreitung"
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr "Aktive IKE-SAs"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Mit * gekennzeichnete Algorithmen gelten als unsicher"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Authentifizierungsmethode"
 
@@ -61,18 +73,18 @@ msgstr "Bytes eingehend"
 msgid "Bytes out"
 msgstr "Bytes ausgehend"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "CA-Zertifikat"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "CA-Zertifikat, das im Vertrauenspfad des Zertifikats des Remote-Partners "
 "enthalten sein muss"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Zu verwendender Zertifikatspfad für die Authentifizierung"
 
@@ -88,7 +100,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Schließen"
 
@@ -96,7 +108,7 @@ msgstr "Schließen"
 msgid "Configuration is enabled or not"
 msgstr "Die Konfiguration ist aktiviert oder nicht"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -111,23 +123,28 @@ msgstr "Verbindung"
 msgid "Connection Details"
 msgstr "Verbindungsdetails"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Krypto-Vorschlag"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Krypto-Vorschlag (Phase 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "DPD Aktion"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "DPD Verzögerung"
 
@@ -147,7 +164,7 @@ msgstr "Tage"
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -167,7 +184,7 @@ msgstr "Remote-IKE-Konfigurationen definieren"
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Diffie-Hellman-Gruppe"
 
@@ -176,19 +193,19 @@ msgstr "Diffie-Hellman-Gruppe"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Dauer des CHILD_SA vor der Neuschlüsselung"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "ESP-Vorschlag"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Hardware-Offload aktivieren"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Komprimierung ipcomp aktivieren"
 
@@ -197,7 +214,7 @@ msgid "Enabled"
 msgstr "Aktiviert"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Verschlüsselungsalgorithmus"
 
@@ -205,7 +222,7 @@ msgstr "Verschlüsselungsalgorithmus"
 msgid "Encryption Keysize"
 msgstr "Schlüsselgröße"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Verschlüsselungsvorschläge"
 
@@ -213,12 +230,8 @@ msgstr "Verschlüsselungsvorschläge"
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Gateway (Remote-Endpunkt)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Allgemein"
 
@@ -230,7 +243,7 @@ msgstr "Allgemeine Einstellungen"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Hardware-Offload"
 
@@ -238,7 +251,7 @@ msgstr "Hardware-Offload"
 msgid "Half-Open IKE_SAs"
 msgstr "Halboffene IKE_SAs"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Hash-Algorithmus"
 
@@ -254,31 +267,40 @@ msgstr "Stunden"
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "IKE-Fragmentierung"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "IKE-Authentifizierung (Phase 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "IKEv2-Intervall zur Aktualisierung des Schlüsselmaterials; wird auch zur "
 "Berechnung der Lebensdauer verwendet"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "IP-Adresse oder FQDN des entfernten Tunnel-Endpunkts"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "IP-Adresse oder FQDN des lokalen Tunnel-Endpunkts"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -286,7 +308,7 @@ msgstr ""
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Inaktivität"
 
@@ -298,35 +320,44 @@ msgstr "Installationsdauer"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Schnittstellen, die VPN-Datenverkehr akzeptieren."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Zeitraum vor dem Schließen eines inaktiven CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Intervall zur Überprüfung der Erreichbarkeit eines Peers"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Schlüsselaustausch"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Wiederholungsversuche bei der Schlüsselung"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Lebensdauer"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Lebensdauer"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "Frist für die Durchführung der Neukonfiguration/Neuauthentifizierung"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -334,7 +365,7 @@ msgstr ""
 "Liste der ESP-Vorschläge (Phase 2). Es können nur Vorschläge ausgewählt "
 "werden, bei denen das ESP-Kästchen angekreuzt ist."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Liste der IKE-Vorschläge (Phase 1) zur Authentifizierung"
 
@@ -350,39 +381,27 @@ msgstr "Lokale Adresse"
 msgid "Local Auth"
 msgstr "Locale Authentifizierung"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Lokales Zertifikat"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Lokales Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "Lokale IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Lokaler Identifier"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Lokaler Schlüssel"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "Lokales NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Lokaler Port"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "Lokale Quell IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Lokales Subnetz"
 
@@ -391,29 +410,33 @@ msgstr "Lokales Subnetz"
 msgid "Local Traffic Selectors"
 msgstr "Lokaler Trafficselector"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Lokale Adresse(n) für die IKE-Verhandlung"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Lokaler Identifikator für IKE (Phase 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Lokales Netzwerk (Netzwerke)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (IKEv2 Mobility und Multihoming Protokoll)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Maximale Laufzeit des CHILD_SA vor dem Schließen"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -427,10 +450,6 @@ msgstr "Minuten"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Modus"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "NAT-Bereich für Tunnel mit sich überschneidenden IP-Adressen"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -447,21 +466,27 @@ msgstr "Der Name darf nicht länger als 15 Zeichen sein"
 msgid "Number must have suffix s, m, h or d"
 msgstr "Die Zahl muss die Endung s, m, h oder d haben"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Anzahl der Wiederholungsversuche während der anfänglichen Verhandlung"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "Auf dieser Seite kann der IPsec-Dienst konfiguriert werden."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-"Auf dieser Seite können die IPsec-Tunnel und IPsec-Remote-Verbindungen "
-"konfiguriert werden."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -469,11 +494,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "PRF-Algorithmus"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -481,36 +506,36 @@ msgstr ""
 "Bei Verwendung eines authentifizierten Verschlüsselungsalgorithmus muss der "
 "RF-Algorithmus konfiguriert werden"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 "Pfad zum Skript, das bei CHILD_SA-Up-/Down-Ereignissen ausgeführt werden soll"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Bitte erstellen Sie zunächst ein Proposal"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Bitte richten Sie zunächst einen Tunnel ein"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Bitte erstellen Sie zunächst einen ESP-Proposal"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Pre-Shared Schlüssel"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Priorität"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Priorität von CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 "Pfadname des privaten Schlüssels, der mit dem oben genannten Zertifikat "
@@ -529,8 +554,16 @@ msgstr "Die Abfrage bei strongSwan ist fehlgeschlagen"
 msgid "Reauthentication Interval"
 msgstr "Intervall für die erneute Authentifizierung"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Zeit für einen Schlüsselwechsel"
 
@@ -551,11 +584,19 @@ msgstr "Remote-Adressen"
 msgid "Remote Auth"
 msgstr "Remote-Authentifizierung"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Remote-Konfigurationen"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Remote-Identifier"
 
@@ -563,7 +604,7 @@ msgstr "Remote-Identifier"
 msgid "Remote Port"
 msgstr "Remote Port"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Remote Subnetz"
 
@@ -572,21 +613,13 @@ msgstr "Remote Subnetz"
 msgid "Remote Traffic Selectors"
 msgstr "Remote Trafficselectoren"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Remote-Identifikator für IKE (Phase 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Remote Netwerk (Netzwerke)"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Remote-/Tunnel-Konfiguration"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
@@ -594,13 +627,17 @@ msgstr ""
 "Remote, Verschlüsselungsvorschläge und Tunnel dürfen nicht denselben Namen "
 "tragen."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Replay Fenster"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Replay Fenster vom CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -624,6 +661,20 @@ msgstr ""
 "Wählen Sie eine Schnittstelle aus oder lassen Sie das Feld leer, um alle "
 "Schnittstellen auszuwählen."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -643,7 +694,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Start-Aktion"
 
@@ -659,24 +710,36 @@ msgstr "Zustand"
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "Der Tunnel mit dem ESP-Abschnitt (Phase 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "Der pre-shared Schlüssel für den Tunnel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 "Protokollierungsstufe: 0 ist die geringste Ausführlichkeit, 4 die größte"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Tunnel-Konfiguration"
 
@@ -684,7 +747,7 @@ msgstr "Tunnel-Konfiguration"
 msgid "Unique ID"
 msgstr "Eindeutige ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Up/Down Skriptpfad"
 
@@ -692,7 +755,20 @@ msgstr "Up/Down Skriptpfad"
 msgid "Uptime"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "IKE-Fragmentierung verwenden"
 
@@ -702,7 +778,13 @@ msgstr ""
 "Verwenden Sie Kombinationen wie „tunnel1_phase1“, die nicht länger als 15 "
 "Zeichen sind."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "Werte größer als 32 werden nur vom Netlink-Backend unterstützt"
 
@@ -711,29 +793,37 @@ msgstr "Werte größer als 32 werden nur vom Netlink-Backend unterstützt"
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "IKE-Version für die Aushandlung"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
-msgstr "In IKEv2-Konfigurationsanfragen anzufordernde virtuelle IP-Adressen"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Ob es sich hierbei um einen ESP-Vorschlag (Phase 2) handelt oder nicht"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 "XFRM-Schnittstellen-ID für Eingangs- und Ausgangsschnittstellen festgelegt"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "beide"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "veraltet"
 
@@ -745,3 +835,50 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr ""
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Dauer des CHILD_SA vor der Neuschlüsselung"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Gateway (Remote-Endpunkt)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "IP-Adresse oder FQDN des entfernten Tunnel-Endpunkts"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "IP-Adresse oder FQDN des lokalen Tunnel-Endpunkts"
+
+#~ msgid "Lifetime"
+#~ msgstr "Lebensdauer"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Lokales Gateway"
+
+#~ msgid "Local IP"
+#~ msgstr "Lokale IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "Lokales NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "Lokale Quell IP"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Lokale Adresse(n) für die IKE-Verhandlung"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Maximale Laufzeit des CHILD_SA vor dem Schließen"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "NAT-Bereich für Tunnel mit sich überschneidenden IP-Adressen"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr ""
+#~ "Auf dieser Seite können die IPsec-Tunnel und IPsec-Remote-Verbindungen "
+#~ "konfiguriert werden."
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Remote-/Tunnel-Konfiguration"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr "In IKEv2-Konfigurationsanfragen anzufordernde virtuelle IP-Adressen"

--- a/applications/luci-app-strongswan-swanctl/po/es/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/es/strongswan-swanctl.po
@@ -20,15 +20,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d segundos"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Acción en carga de configuración inicial"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Acción cuando CHILD_SA está cerrado"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Acción al suceder vencimiento DPD"
 
@@ -37,22 +37,34 @@ msgid "Active IKE_SAs"
 msgstr "IKE_SA activo"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Algoritmo marcado con * es considerado inseguro"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Método de Autenticación"
 
@@ -64,18 +76,18 @@ msgstr "Bytes en"
 msgid "Bytes out"
 msgstr "Bytes salientes"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "Certificado AC"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "Certificado de CA que debe estar en la ruta de confianza del certificado de "
 "par remoto"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Nombre de ruta del certificado que se utiliza para autenticación"
 
@@ -91,7 +103,7 @@ msgstr "Niños"
 msgid "Class"
 msgstr "Clase"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Cerrar acción"
 
@@ -99,7 +111,7 @@ msgstr "Cerrar acción"
 msgid "Configuration is enabled or not"
 msgstr "Si está activada o no la configuración"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -114,23 +126,28 @@ msgstr "Conexión"
 msgid "Connection Details"
 msgstr "Detalles de conexión"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Conexiones"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Cripto propuesta"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Cripto propuesta (Fase 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "Acción DPD"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "Retraso DPD"
 
@@ -150,7 +167,7 @@ msgstr "Días"
 msgid "Debug Level"
 msgstr "Nivel de depuración"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -170,7 +187,7 @@ msgstr "Definir configuraciones IKE remotas."
 msgid "Details"
 msgstr "Detalles"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Grupo Diffie-Hellman"
 
@@ -179,19 +196,19 @@ msgstr "Grupo Diffie-Hellman"
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Duración de la CHILD_SA antes de re-introducción de claves"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "Propuesta ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Activar descarga de hardware"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Activar compresión ipcomp"
 
@@ -200,7 +217,7 @@ msgid "Enabled"
 msgstr "Activado"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Algoritmo de cifrado"
 
@@ -208,7 +225,7 @@ msgstr "Algoritmo de cifrado"
 msgid "Encryption Keysize"
 msgstr "Tamaño de clave de cifrado"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Propuestas de cifrado"
 
@@ -216,12 +233,8 @@ msgstr "Propuestas de cifrado"
 msgid "Established"
 msgstr "Establecido"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Puerta de enlace (Punto final remoto)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "General"
 
@@ -233,7 +246,7 @@ msgstr "Ajustes generales"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Conceder acceso a luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Descargar A/L"
 
@@ -241,7 +254,7 @@ msgstr "Descargar A/L"
 msgid "Half-Open IKE_SAs"
 msgstr "IKE_SAs Medio-Abierta"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Algoritmo Hash"
 
@@ -257,39 +270,48 @@ msgstr "Horas"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "Fragmentación IKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "Autenticación IKE (fase 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "Intervalo IKEv2 para refrescar material de anillo; además utilizado para "
 "calcular tiempo de vida"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "Dirección IP o nombre FQDN del túnel de punto final remoto"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "Dirección IP o FQDN del punto final de túnel local"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Inactivo"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Inactividad"
 
@@ -301,35 +323,44 @@ msgstr "Tiempo de instalación"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Interfaces que aceptan tráfico VPN."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Intervalo antes de cerrar un CHILD_SA inactivo"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Intervalo para comprobar la vida de un par"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Keyexchange"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Reintentos de anillo"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Tiempo de vida"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Vida"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "Límite en tiempo para completar re-clave/re-autenticación"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -337,7 +368,7 @@ msgstr ""
 "Listado de propuestas ESP (fase dos). Solo Propuestas con indicador de ESP "
 "marcado son seleccionables"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Listado de propuestas IKE (fase 1) para utilizar para autenticación"
 
@@ -353,39 +384,27 @@ msgstr "Direcciones locales"
 msgid "Local Auth"
 msgstr "Autenticación local"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Certificado local"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Puerta de enlace local"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "IP local"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Identificador local"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Clave Local"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "NAT local"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Puerto local"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "IP de origen local"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Subred local"
 
@@ -394,29 +413,33 @@ msgstr "Subred local"
 msgid "Local Traffic Selectors"
 msgstr "Selectores de tráfico local"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Dirección(es) local(es) para utilizar en negociación IKE"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Identificador local para IKE (fase 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Red(es) local(es)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (Protocolo IKEv2 de Movilidad y Multihogar)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Duración máxima del CHILD_SA antes de cerrar"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -430,10 +453,6 @@ msgstr "Minutos"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Modo"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "Intervalo de NAT para túneles con sobrecarga de direcciones IP"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -450,19 +469,27 @@ msgstr "La longitud del nombre no debe exceder los 15 caracteres"
 msgid "Number must have suffix s, m, h or d"
 msgstr "El número debe tener sufijo s, m, h o d"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Número de retransmisiones intentadas durante negociación inicial"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "En esta página puedes configurar el servicio IPsec."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr "En esta página puedes configurar los túneles y remotos IPsec."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Fuera de hora"
 
@@ -470,11 +497,11 @@ msgstr "Fuera de hora"
 msgid "Overview"
 msgstr "Vista general"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "Algoritmo PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -482,35 +509,35 @@ msgstr ""
 "Algoritmo PRF debe ser configurado cuando utilice un Algoritmo de cifrado "
 "autenticado"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr "Ruta para script a ejecutar en CHILD_SA para subir/bajar eventos"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Cree primero una propuesta"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Cree un túnel primero"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Cree primero una propuesta ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Clave pre-compartida"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Prioridad"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Prioridad del CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "Nombre de ruta de clave privada a utilizar con certificado de arriba"
 
@@ -527,8 +554,16 @@ msgstr "La consulta a strongSwan falló"
 msgid "Reauthentication Interval"
 msgstr "Intervalo de reautenticación"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Tiempo de re-clave"
 
@@ -549,11 +584,19 @@ msgstr "Direcciones remotas"
 msgid "Remote Auth"
 msgstr "Autenticación remota"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Configuración remota"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Identificador remoto"
 
@@ -561,7 +604,7 @@ msgstr "Identificador remoto"
 msgid "Remote Port"
 msgstr "Puerto remoto"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Subred remota"
 
@@ -570,21 +613,13 @@ msgstr "Subred remota"
 msgid "Remote Traffic Selectors"
 msgstr "Selectores de tráfico remoto"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Identificador remoto para IKE (fase 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Red(es) remota(s)"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "Remoto/Túnel"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Configuración de remotos y túneles"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
@@ -592,13 +627,17 @@ msgstr ""
 "Remotos, Propuestas de cifrado y Túneles pueden no compartir los mismos "
 "nombres."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Ventana de reproducción"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Ventana de reproducción del CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -620,6 +659,20 @@ msgstr "Segundos"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "Selecciona una interfaz o déjalo vacío para todas las interfaces."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "Servicio"
@@ -640,7 +693,7 @@ msgstr ""
 msgid "Start"
 msgstr "Iniciar"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Iniciar acción"
 
@@ -656,23 +709,35 @@ msgstr "Estado"
 msgid "Stop"
 msgstr "Detener"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "El túnel conteniendo la sección del ESP (fase 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "La clave pre-compartida para el túnel"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "Nivel de seguimiento: 0 es el de menor detallado, 5 es el de más"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "Túnel"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Configuración del túnel"
 
@@ -680,7 +745,7 @@ msgstr "Configuración del túnel"
 msgid "Unique ID"
 msgstr "ID único"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Subir/Bajar ruta de script"
 
@@ -688,7 +753,20 @@ msgstr "Subir/Bajar ruta de script"
 msgid "Uptime"
 msgstr "Tiempo de actividad"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Utiliza fragmentación de IKE"
 
@@ -696,7 +774,13 @@ msgstr "Utiliza fragmentación de IKE"
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr "Utiliza combinaciones como tunnel1_phase1 que no supere 15 caracteres."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 "Valores más grandes que 32 están admitidos solo por el backend de Netlink"
@@ -706,30 +790,36 @@ msgstr ""
 msgid "Version"
 msgstr "Versión"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "Versión de IKE para negociación"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
-"IP(s) virtual(es) para solicitar en configuración de cargas IKEv2 útiles "
-"solicitadas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Si esto es un ESP (fase 2) propuesto o no"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr "ID de interfaz XFRM fijado sobre interfaces de entrada y salida"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "ambos"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "obsoleto"
 
@@ -741,6 +831,56 @@ msgstr "IPSec de strongSwan"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "Estado de strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Duración de la CHILD_SA antes de re-introducción de claves"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Puerta de enlace (Punto final remoto)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "Dirección IP o nombre FQDN del túnel de punto final remoto"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "Dirección IP o FQDN del punto final de túnel local"
+
+#~ msgid "Lifetime"
+#~ msgstr "Vida"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Puerta de enlace local"
+
+#~ msgid "Local IP"
+#~ msgstr "IP local"
+
+#~ msgid "Local NAT"
+#~ msgstr "NAT local"
+
+#~ msgid "Local Source IP"
+#~ msgstr "IP de origen local"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Dirección(es) local(es) para utilizar en negociación IKE"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Duración máxima del CHILD_SA antes de cerrar"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "Intervalo de NAT para túneles con sobrecarga de direcciones IP"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr "En esta página puedes configurar los túneles y remotos IPsec."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "Remoto/Túnel"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Configuración de remotos y túneles"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr ""
+#~ "IP(s) virtual(es) para solicitar en configuración de cargas IKEv2 útiles "
+#~ "solicitadas"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "Configure strongSwan para conexión VPN segura."

--- a/applications/luci-app-strongswan-swanctl/po/ga/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ga/strongswan-swanctl.po
@@ -18,15 +18,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d soicind"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Gníomh ar an ualach cumraíochta tosaigh"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Gníomh nuair a bhíonn CHILD_SA dúnta"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Gníomh nuair a tharlaíonn teorainn ama DPD"
 
@@ -35,22 +35,34 @@ msgid "Active IKE_SAs"
 msgstr "IKE_SAanna gníomhacha"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Ardleibhéil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Meastar go bhfuil halgartaim atá marcáilte le * neamhshábháilte"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Fíordheimhniú"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Modh Fíordheimhnithe"
 
@@ -62,17 +74,17 @@ msgstr "Bearta isteach"
 msgid "Bytes out"
 msgstr "Bearta amach"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "Teastas CA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "Teastas CA a chaithfidh a bheith i gcosán muiníne deimhnithe piaraí iargúlta"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Ainm cosáin an deimhnithe le húsáid le haghaidh fíordheimhnithe"
 
@@ -88,7 +100,7 @@ msgstr "Leanaí"
 msgid "Class"
 msgstr "Rang"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Dún Gníomh"
 
@@ -96,7 +108,7 @@ msgstr "Dún Gníomh"
 msgid "Configuration is enabled or not"
 msgstr "An bhfuil an chumraíocht cumasaithe nó nach bhfuil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -110,23 +122,28 @@ msgstr "Ceangal"
 msgid "Connection Details"
 msgstr "Sonraí Ceangail"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Ceangail"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Togra Cripte"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Togra Cripte (Céim 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "Gníomh DPD"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "Moill DPD"
 
@@ -146,7 +163,7 @@ msgstr "Laethanta"
 msgid "Debug Level"
 msgstr "Leibhéal Dífhabhtaithe"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr "Sainmhínigh Leanaí Nasc le húsáid mar Tholláin i gCumraíochtaí Cianda."
@@ -164,7 +181,7 @@ msgstr "Sainmhínigh Cumraíochtaí IKE Cianda."
 msgid "Details"
 msgstr "Sonraí"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Grúpa Diffie-Hellman"
 
@@ -173,19 +190,19 @@ msgstr "Grúpa Diffie-Hellman"
 msgid "Dismiss"
 msgstr "Díbhe"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Fad an CHILD_SA roimh ath-eochrú"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "Togra ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Cumasaigh díluchtú crua-earraí"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Cumasaigh comhbhrú ipcomp"
 
@@ -194,7 +211,7 @@ msgid "Enabled"
 msgstr "Cumasaithe"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Algartam Criptithe"
 
@@ -202,7 +219,7 @@ msgstr "Algartam Criptithe"
 msgid "Encryption Keysize"
 msgstr "Méid Eochrach Criptithe"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Tograí Criptithe"
 
@@ -210,12 +227,8 @@ msgstr "Tograí Criptithe"
 msgid "Established"
 msgstr "Bunaithe"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Geata (Críochphointe Iargúlta)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Ginearálta"
 
@@ -227,7 +240,7 @@ msgstr "Socruithe Ginearálta"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Deonaigh rochtain ar luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Díluchtú Crua-earraí"
 
@@ -235,7 +248,7 @@ msgstr "Díluchtú Crua-earraí"
 msgid "Half-Open IKE_SAs"
 msgstr "IKE_SAanna Leath-Oscailte"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Algartam Hais"
 
@@ -251,39 +264,48 @@ msgstr "Uaireanta"
 msgid "ID"
 msgstr "Aitheantas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "Ilroinnt IKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "Fíordheimhniú IKE (céim 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "Eatramh IKEv2 chun ábhar eochrach a athnuachan; úsáidtear é freisin chun "
 "saolré a ríomh"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "Seoladh IP nó ainm FQDN chríochphointe iargúlta an tolláin"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "Seoladh IP nó FQDN chríochphointe áitiúil an tolláin"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Neamhghníomhach"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Neamhghníomhaíocht"
 
@@ -295,35 +317,44 @@ msgstr "Am Suiteála"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Comhéadain a ghlacann le trácht VPN."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Eatramh roimh dhúnadh CHILD_SA neamhghníomhach"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Eatramh chun beochan piara a sheiceáil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Malartú Eochrach"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Ath-Iarrachtaí Eochracha"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Am Saoil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Saolré"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "Teorainn ama chun ath-eochrú/athfhíordheimhniú a chríochnú"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -331,7 +362,7 @@ msgstr ""
 "Liosta de thograí ESP (céim a dó). Ní féidir ach tograí a roghnú a bhfuil "
 "bratach ESP ticáilte orthu"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Liosta de mholtaí IKE (céim 1) le húsáid le haghaidh fíordheimhnithe"
 
@@ -347,39 +378,27 @@ msgstr "Seoltaí Áitiúla"
 msgid "Local Auth"
 msgstr "Údarú Áitiúil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Teastas Áitiúil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Geata Áitiúil"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "IP Áitiúil"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Aitheantóir Áitiúil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Eochair Áitiúil"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "NAT Áitiúil"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Port Áitiúil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "IP Foinse Áitiúil"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Fo-líonra Áitiúil"
 
@@ -388,29 +407,33 @@ msgstr "Fo-líonra Áitiúil"
 msgid "Local Traffic Selectors"
 msgstr "Roghnóirí Tráchta Áitiúla"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Seoladh(anna) áitiúil le húsáid in idirbheartaíocht IKE"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Aitheantóir áitiúil le haghaidh IKE (céim 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Líonra(í) áitiúil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (Prótacal Soghluaisteachta agus Il-Tíre IKEv2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Uasfhad an CHILD_SA roimh dhúnadh"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -424,10 +447,6 @@ msgstr "Nóiméid"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Mód"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "Raon NAT do tholláin le seoltaí IP forluiteacha"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -444,21 +463,27 @@ msgstr "Ní fhéadfaidh fad an ainm a bheith níos mó ná 15 charachtar"
 msgid "Number must have suffix s, m, h or d"
 msgstr "Ní mór iarmhír s, m, h nó d a bheith ag an uimhir"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Líon na n-iarrachtaí athchraolta le linn na caibidlíochta tosaigh"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "Ar an leathanach seo, is féidir leat an tseirbhís IPsec a chumrú."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-"Ar an leathanach seo, is féidir leat na tolláin IPsec agus na cianrialtáin a "
-"chumrú."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Am breise"
 
@@ -466,46 +491,46 @@ msgstr "Am breise"
 msgid "Overview"
 msgstr "Forbhreathnú"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "Algartam PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 "Ní mór Algartam PRF a chumrú agus Algartam Criptithe Fíordheimhnithe á úsáid"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr "Cosán chuig an script le rith ar imeachtaí suas/síos CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Cruthaigh Togra ar dtús le do thoil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Cruthaigh Tollán ar dtús le do thoil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Cruthaigh Togra ESP ar dtús le do thoil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Eochair Réamh-Roinnte"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Tosaíocht"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Tosaíocht an CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "Ainm cosáin eochrach phríobháideach le húsáid leis an teastas thuas"
 
@@ -522,8 +547,16 @@ msgstr "Theip ar an gceistiú strongSwan"
 msgid "Reauthentication Interval"
 msgstr "Eatramh Athfhíordheimhnithe"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Am Atheochrach"
 
@@ -544,11 +577,19 @@ msgstr "Seoltaí Cianda"
 msgid "Remote Auth"
 msgstr "Údarú Cianda"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Cumraíocht Chianda"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Aitheantóir Cianda"
 
@@ -556,7 +597,7 @@ msgstr "Aitheantóir Cianda"
 msgid "Remote Port"
 msgstr "Port Cianda"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Fo-líonra cianda"
 
@@ -565,21 +606,13 @@ msgstr "Fo-líonra cianda"
 msgid "Remote Traffic Selectors"
 msgstr "Roghnóirí Tráchta Cianda"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Aitheantóir cianda le haghaidh IKE (céim 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Líonra(í) iargúlta"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "Cianda/Tollán"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Cumraíocht iargúlta/tolláin"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
@@ -587,13 +620,17 @@ msgstr ""
 "B’fhéidir nach mbeadh na hainmneacha céanna ar Chianrialtáin, ar Thograí "
 "Criptithe agus ar Tolláin."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Fuinneog Athsheinm"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Fuinneog Athsheinm an CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -615,6 +652,20 @@ msgstr "Soicindí"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "Roghnaigh comhéadan nó fág folamh é do gach comhéadan."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "Seirbhís"
@@ -634,7 +685,7 @@ msgstr "Níl roinnt roghanna ar fáil mar theip ar swanctl a luchtú: %s"
 msgid "Start"
 msgstr "Tosaigh"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Tosaigh Gníomh"
 
@@ -650,23 +701,35 @@ msgstr "Stát"
 msgid "Stop"
 msgstr "Stop"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "An Tollán ina bhfuil an chuid ESP (céim 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "An eochair réamhroinnte don tollán"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "Leibhéal rianaithe: 0 is lú focal, 4 is mó"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "Tollán"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Cumraíocht Tolláin"
 
@@ -674,7 +737,7 @@ msgstr "Cumraíocht Tolláin"
 msgid "Unique ID"
 msgstr "Aitheantas Uathúil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Cosán Scripte Suas/Síos"
 
@@ -682,7 +745,20 @@ msgstr "Cosán Scripte Suas/Síos"
 msgid "Uptime"
 msgstr "Am ar Fáil"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Úsáid ilroinnt IKE"
 
@@ -692,7 +768,13 @@ msgstr ""
 "Bain úsáid as teaglaim cosúil le tunnel1_phase1 nach bhfuil níos mó ná 15 "
 "charachtar."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "Ní thacaíonn ach cúltaca Netlink le luachanna níos mó ná 32"
 
@@ -701,28 +783,36 @@ msgstr "Ní thacaíonn ach cúltaca Netlink le luachanna níos mó ná 32"
 msgid "Version"
 msgstr "Leagan"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "Leagan de IKE le haghaidh caibidlíochta"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
-msgstr "IP(anna) fíorúla le hiarraidh in iarratais ar ualaí cumraíochta IKEv2"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Cibé acu togra ESP (céim 2) atá ann nó nach ea"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr "Socraíodh ID comhéadain XFRM ar chomhéadain ionchuir agus aschuir"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "an dá cheann"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "as feidhm"
 
@@ -734,6 +824,57 @@ msgstr "IPsec strongSwan"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "Stádas strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Fad an CHILD_SA roimh ath-eochrú"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Geata (Críochphointe Iargúlta)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "Seoladh IP nó ainm FQDN chríochphointe iargúlta an tolláin"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "Seoladh IP nó FQDN chríochphointe áitiúil an tolláin"
+
+#~ msgid "Lifetime"
+#~ msgstr "Saolré"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Geata Áitiúil"
+
+#~ msgid "Local IP"
+#~ msgstr "IP Áitiúil"
+
+#~ msgid "Local NAT"
+#~ msgstr "NAT Áitiúil"
+
+#~ msgid "Local Source IP"
+#~ msgstr "IP Foinse Áitiúil"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Seoladh(anna) áitiúil le húsáid in idirbheartaíocht IKE"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Uasfhad an CHILD_SA roimh dhúnadh"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "Raon NAT do tholláin le seoltaí IP forluiteacha"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr ""
+#~ "Ar an leathanach seo, is féidir leat na tolláin IPsec agus na "
+#~ "cianrialtáin a chumrú."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "Cianda/Tollán"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Cumraíocht iargúlta/tolláin"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr ""
+#~ "IP(anna) fíorúla le hiarraidh in iarratais ar ualaí cumraíochta IKEv2"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "Cumraigh strongSwan le haghaidh naisc VPN slána."

--- a/applications/luci-app-strongswan-swanctl/po/ko/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ko/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d초"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr "활성 IKE_SA"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "고급"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "* 표시가 된 알고리즘은 안전하지 않은 것으로 간주됩니다"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "인증"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "인증 방식"
 
@@ -61,16 +73,16 @@ msgstr "수신 바이트"
 msgid "Bytes out"
 msgstr "송신 바이트"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "CA 인증서"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -86,7 +98,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -94,7 +106,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -107,23 +119,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "DPD 동작"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "DPD 확인 주기"
 
@@ -143,7 +160,7 @@ msgstr "일"
 msgid "Debug Level"
 msgstr "디버그 수준"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -161,7 +178,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -170,19 +187,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -191,7 +208,7 @@ msgid "Enabled"
 msgstr "활성화"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "암호화 알고리즘"
 
@@ -199,7 +216,7 @@ msgstr "암호화 알고리즘"
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -207,12 +224,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "게이트웨이 (원격 엔드포인트)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "일반"
 
@@ -224,7 +237,7 @@ msgstr "일반 설정"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "luci-app-strongswan-swanctl에 접근 권한 부여"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -232,7 +245,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr "반개방 IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "해시 알고리즘"
 
@@ -248,29 +261,38 @@ msgstr "시간"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -278,7 +300,7 @@ msgstr ""
 msgid "Inactive"
 msgstr "비활성"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -290,41 +312,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "유효 수명"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -340,39 +371,27 @@ msgstr "로컬 주소"
 msgid "Local Auth"
 msgstr "로컬 인증"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "로컬 인증서"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "로컬 게이트웨이"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "로컬 IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "로컬 식별자"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "로컬 NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "로컬 포트"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "로컬 출발지 IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "로컬 서브넷"
 
@@ -381,28 +400,32 @@ msgstr "로컬 서브넷"
 msgid "Local Traffic Selectors"
 msgstr "로컬 트래픽 선택자"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "로컬 네트워크"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (IKEv2 이동성 및 멀티호밍 프로토콜)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -417,10 +440,6 @@ msgstr "분"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "모드"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -437,19 +456,27 @@ msgstr "이름은 최대 15자까지만 입력 가능"
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -457,45 +484,45 @@ msgstr ""
 msgid "Overview"
 msgstr "개요"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "PRF 알고리즘"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "먼저 터널을 생성하세요"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "사전 공유 키(PSK)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "우선순위"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -512,8 +539,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -534,11 +569,19 @@ msgstr "원격 주소"
 msgid "Remote Auth"
 msgstr "원격 인증"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "원격 설정"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "원격 식별자"
 
@@ -546,7 +589,7 @@ msgstr "원격 식별자"
 msgid "Remote Port"
 msgstr "원격 포트"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "원격 서브넷"
 
@@ -555,32 +598,28 @@ msgstr "원격 서브넷"
 msgid "Remote Traffic Selectors"
 msgstr "원격 트래픽 선택자"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "원격 네트워크"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "원격/터널"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "원격/터널 설정"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -603,6 +642,20 @@ msgstr "초"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "서비스"
@@ -622,7 +675,7 @@ msgstr ""
 msgid "Start"
 msgstr "시작"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -638,23 +691,35 @@ msgstr "상태"
 msgid "Stop"
 msgstr "중지"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "터널"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "터널 설정"
 
@@ -662,7 +727,7 @@ msgstr "터널 설정"
 msgid "Unique ID"
 msgstr "고유 ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -670,7 +735,20 @@ msgstr ""
 msgid "Uptime"
 msgstr "가동 시간"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -678,7 +756,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -687,28 +771,36 @@ msgstr ""
 msgid "Version"
 msgstr "버전"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 
@@ -720,6 +812,27 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "strongSwan 상태"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "게이트웨이 (원격 엔드포인트)"
+
+#~ msgid "Local Gateway"
+#~ msgstr "로컬 게이트웨이"
+
+#~ msgid "Local IP"
+#~ msgstr "로컬 IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "로컬 NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "로컬 출발지 IP"
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "원격/터널"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "원격/터널 설정"
 
 #~ msgid "Zone"
 #~ msgstr "영역(Zone)"

--- a/applications/luci-app-strongswan-swanctl/po/lo/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/lo/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d ວິນາທີ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "ການກະທຳເມື່ອໂຫຼດການຕັ້ງຄ່າເລີ່ມຕົ້ນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "ການກະທຳເມື່ອ CHILD_SA ຖືກປິດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "ການກະທຳເມື່ອ DPD ໝົດເວລາ"
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr "IKE_SAs ທີ່ກຳລັງເຮັດວຽກ"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "ຂັ້ນສູງ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "ອະລະກໍລິດທີ່ໝາຍດ້ວຍ * ຖືວ່າບໍ່ປອດໄພ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "ການຢືນຢັນຕົວຕົນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "ວິທີການຢືນຢັນຕົວຕົນ"
 
@@ -61,16 +73,16 @@ msgstr "ຈຳນວນຂໍ້ມູນເຂົ້າ"
 msgid "Bytes out"
 msgstr "ຈຳນວນຂໍ້ມູນອອກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "ໃບຢັ້ງຢືນ CA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr "ໃບຢັ້ງຢືນ CA ທີ່ຕ້ອງຢູ່ໃນເສັ້ນທາງຄວາມເຊື່ອຖືຂອງໃບຢັ້ງຢືນຝັ່ງທາງໄກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "ເສັ້ນທາງໄຟລ໌ໃບຢັ້ງຢືນສຳລັບໃຊ້ຢືນຢັນຕົວຕົນ"
 
@@ -86,7 +98,7 @@ msgstr "Child"
 msgid "Class"
 msgstr "ປະເພດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "ການກະທຳເມື່ອປິດ"
 
@@ -94,7 +106,7 @@ msgstr "ການກະທຳເມື່ອປິດ"
 msgid "Configuration is enabled or not"
 msgstr "ເປີດໃຊ້ງານການຕັ້ງຄ່ານີ້ຫຼືບໍ່"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr "ຕັ້ງຄ່າ Cipher Suites ເພື່ອກຳນົດຂໍ້ສະເໜີ IKE (ໄລຍະ 1) ຫຼື ESP (ໄລຍະ 2)"
@@ -107,23 +119,28 @@ msgstr "ການເຊື່ອມຕໍ່"
 msgid "Connection Details"
 msgstr "ລາຍລະອຽດການເຊື່ອມຕໍ່"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "ການເຊື່ອມຕໍ່"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ (ໄລຍະ 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "ການກະທຳ DPD"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "ຄວາມຊັກຊ້າ DPD"
 
@@ -143,7 +160,7 @@ msgstr "ມື້"
 msgid "Debug Level"
 msgstr "ລະດັບການດີບັກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr "ກຳນົດ Connection Children ເພື່ອໃຊ້ເປັນອຸໂມງໃນການຕັ້ງຄ່າຝັ່ງທາງໄກ"
@@ -161,7 +178,7 @@ msgstr "ກຳນົດການຕັ້ງຄ່າ IKE ຝັ່ງທາງ�
 msgid "Details"
 msgstr "ລາຍລະອຽດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "ກຸ່ມ Diffie-Hellman"
 
@@ -170,19 +187,19 @@ msgstr "ກຸ່ມ Diffie-Hellman"
 msgid "Dismiss"
 msgstr "ປິດອອກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "ໄລຍະເວລາຂອງ CHILD_SA ກ່ອນຈະມີການສ້າງຄີໃໝ່"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "ຂໍ້ສະເໜີ ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "ເປີດໃຊ້ງານ Hardware offload"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "ເປີດໃຊ້ງານການບີບອັດ ipcomp"
 
@@ -191,7 +208,7 @@ msgid "Enabled"
 msgstr "ເປີດໃຊ້ງານ"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "ອະລະກໍລິດການເຂົ້າລະຫັດ"
 
@@ -199,7 +216,7 @@ msgstr "ອະລະກໍລິດການເຂົ້າລະຫັດ"
 msgid "Encryption Keysize"
 msgstr "ຂະໜາດຄີການເຂົ້າລະຫັດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ"
 
@@ -207,12 +224,8 @@ msgstr "ຂໍ້ສະເໜີການເຂົ້າລະຫັດ"
 msgid "Established"
 msgstr "ສ້າງການເຊື່ອມຕໍ່ແລ້ວ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "ເກດເວ (ຈຸດໝາຍປາຍທາງທາງໄກ)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "ທົ່ວໄປ"
 
@@ -224,7 +237,7 @@ msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "ໃຫ້ສິດເຂົ້າເຖິງ luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "H/W Offload"
 
@@ -232,7 +245,7 @@ msgstr "H/W Offload"
 msgid "Half-Open IKE_SAs"
 msgstr "IKE_SAs ທີ່ເປີດຢູ່ເຄິ່ງໜຶ່ງ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "ອະລະກໍລິດ Hash"
 
@@ -248,37 +261,46 @@ msgstr "ຊົ່ວໂມງ"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "ການແຍກສ່ວນ IKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "ການຢືນຢັນຕົວຕົນ IKE (ໄລຍະ 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr "ໄລຍະເວລາ IKEv2 ສຳລັບການປັບປຸງວັດຖຸຄີ; ໃຊ້ສຳລັບຄຳນວນໄລຍະເວລາການໃຊ້ງານນຳ"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "ທີ່ຢູ່ IP ຫຼື ຊື່ FQDN ຂອງຈຸດໝາຍປາຍທາງອຸໂມງທາງໄກ"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "ທີ່ຢູ່ IP ຫຼື FQDN ຂອງຈຸດໝາຍປາຍທາງອຸໂມງພາຍໃນ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "ບໍ່ເຮັດວຽກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "ບໍ່ມີການເຄື່ອນໄຫວ"
 
@@ -290,41 +312,50 @@ msgstr "ເວລາຕິດຕັ້ງ"
 msgid "Interfaces that accept VPN traffic."
 msgstr "ອິນເຕີເຟດທີ່ຍອມຮັບການຮັບສົ່ງຂໍ້ມູນ VPN."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "ໄລຍະເວລາກ່ອນປິດ CHILD_SA ທີ່ບໍ່ມີການເຄື່ອນໄຫວ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "ໄລຍະເວລາໃນການກວດສອບສະຖານະຂອງເພຍ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "ການແລກປ່ຽນຄີ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "ຈຳນວນຄັ້ງການລອງໃໝ່ໃນການສ້າງຄີ"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "ໄລຍະເວລາການໃຊ້ງານ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "ໄລຍະເວລາການໃຊ້ງານ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "ຈຳກັດເວລາໃນການສ້າງຄີ/ຢືນຢັນຕົວຕົນໃໝ່"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr "ລາຍການຂໍ້ສະເໜີ ESP (ໄລຍະ 2). ສາມາດເລືອກໄດ້ສະເພາະຂໍ້ສະເໜີທີ່ໝາຍຕິກ ESP ໄວ້ເທົ່ານັ້ນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "ລາຍການຂໍ້ສະເໜີ IKE (ໄລຍະ 1) ສຳລັບໃຊ້ຢືນຢັນຕົວຕົນ"
 
@@ -340,39 +371,27 @@ msgstr "ທີ່ຢູ່ທ້ອງຖິ່ນ"
 msgid "Local Auth"
 msgstr "ການຢືນຢັນຕົວຕົນທ້ອງຖິ່ນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "ໃບຢັ້ງຢືນພາຍໃນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "ເກດເວພາຍໃນ"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "IP ພາຍໃນ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "ຕົວລະບຸພາຍໃນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "ຄີພາຍໃນ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "NAT ພາຍໃນ"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "ພອດທ້ອງຖິ່ນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "IP ແຫຼ່ງຂໍ້ມູນທ້ອງຖິ່ນ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Subnet ທ້ອງຖິ່ນ"
 
@@ -381,29 +400,33 @@ msgstr "Subnet ທ້ອງຖິ່ນ"
 msgid "Local Traffic Selectors"
 msgstr "ຕົວເລືອກການຈະລາຈອນພາຍໃນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "ທີ່ຢູ່ພາຍໃນສຳລັບໃຊ້ໃນການຕໍ່ລອງ IKE"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "ຕົວລະບຸພາຍໃນສຳລັບ IKE (ໄລຍະ 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "ເຄືອຂ່າຍພາຍໃນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (ໂປຣໂຕຄອນການເຄື່ອນທີ່ແລະຫຼາຍເສັ້ນທາງຂອງ IKEv2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "ໄລຍະເວລາສູງສຸດຂອງ CHILD_SA ກ່ອນຈະປິດ"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -417,10 +440,6 @@ msgstr "ນາທີ"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "ໂໝດ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "ຊ່ວງ NAT ສຳລັບອຸໂມງທີ່ມີທີ່ຢູ່ IP ຊ້ຳກັນ"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -437,19 +456,27 @@ msgstr "ຄວາມຍາວຂອງຊື່ຕ້ອງບໍ່ເກີນ
 msgid "Number must have suffix s, m, h or d"
 msgstr "ຕົວເລກຕ້ອງມີຫົວໜ່ວຍຕໍ່ທ້າຍ s, m, h ຫຼື d"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "ຈຳນວນຄັ້ງທີ່ພະຍາຍາມສົ່ງຂໍ້ມູນໃໝ່ໃນລະຫວ່າງການຕໍ່ລອງເບື້ອງຕົ້ນ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "ໃນໜ້ານີ້, ເຈົ້າສາມາດຕັ້ງຄ່າບໍລິການ IPsec ໄດ້."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr "ໃນໜ້ານີ້, ເຈົ້າສາມາດຕັ້ງຄ່າ IPsec tunnels ແລະ remotes ໄດ້."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "ເວລາເກີນ"
 
@@ -457,45 +484,45 @@ msgstr "ເວລາເກີນ"
 msgid "Overview"
 msgstr "ພາບລວມ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "ອະລະກໍລິດ PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr "ຕ້ອງຕັ້ງຄ່າອະລະກໍລິດ PRF ເມື່ອໃຊ້ການເຂົ້າລະຫັດແບບ Authenticated"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr "ເສັ້ນທາງໄຟລ໌ສະຄຣິບທີ່ຈະໃຫ້ເຮັດວຽກເມື່ອເກີດເຫດການ CHILD_SA up/down"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "ກະລຸນາສ້າງຂໍ້ສະເໜີກ່ອນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "ກະລຸນາສ້າງອຸໂມງກ່ອນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "ກະລຸນາສ້າງຂໍ້ສະເໜີ ESP ກ່ອນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "ຄີທີ່ແບ່ງປັນກັນ (Pre-Shared Key)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "ບູລິມະສິດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Priority of the CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "ເສັ້ນທາງໄຟລ໌ Private key ສຳລັບໃຊ້ກັບໃບຢັ້ງຢືນຂ້າງເທິງ"
 
@@ -512,8 +539,16 @@ msgstr "ການຮ້ອງຂໍຂໍ້ມູນຈາກ strongSwan ລົ
 msgid "Reauthentication Interval"
 msgstr "ໄລຍະຫ່າງການຢືນຢັນຕົວຕົນໃໝ່"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "ເວລາສ້າງຄີໃໝ່"
 
@@ -534,11 +569,19 @@ msgstr "ທີ່ຢູ່ທາງໄກ"
 msgid "Remote Auth"
 msgstr "ການຢືນຢັນຕົວຕົນທາງໄກ"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "ການຕັ້ງຄ່າຝັ່ງທາງໄກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "ຕົວລະບຸຝັ່ງທາງໄກ"
 
@@ -546,7 +589,7 @@ msgstr "ຕົວລະບຸຝັ່ງທາງໄກ"
 msgid "Remote Port"
 msgstr "ພອດທາງໄກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Subnet ຝັ່ງທາງໄກ"
 
@@ -555,33 +598,29 @@ msgstr "Subnet ຝັ່ງທາງໄກ"
 msgid "Remote Traffic Selectors"
 msgstr "ຕົວເລືອກການຈະລາຈອນຝັ່ງທາງໄກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "ຕົວລະບຸຝັ່ງທາງໄກສຳລັບ IKE (ໄລຍະ 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "ເຄືອຂ່າຍຝັ່ງທາງໄກ"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "ທາງໄກ/Tunnel"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "ການຕັ້ງຄ່າ ທາງໄກ/Tunnel"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr "Remotes, Encryption Proposals ແລະ Tunnels ບໍ່ຄວນໃຊ້ຊື່ດຽວກັນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Replay Window"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Replay Window ຂອງ CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -603,6 +642,20 @@ msgstr "ວິນາທີ"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "ເລືອກອິນເຕີເຟດ ຫຼື ປ່ອຍວ່າງໄວ້ສຳລັບທຸກອິນເຕີເຟດ."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "ບໍລິການ"
@@ -622,7 +675,7 @@ msgstr "ບາງຕົວເລືອກບໍ່ສາມາດໃຊ້ງາ
 msgid "Start"
 msgstr "ເລີ່ມ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "ການກະທຳເມື່ອເລີ່ມຕົ້ນ"
 
@@ -638,23 +691,35 @@ msgstr "ສະຖານະ"
 msgid "Stop"
 msgstr "ຢຸດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "ອຸໂມງທີ່ມີສ່ວນຂອງ ESP (ໄລຍະ 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "ຄີທີ່ແບ່ງປັນກັນສຳລັບອຸໂມງ"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "ລະດັບການແກ້ບັກ: 0 ແມ່ນລະອຽດນ້ອຍສຸດ, 4 ແມ່ນລະອຽດຫຼາຍສຸດ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "ອຸໂມງ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "ການຕັ້ງຄ່າອຸໂມງ"
 
@@ -662,7 +727,7 @@ msgstr "ການຕັ້ງຄ່າອຸໂມງ"
 msgid "Unique ID"
 msgstr "ID ສະເພາະ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "ເສັ້ນທາງໄຟລ໌ສະຄຣິບ Up/Down"
 
@@ -670,7 +735,20 @@ msgstr "ເສັ້ນທາງໄຟລ໌ສະຄຣິບ Up/Down"
 msgid "Uptime"
 msgstr "ເວລາທີ່ເຮັດວຽກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "ໃຊ້ການແຍກສ່ວນ IKE"
 
@@ -678,7 +756,13 @@ msgstr "ໃຊ້ການແຍກສ່ວນ IKE"
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr "ໃຊ້ການປະສົມຊື່ເຊັ່ນ tunnel1_phase1 ທີ່ບໍ່ເກີນ 15 ຕົວອັກສອນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "ຄ່າທີ່ໃຫຍ່ກວ່າ 32 ຮອງຮັບໂດຍ Netlink backend ເທົ່ານັ້ນ"
 
@@ -687,28 +771,36 @@ msgstr "ຄ່າທີ່ໃຫຍ່ກວ່າ 32 ຮອງຮັບໂດ�
 msgid "Version"
 msgstr "ເວີຊັນ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "ເວີຊັນ IKE ສຳລັບການຕໍ່ລອງ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
-msgstr "Virtual IP ທີ່ຈະຮ້ອງຂໍໃນການຮ້ອງຂໍ configuration payloads ຂອງ IKEv2"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "ນີ້ແມ່ນຂໍ້ສະເໜີ ESP (ໄລຍະ 2) ຫຼືບໍ່"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr "ID ຂອງອິນເຕີເຟສ XFRM ທີ່ຕັ້ງໄວ້ເທິງອິນເຕີເຟສຂາເຂົ້າ ແລະ ຂາອອກ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "ທັງສອງ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "ບໍ່ແນະນຳໃຫ້ໃຊ້ແລ້ວ"
 
@@ -720,6 +812,54 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "ສະຖານະ strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "ໄລຍະເວລາຂອງ CHILD_SA ກ່ອນຈະມີການສ້າງຄີໃໝ່"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "ເກດເວ (ຈຸດໝາຍປາຍທາງທາງໄກ)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "ທີ່ຢູ່ IP ຫຼື ຊື່ FQDN ຂອງຈຸດໝາຍປາຍທາງອຸໂມງທາງໄກ"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "ທີ່ຢູ່ IP ຫຼື FQDN ຂອງຈຸດໝາຍປາຍທາງອຸໂມງພາຍໃນ"
+
+#~ msgid "Lifetime"
+#~ msgstr "ໄລຍະເວລາການໃຊ້ງານ"
+
+#~ msgid "Local Gateway"
+#~ msgstr "ເກດເວພາຍໃນ"
+
+#~ msgid "Local IP"
+#~ msgstr "IP ພາຍໃນ"
+
+#~ msgid "Local NAT"
+#~ msgstr "NAT ພາຍໃນ"
+
+#~ msgid "Local Source IP"
+#~ msgstr "IP ແຫຼ່ງຂໍ້ມູນທ້ອງຖິ່ນ"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "ທີ່ຢູ່ພາຍໃນສຳລັບໃຊ້ໃນການຕໍ່ລອງ IKE"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "ໄລຍະເວລາສູງສຸດຂອງ CHILD_SA ກ່ອນຈະປິດ"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "ຊ່ວງ NAT ສຳລັບອຸໂມງທີ່ມີທີ່ຢູ່ IP ຊ້ຳກັນ"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr "ໃນໜ້ານີ້, ເຈົ້າສາມາດຕັ້ງຄ່າ IPsec tunnels ແລະ remotes ໄດ້."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "ທາງໄກ/Tunnel"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "ການຕັ້ງຄ່າ ທາງໄກ/Tunnel"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr "Virtual IP ທີ່ຈະຮ້ອງຂໍໃນການຮ້ອງຂໍ configuration payloads ຂອງ IKEv2"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "ຕັ້ງຄ່າ strongSwan ສຳລັບການເຊື່ອມຕໍ່ VPN ທີ່ປອດໄພ"

--- a/applications/luci-app-strongswan-swanctl/po/lt/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/lt/strongswan-swanctl.po
@@ -18,15 +18,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d sekundės"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Veiksmas įkeliant pradinę konfigūraciją"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Veiksmas, kai „CHILD_SA“ yra uždarytas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Veiksmas, kai sueina „DPD“ pasibaigusios užklausos laikas"
 
@@ -35,22 +35,34 @@ msgid "Active IKE_SAs"
 msgstr "Aktyvūs „IKE_SA“ (dgs.)"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Pažangūs"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Algoritmai pažymėti su „*“ yra laikomi nesaugiais"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Autentifikavimas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Autentifikavimo būdas"
 
@@ -62,18 +74,18 @@ msgstr "Gauti baitai"
 msgid "Bytes out"
 msgstr "Perduoti baitai"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "„CA“ sertifikatas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "„CA“ sertifikatas, kuris turi būti nuotolinio lygiarangio sertifikato "
 "patikimo kelio sudėtyje"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Sertifikato kelio pavadinimas, naudojamas autentifikavimui"
 
@@ -89,7 +101,7 @@ msgstr "„Vaikai“"
 msgid "Class"
 msgstr "Klasė"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Uždaryti veiksma"
 
@@ -97,7 +109,7 @@ msgstr "Uždaryti veiksma"
 msgid "Configuration is enabled or not"
 msgstr "Konfigūraciją yra įjungtą/įgalinta arba ne"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -112,23 +124,28 @@ msgstr "Prisijungimas"
 msgid "Connection Details"
 msgstr "Prisijungimo išsamesnę informaciją"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Prisijungimai"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Kripto pasiūlymas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Kripto pasiūlymas (2-oji fazė)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "„DPD“ veiksmas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "„DPD“ atidėjimas"
 
@@ -148,7 +165,7 @@ msgstr "Dienos"
 msgid "Debug Level"
 msgstr "Derinimo/Trukdžių šalinimo lygis"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -168,7 +185,7 @@ msgstr "Apibrėžti nuotolines „IKE“ konfigūracijas."
 msgid "Details"
 msgstr "išsamesnės informacijos"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Difio-Helmano grupė"
 
@@ -177,19 +194,19 @@ msgstr "Difio-Helmano grupė"
 msgid "Dismiss"
 msgstr "Nepaisyti"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "„CHILD_SA“ trukmė prieš pakartotinio rakto įvedimo"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "„ESP“ pasiūlymas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Įjungti/Įgalinti aparatinės įrangos iškrovimo/apkrovos perkėlimą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Įjungti/Įgalinti „IPcomp“ suspaudimą/suglaudi(ni)mą"
 
@@ -198,7 +215,7 @@ msgid "Enabled"
 msgstr "Įjungta/Įgalinta (-s/-i)"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Šifravimo algoritmas"
 
@@ -206,7 +223,7 @@ msgstr "Šifravimo algoritmas"
 msgid "Encryption Keysize"
 msgstr "Šifravimo rakto dydis"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Šifravimo pasiūlymai"
 
@@ -214,12 +231,8 @@ msgstr "Šifravimo pasiūlymai"
 msgid "Established"
 msgstr "Įtvirtinti"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Tinklo tarpuvartė (nuotolinis galutinis taškas)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Bendra/-i/-ai/-s"
 
@@ -231,7 +244,7 @@ msgstr "Bendri nustatymai"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Duoti prieigą prie – „luci-app-strongswan-swanctl“"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Aparatinės įrangos iškrovimo/apkrovos perkėlimas"
 
@@ -239,7 +252,7 @@ msgstr "Aparatinės įrangos iškrovimo/apkrovos perkėlimas"
 msgid "Half-Open IKE_SAs"
 msgstr "Pusiau atidaryti „IKEA_SA“ (dgs.)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "maišos algoritmas"
 
@@ -255,43 +268,48 @@ msgstr "Valandos"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "„IKE“ fragmentavimas/-cija"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "„IKE“ autentifikavimas (1-oji fazė)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "„IKEv2“ intervalas, skirtas atnaujinti raktų medžiagą; taip pat naudojamas "
 "gyvavimo laikui apskaičiuoti"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
-"„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą "
-"nuotolinio galutinio taško IP adresas arba „FQDN“ pavadinimas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-"„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą "
-"vietinio galutinio taško IP adresas arba „FQDN“"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "„IPComp“"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Neaktyvus"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Neaktyvumas"
 
@@ -303,35 +321,44 @@ msgstr "Įdiegimo laikas"
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Intervalas prieš uždarant neaktyvų „CHILD_SA“"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Intervalas, skirtas patikrinti lygiarangio gyvumą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Raktų mainų protokolas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Raktų keitimo bandymai"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Gyvavimo laikas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Gyvavimo laikas"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "Laiko apribojimas, atliekant pakartotinį raktų keitimą/autentifikavimą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -339,7 +366,7 @@ msgstr ""
 "„ESP“ (2-osios fazės) pasiūlymų sąrašas. Galima pasirinkti tik pasiūlymus, "
 "pažymėtus su „ESP“ vėliavėle"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 "„IKE“ (1-os fazės) pasiūlymų sąrašas, kuriuos galima naudoti autentifikavimui"
@@ -356,39 +383,27 @@ msgstr "Vietiniai adresai"
 msgid "Local Auth"
 msgstr "Vietinis autentifikavimas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Vietinis sertifikatas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Vietinė tinklo tarpuvartė"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "Vietinis IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Vietinis identifikatorius"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Vietinis raktas"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "Vietinis „NAT“"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Vietinis prievadas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "Vietinis šaltinio IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Vietinis potinklis"
 
@@ -397,29 +412,33 @@ msgstr "Vietinis potinklis"
 msgid "Local Traffic Selectors"
 msgstr "Vietiniai srauto parinkikliai"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Vietinis(-iai) adresas(-ai), naudojamas(-i) „IKE“ derybose"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Vietinis identifikatorius, skirtas – „IKE“ (1-oji fazė)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Vietinis/-iai tinklas/-ai"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "„MOBIKE“"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "„MOBIKE“ („IKEv2“ mobilumo ir daugiafunkcinis protokolas)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Maksimali „CHILD_SA“ trukmė prieš uždarymą"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -433,12 +452,6 @@ msgstr "Minutės"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Veiksena"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr ""
-"„NAT“ diapazonas „tuneliams“ – tinklo protokolams, skirtiems šifruoti/"
-"pereiti į kitą tinklą su persidengiančiais IP adresais"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -456,19 +469,27 @@ msgid "Number must have suffix s, m, h or d"
 msgstr ""
 "Numeriai turi turėti priesagas s (sek), m (min), h (val) arba d (diena)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Retransliavimo bandymų skaičius, pradines derybos metu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Viršvalandžiai"
 
@@ -476,11 +497,11 @@ msgstr "Viršvalandžiai"
 msgid "Overview"
 msgstr "Apžiūra"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "„PRF“ algoritmas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -488,39 +509,39 @@ msgstr ""
 "Naudojant autentifikuotą šifravimo algoritmą, reikia sukonfigūruoti „PRF“ "
 "algoritmą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 "Kelias į skriptą, kuris bus vykdomas ant – „CHILD_SA“ įvykių metu (įjungti/"
 "išgalinti┃išjungti/išgalinti)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Prašome sukurti pasiūlymą pirmą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 "Prašome pirmą sukurti „tunelį“ – Tinklo protokolą, skirtą šifruoti/pereiti į "
 "kitą tinklą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Prašome pirmą sukurti „ESP“ pasiūlymą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Išankstinis bendras raktas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Pirmenybė"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "„CHILD_SA“ pirmenybė"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 "Privataus rakto kelio pavadinimas, naudojamas su aukščiau nurodytu "
@@ -539,8 +560,16 @@ msgstr "Nepavyko atlikti užklausos „strongSwan“"
 msgid "Reauthentication Interval"
 msgstr "Pakartotinio autentifikavimo intervalas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Pakartotinio rakto įvedimo laikas"
 
@@ -561,11 +590,19 @@ msgstr "Nuotoliniai adresai"
 msgid "Remote Auth"
 msgstr "Nuotolinis autentifikavimas"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Nuotolinė konfigūracija"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Nuotolinis identifikatorius"
 
@@ -573,7 +610,7 @@ msgstr "Nuotolinis identifikatorius"
 msgid "Remote Port"
 msgstr "Nuotolinis prievadas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Nuotolinis potinklis"
 
@@ -582,21 +619,13 @@ msgstr "Nuotolinis potinklis"
 msgid "Remote Traffic Selectors"
 msgstr "Nuotoliniai srauto parinkikliai"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Nuotolinis parinkiklis, skirtas – „IKE“ (1-oji fazė)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Nuotolinis/-iai tinklas/-ai"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
@@ -604,13 +633,17 @@ msgstr ""
 "Nuotoliniai, šifravimo pasiūlymai ir „tuneliai“ – tinklo protokolai, skirti "
 "šifruoti/pereiti į kitus tinklus negali turėti tų pačių pavadinimų."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Pakartojimo langas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "„CHILD_SA“ pakartojimo langas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -632,6 +665,20 @@ msgstr "Sekundės"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -651,7 +698,7 @@ msgstr ""
 msgid "Start"
 msgstr "Paleisti"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Pradėti veiksmą"
 
@@ -667,17 +714,29 @@ msgstr "Būklę/Būseną"
 msgid "Stop"
 msgstr "Stabdyti"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 "„Tunelis“ – tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą, "
 "kuriame yra „ESP“ (2-osios fazės) skyrius"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr ""
 "Išankstinis bendras „tunelio“ – tinklo protokolo, skirtas šifruoti/pereiti į "
 "kitą tinklą raktas"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
@@ -685,11 +744,11 @@ msgstr ""
 "Atsekamumo lygis: 0-is yra mažiausiai platus/išsamus/daugiažodiškas, 4-i yra "
 "daugiausiai"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "„Tunelis“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 "„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kito tinklo "
@@ -699,7 +758,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr "Išskirtinis ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Įjungimo/Įgalinimo┃/Išjungimo/Išgalinimo skripto kelias"
 
@@ -707,7 +766,20 @@ msgstr "Įjungimo/Įgalinimo┃/Išjungimo/Išgalinimo skripto kelias"
 msgid "Uptime"
 msgstr "Aktyvumo laikas"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Naudoti „IKE“ fragmentavimą/-ciją"
 
@@ -717,7 +789,13 @@ msgstr ""
 "Naudokite tokias kombinacijas kaip – „tunnel1_phase1“, kurios neviršija 15-"
 "os rašmenų."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 "Reikšmes didesnės nei 32-i yra palaikomos tik „Netlink“ uždaros sąsajos"
@@ -727,32 +805,38 @@ msgstr ""
 msgid "Version"
 msgstr "Versija"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "„IKE“ versija, skirta deryboms"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
-"Virtualūs IP (dgs.), kurių reikia prašyti – „IKEv2“ konfigūracijos "
-"naudingosios apkrovos užklausose"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Ar tai yra „ESP“ (2-sios fazės) pasiūlymas, ar ne"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 "„XFRM“ sąsajos ir/arba sietuvo ID, nustatytas įvesties ir išvesties sąsajose "
 "ir/arba sietuvuose"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "abi/abu"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "nebenaudojamas/-a"
 
@@ -764,6 +848,53 @@ msgstr "„strongSwan IPsec“"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "„strongSwan“ būklę/būseną"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "„CHILD_SA“ trukmė prieš pakartotinio rakto įvedimo"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Tinklo tarpuvartė (nuotolinis galutinis taškas)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr ""
+#~ "„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą "
+#~ "nuotolinio galutinio taško IP adresas arba „FQDN“ pavadinimas"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr ""
+#~ "„Tunelio“ – Tinklo protokolas, skirtas šifruoti/pereiti į kitą tinklą "
+#~ "vietinio galutinio taško IP adresas arba „FQDN“"
+
+#~ msgid "Lifetime"
+#~ msgstr "Gyvavimo laikas"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Vietinė tinklo tarpuvartė"
+
+#~ msgid "Local IP"
+#~ msgstr "Vietinis IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "Vietinis „NAT“"
+
+#~ msgid "Local Source IP"
+#~ msgstr "Vietinis šaltinio IP"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Vietinis(-iai) adresas(-ai), naudojamas(-i) „IKE“ derybose"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Maksimali „CHILD_SA“ trukmė prieš uždarymą"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr ""
+#~ "„NAT“ diapazonas „tuneliams“ – tinklo protokolams, skirtiems šifruoti/"
+#~ "pereiti į kitą tinklą su persidengiančiais IP adresais"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr ""
+#~ "Virtualūs IP (dgs.), kurių reikia prašyti – „IKEv2“ konfigūracijos "
+#~ "naudingosios apkrovos užklausose"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "Konfigūruokite „strongSwan“ saugiems „VPN“ ryšiams."

--- a/applications/luci-app-strongswan-swanctl/po/pl/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/pl/strongswan-swanctl.po
@@ -18,15 +18,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d sek."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Akcja po załadowaniu konfiguracji początkowej"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Akcja, gdy CHILD_SA jest zamknięte"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Akcja przy przekroczeniu limitu czasu DPD"
 
@@ -35,22 +35,34 @@ msgid "Active IKE_SAs"
 msgstr "Aktywne IKE_SA"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Zaawansowane"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Algorytmy oznaczone * są uważane za niebezpieczne"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Uwierzytelnienie"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Metoda uwierzytelnienia"
 
@@ -62,18 +74,18 @@ msgstr "Bajty odebrane"
 msgid "Bytes out"
 msgstr "Bajty wysłane"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "Certyfikat CA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "Certyfikat CA, który musi znajdować się w zdalnej ścieżce zaufania "
 "certyfikatu peera"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 "Ścieżka dostępu do certyfikatu, która ma być używana do uwierzytelniania"
@@ -90,7 +102,7 @@ msgstr "Podrzędne"
 msgid "Class"
 msgstr "Klasa"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Zamknij akcję"
 
@@ -98,7 +110,7 @@ msgstr "Zamknij akcję"
 msgid "Configuration is enabled or not"
 msgstr "Konfiguracja jest włączona lub nie"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -113,23 +125,28 @@ msgstr "Połączenie"
 msgid "Connection Details"
 msgstr "Szczegóły połączenia"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Połączenia"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Propozycja kryptograficzna"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Propozycja kryptograficzna (Faza 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "Akcja DPD"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "Opóźnienie DPD"
 
@@ -149,7 +166,7 @@ msgstr "Dni"
 msgid "Debug Level"
 msgstr "Poziom debugowania"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -169,7 +186,7 @@ msgstr "Określ zdalne konfiguracje IKE."
 msgid "Details"
 msgstr "Szczegóły"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Grupa Diffiego-Hellmana"
 
@@ -178,19 +195,19 @@ msgstr "Grupa Diffiego-Hellmana"
 msgid "Dismiss"
 msgstr "Zamknij"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Czas trwania CHILD_SA przed wznawianiem klucza"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "Propozycja ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Włącz odciążanie sprzętowe"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Włącz kompresję ipcomp"
 
@@ -199,7 +216,7 @@ msgid "Enabled"
 msgstr "Włączone"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Algorytm szyfrowania"
 
@@ -207,7 +224,7 @@ msgstr "Algorytm szyfrowania"
 msgid "Encryption Keysize"
 msgstr "Rozmiar klucza szyfrującego"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Propozycje szyfrowania"
 
@@ -215,12 +232,8 @@ msgstr "Propozycje szyfrowania"
 msgid "Established"
 msgstr "Nawiązano"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Brama (zdalny punkt końcowy)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Ogólne"
 
@@ -232,7 +245,7 @@ msgstr "Ustawienia główne"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Udziel dostępu do luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Odciążenie sprzętowe"
 
@@ -240,7 +253,7 @@ msgstr "Odciążenie sprzętowe"
 msgid "Half-Open IKE_SAs"
 msgstr "Półotwarte IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Algorytm haszujący"
 
@@ -256,39 +269,48 @@ msgstr "Godziny"
 msgid "ID"
 msgstr "Identyfikator"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "Fragmentacja IKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "Uwierzytelnienie IKE (Faza 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "Interwał IKEv2 do odświeżenia materiału wznawiania klucza; używany również "
 "do obliczania czasu życia"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "Adres IP lub nazwa FQDN zdalnego punktu końcowego tunelu"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "Adres IP lub nazwaFQDN lokalnego punktu końcowego tunelu"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Nieaktywna"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Bezczynność"
 
@@ -300,35 +322,44 @@ msgstr "Czas instalacji"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Interfejsy akceptujące ruch VPN."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Interwał przed zamknięciem nieaktywnego CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Interwał sprawdzania żywotności peera"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Wymiana kluczy"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Ponowne próby wznawiania klucza"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Czas życia"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Życie"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "Ograniczenie czasu na wznowienie klucza / ponowne uwierzytelnienie"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -336,7 +367,7 @@ msgstr ""
 "Lista propozycji ESP (Faza 2). Można wybrać tylko propozycje z zaznaczoną "
 "flagą ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Lista propozycji IKE (Faza 1) do wykorzystania w uwierzytelnianiu"
 
@@ -352,39 +383,27 @@ msgstr "Adresy lokalne"
 msgid "Local Auth"
 msgstr "Uwierzytelnianie lokalne"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Certyfikat lokalny"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Brama lokalna"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "Lokalny IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Identyfikator lokalny"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Klucz lokalny"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "Lokalny NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Port lokalny"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "Lokalny źródłowy adres IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Lokalna podsieć"
 
@@ -393,29 +412,33 @@ msgstr "Lokalna podsieć"
 msgid "Local Traffic Selectors"
 msgstr "Selektory ruchu lokalnego"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Adresy lokalne do wykorzystania w negocjacjach IKE"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Identyfikator lokalny dla IKE (Faza 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Sieci lokalne"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (protokół mobilności i wielodostępności IKEv2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Maksymalny czas trwania CHILD_SA przed zamknięciem"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -429,10 +452,6 @@ msgstr "Minuty"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Tryb"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "Zakres NAT dla tuneli z nakładającymi się adresami IP"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -449,19 +468,27 @@ msgstr "Długość nazwy nie może przekraczać 15 znaków"
 msgid "Number must have suffix s, m, h or d"
 msgstr "Liczba musi mieć sufiks s, m, h lub d"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Liczba prób retransmisji podczas początkowych negocjacji"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "Na tej stronie możesz skonfigurować usługę IPsec."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr "Na tej stronie możesz skonfigurować tunele IPsec i zdalne hosty."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Czas nadliczbowy"
 
@@ -469,11 +496,11 @@ msgstr "Czas nadliczbowy"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "Algorytm PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -481,37 +508,37 @@ msgstr ""
 "Algorytm PRF musi być skonfigurowany w przypadku korzystania z algorytmu "
 "szyfrowania uwierzytelnionego"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 "Ścieżka do skryptu uruchamianego w przypadku zdarzeń przesyłania/pobierania "
 "CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Najpierw utwórz propozycję"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Najpierw utwórz tunel"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Najpierw utwórz propozycję ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Klucz wstępnie udostępniony"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Priorytet"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Priorytet CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "Ścieżka do klucza prywatnego do użycia z powyższym certyfikatem"
 
@@ -528,8 +555,16 @@ msgstr "Nie powiodło się zapytanie strongSwan"
 msgid "Reauthentication Interval"
 msgstr "Interwał ponownego uwierzytelniania"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Czas wznawiania klucza"
 
@@ -550,11 +585,19 @@ msgstr "Adresy zdalne"
 msgid "Remote Auth"
 msgstr "Uwierzytelnianie zdalne"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Konfiguracja zdalna"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Identyfikator zdalny"
 
@@ -562,7 +605,7 @@ msgstr "Identyfikator zdalny"
 msgid "Remote Port"
 msgstr "Port zdalny"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Zdalna podsieć"
 
@@ -571,34 +614,30 @@ msgstr "Zdalna podsieć"
 msgid "Remote Traffic Selectors"
 msgstr "Selektory ruchu zdalnego"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Identyfikator zdalny dla IKE (Faza 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Sieci zdalne"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "Zdalne hosty/Tunel"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Konfiguracja zdalnych hostów/tunelu"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 "Zdalne, propozycje szyfrowania i tunele nie mogą mieć tych samych nazw."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Okno powtórzenia"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Okno powtórzenia CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -620,6 +659,20 @@ msgstr "Sekundy"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "Wybierz interfejs lub pozostaw puste pole dla wszystkich interfejsów."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "Usługa"
@@ -640,7 +693,7 @@ msgstr ""
 msgid "Start"
 msgstr "Uruchom"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Rozpocznij akcję"
 
@@ -656,13 +709,25 @@ msgstr "Stan"
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "Tunel zawierający sekcję ESP (Faza 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "Klucz wstępnie udostępniony dla tunelu"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
@@ -670,11 +735,11 @@ msgstr ""
 "Poziom śledzenia: 0 oznacza najmniej szczegółowy, 4 oznacza najbardziej "
 "szczegółowy"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "Tunel"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Konfiguracja tunelu"
 
@@ -682,7 +747,7 @@ msgstr "Konfiguracja tunelu"
 msgid "Unique ID"
 msgstr "Unikalny identyfikator"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Ścieżka skryptu przesyłania/pobierania"
 
@@ -690,7 +755,20 @@ msgstr "Ścieżka skryptu przesyłania/pobierania"
 msgid "Uptime"
 msgstr "Czas pracy"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Użyj fragmentacji IKE"
 
@@ -700,7 +778,13 @@ msgstr ""
 "Należy używać kombinacji takich jak tunel1_faza1, które nie przekraczają 15 "
 "znaków."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "Wartości większe niż 32 są obsługiwane tylko przez backend Netlink"
 
@@ -709,30 +793,38 @@ msgstr "Wartości większe niż 32 są obsługiwane tylko przez backend Netlink"
 msgid "Version"
 msgstr "Wersja"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "Wersja IKE do negocjacji"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
-msgstr "Wirtualne adresy IP do żądania w konfiguracji ładunku IKEv2"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Czy jest to propozycja ESP (Faza 2), czy nie"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 "Identyfikator interfejsu XFRM ustawiony na interfejsach wejściowych i "
 "wyjściowych"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "oba"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "przestarzałe"
 
@@ -744,6 +836,54 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "Status strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Czas trwania CHILD_SA przed wznawianiem klucza"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Brama (zdalny punkt końcowy)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "Adres IP lub nazwa FQDN zdalnego punktu końcowego tunelu"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "Adres IP lub nazwaFQDN lokalnego punktu końcowego tunelu"
+
+#~ msgid "Lifetime"
+#~ msgstr "Życie"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Brama lokalna"
+
+#~ msgid "Local IP"
+#~ msgstr "Lokalny IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "Lokalny NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "Lokalny źródłowy adres IP"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Adresy lokalne do wykorzystania w negocjacjach IKE"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Maksymalny czas trwania CHILD_SA przed zamknięciem"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "Zakres NAT dla tuneli z nakładającymi się adresami IP"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr "Na tej stronie możesz skonfigurować tunele IPsec i zdalne hosty."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "Zdalne hosty/Tunel"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Konfiguracja zdalnych hostów/tunelu"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr "Wirtualne adresy IP do żądania w konfiguracji ładunku IKEv2"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr ""

--- a/applications/luci-app-strongswan-swanctl/po/pt/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/pt/strongswan-swanctl.po
@@ -14,15 +14,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -31,22 +31,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr ""
 
@@ -58,16 +70,16 @@ msgstr ""
 msgid "Bytes out"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -83,7 +95,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -91,7 +103,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -104,23 +116,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr ""
 
@@ -140,7 +157,7 @@ msgstr ""
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -158,7 +175,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -167,19 +184,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -188,7 +205,7 @@ msgid "Enabled"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr ""
 
@@ -196,7 +213,7 @@ msgstr ""
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -204,12 +221,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr ""
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr ""
 
@@ -221,7 +234,7 @@ msgstr ""
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -229,7 +242,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr ""
 
@@ -245,29 +258,38 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -275,7 +297,7 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -287,41 +309,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -337,39 +368,27 @@ msgstr ""
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr ""
 
@@ -378,28 +397,32 @@ msgstr ""
 msgid "Local Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -413,10 +436,6 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:99
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
@@ -434,19 +453,27 @@ msgstr ""
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -454,45 +481,45 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -509,8 +536,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -531,11 +566,19 @@ msgstr ""
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr ""
 
@@ -543,7 +586,7 @@ msgstr ""
 msgid "Remote Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr ""
 
@@ -552,32 +595,28 @@ msgstr ""
 msgid "Remote Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -600,6 +639,20 @@ msgstr ""
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -619,7 +672,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -635,23 +688,35 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 
@@ -659,7 +724,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -667,7 +732,20 @@ msgstr ""
 msgid "Uptime"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -675,7 +753,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -684,28 +768,36 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 

--- a/applications/luci-app-strongswan-swanctl/po/pt_BR/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/pt_BR/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr ""
 
@@ -61,16 +73,16 @@ msgstr ""
 msgid "Bytes out"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -86,7 +98,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -94,7 +106,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -107,23 +119,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr ""
 
@@ -143,7 +160,7 @@ msgstr ""
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -161,7 +178,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -170,19 +187,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -191,7 +208,7 @@ msgid "Enabled"
 msgstr "Ativado"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr ""
 
@@ -199,7 +216,7 @@ msgstr ""
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -207,12 +224,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr ""
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr ""
 
@@ -224,7 +237,7 @@ msgstr "Configurações gerais"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -232,7 +245,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr ""
 
@@ -248,29 +261,38 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -278,7 +300,7 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -290,41 +312,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -340,39 +371,27 @@ msgstr ""
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr ""
 
@@ -381,28 +400,32 @@ msgstr ""
 msgid "Local Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -416,10 +439,6 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:99
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
@@ -437,19 +456,27 @@ msgstr ""
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -457,45 +484,45 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -512,8 +539,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -534,11 +569,19 @@ msgstr ""
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr ""
 
@@ -546,7 +589,7 @@ msgstr ""
 msgid "Remote Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr ""
 
@@ -555,32 +598,28 @@ msgstr ""
 msgid "Remote Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -603,6 +642,20 @@ msgstr ""
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -622,7 +675,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -638,23 +691,35 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 
@@ -662,7 +727,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -670,7 +735,20 @@ msgstr ""
 msgid "Uptime"
 msgstr "Tempo de atividade"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -678,7 +756,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -687,28 +771,36 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 

--- a/applications/luci-app-strongswan-swanctl/po/ro/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ro/strongswan-swanctl.po
@@ -15,15 +15,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -32,22 +32,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr ""
 
@@ -59,16 +71,16 @@ msgstr ""
 msgid "Bytes out"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -84,7 +96,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -92,7 +104,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -105,23 +117,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr ""
 
@@ -141,7 +158,7 @@ msgstr ""
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -159,7 +176,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -168,19 +185,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -189,7 +206,7 @@ msgid "Enabled"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr ""
 
@@ -197,7 +214,7 @@ msgstr ""
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -205,12 +222,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr ""
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr ""
 
@@ -222,7 +235,7 @@ msgstr ""
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -230,7 +243,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr ""
 
@@ -246,29 +259,38 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -276,7 +298,7 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -288,41 +310,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -338,39 +369,27 @@ msgstr ""
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr ""
 
@@ -379,28 +398,32 @@ msgstr ""
 msgid "Local Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -414,10 +437,6 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:99
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
@@ -435,19 +454,27 @@ msgstr ""
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -455,45 +482,45 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -510,8 +537,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -532,11 +567,19 @@ msgstr ""
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr ""
 
@@ -544,7 +587,7 @@ msgstr ""
 msgid "Remote Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr ""
 
@@ -553,32 +596,28 @@ msgstr ""
 msgid "Remote Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -601,6 +640,20 @@ msgstr ""
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -620,7 +673,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -636,23 +689,35 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 
@@ -660,7 +725,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -668,7 +733,20 @@ msgstr ""
 msgid "Uptime"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -676,7 +754,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -685,28 +769,36 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 

--- a/applications/luci-app-strongswan-swanctl/po/ru/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ru/strongswan-swanctl.po
@@ -19,15 +19,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d секунд"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Действие при начальной загрузке конфигурации"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Действие при закрытии CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Действие при тайм-ауте DPD"
 
@@ -36,22 +36,34 @@ msgid "Active IKE_SAs"
 msgstr "Активные KE_SA"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Алгоритмы, отмеченные *, считаются небезопасными"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Метод аутентификации"
 
@@ -63,18 +75,18 @@ msgstr "Байт получено"
 msgid "Bytes out"
 msgstr "Байт передано"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "CA-сертификат"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "CA-сертификат, который должен находиться в цепочке доверия сертификата "
 "удалённого узла"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Путь к файлу сертификата для аутентификации"
 
@@ -90,7 +102,7 @@ msgstr "Подчиненное подключение"
 msgid "Class"
 msgstr "Класс"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Действие при закрытии"
 
@@ -98,7 +110,7 @@ msgstr "Действие при закрытии"
 msgid "Configuration is enabled or not"
 msgstr "Конфигурация включена"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -113,23 +125,28 @@ msgstr "Соединение"
 msgid "Connection Details"
 msgstr "Информация о подключении"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "Соединения"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Криптографический профиль"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Криптографический профиль (фаза 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "Действие DPD"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "Интервал проверки DPD"
 
@@ -149,7 +166,7 @@ msgstr "Дней"
 msgid "Debug Level"
 msgstr "Уровень отладки"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -169,7 +186,7 @@ msgstr "Настройка удалённых конфигураций IKE."
 msgid "Details"
 msgstr "Подробности"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Наборы Диффи-Хеллмана"
 
@@ -178,19 +195,19 @@ msgstr "Наборы Диффи-Хеллмана"
 msgid "Dismiss"
 msgstr "Закрыть"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Время жизни CHILD_SA до обновления ключей"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "Профиль ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Включить аппаратное ускорение"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Включить сжатие IPComp"
 
@@ -199,7 +216,7 @@ msgid "Enabled"
 msgstr "Включено"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Алгоритм шифрования"
 
@@ -207,7 +224,7 @@ msgstr "Алгоритм шифрования"
 msgid "Encryption Keysize"
 msgstr "Размер ключа шифрования"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Профили шифрования"
 
@@ -215,12 +232,8 @@ msgstr "Профили шифрования"
 msgid "Established"
 msgstr "Установлено"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Шлюз (удалённая точка)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Основные"
 
@@ -232,7 +245,7 @@ msgstr "Основные настройки"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Предоставить доступ к luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Аппаратное ускорение"
 
@@ -240,7 +253,7 @@ msgstr "Аппаратное ускорение"
 msgid "Half-Open IKE_SAs"
 msgstr "Полуоткрытые IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Алгоритм хеширования"
 
@@ -256,38 +269,47 @@ msgstr "Часов"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "Фрагментация IKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "Аутентификация IKE (фаза 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "Интервал для обновления ключей IKEv2; используется для расчёта времени жизни"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "IP-адрес или FQDN удалённой точки туннеля"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "IP-адрес или FQDN локальной точки туннеля"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "Сжатие IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Неактивный"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Тайм-аут неактивности"
 
@@ -299,36 +321,45 @@ msgstr "Время установки"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Интерфейсы, принимающие VPN-трафик."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Интервал до закрытия неактивного CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Интервал проверки работоспособности узла"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Протокол обмена ключами"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Повторные попытки обмена ключами"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Время жизни"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Время жизни"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 "Максимальное время на завершение обновления ключей/повторной аутентификации"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -336,7 +367,7 @@ msgstr ""
 "Список профилей ESP (фаза 2). Доступны только профили с установленным флагом "
 "ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Список профилей IKE (фаза 1) для аутентификации"
 
@@ -352,39 +383,27 @@ msgstr "Локальные адреса"
 msgid "Local Auth"
 msgstr "Локальная аутентификация"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Локальный сертификат"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Локальный шлюз"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "Локальный IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Локальный идентификатор"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Локальный ключ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "Локальный NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Локальный порт"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "Локальный IP-адрес источника"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Локальная подсеть"
 
@@ -393,29 +412,33 @@ msgstr "Локальная подсеть"
 msgid "Local Traffic Selectors"
 msgstr "Локальные селекторы трафика"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Локальные адреса для использования в согласовании IKE"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Локальный идентификатор для IKE (фаза 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Локальные сети"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (протокол мобильности и множественной адресации IKEv2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Максимальное время жизни CHILD_SA до закрытия"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -429,10 +452,6 @@ msgstr "Минут"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Режим работы"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "Диапазон NAT для туннелей с пересекающимися IP-адресами"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -449,20 +468,27 @@ msgstr "Длина имени не должна превышать 15 симво
 msgid "Number must have suffix s, m, h or d"
 msgstr "Число должно содержать суффикс s (сек.), m (мин.), h (ч.) или d (дн.)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Количество попыток повторной передачи при первоначальном согласовании"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "На этой странице выполняется настройка службы IPsec."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-"На этой странице выполняется настройка IPsec-туннелей и удалённых узлов."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Запас по времени"
 
@@ -470,11 +496,11 @@ msgstr "Запас по времени"
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "Алгоритм PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -482,36 +508,36 @@ msgstr ""
 "При использовании аутентифицированного шифрования необходимо настроить "
 "алгоритм PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 "Путь к скрипту, выполняемому при событиях CHILD_SA (включение/отключение)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Сначала создайте профиль"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Сначала создайте туннель"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Сначала создайте профиль ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Предварительный общий ключ (PSK)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Приоритет"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Приоритет CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "Путь к приватному ключу для указанного сертификата"
 
@@ -528,8 +554,16 @@ msgstr "Не удалось запросить данные у strongSwan"
 msgid "Reauthentication Interval"
 msgstr "Время повторной аутентификации"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Интервал обновления ключей"
 
@@ -550,11 +584,19 @@ msgstr "Удалённые адреса"
 msgid "Remote Auth"
 msgstr "Удалённая авторизация"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Удалённая конфигурация"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Удалённый идентификатор"
 
@@ -562,7 +604,7 @@ msgstr "Удалённый идентификатор"
 msgid "Remote Port"
 msgstr "Удалённый порт"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Удалённая подсеть"
 
@@ -571,21 +613,13 @@ msgstr "Удалённая подсеть"
 msgid "Remote Traffic Selectors"
 msgstr "Удалённые селекторы трафика"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Удалённый идентификатор для IKE (фаза 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Удалённые сети"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "Удалённые узлы/туннели"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Настройка удалённых узлов/туннелей"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
@@ -593,13 +627,17 @@ msgstr ""
 "Имена удалённых конфигураций, профилей шифрования и туннелей не должны "
 "совпадать."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Окно защиты от повторов"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Окно защиты от повторов CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -621,6 +659,20 @@ msgstr "Секунд"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "Выберите интерфейс или оставьте поле пустым для всех интерфейсов."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "Служба"
@@ -641,7 +693,7 @@ msgstr ""
 msgid "Start"
 msgstr "Начало"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Действие при запуске"
 
@@ -657,23 +709,35 @@ msgstr "Состояние"
 msgid "Stop"
 msgstr "Остановить"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "Туннель, содержащий раздел ESP (фаза 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "Предварительный общий ключ для туннеля"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "Уровень трассировки: 0 — минимум сообщений, 4 — максимум"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "Туннель"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Конфигурация туннеля"
 
@@ -681,7 +745,7 @@ msgstr "Конфигурация туннеля"
 msgid "Unique ID"
 msgstr "Уникальный ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Путь к скрипту включения/отключения"
 
@@ -689,7 +753,20 @@ msgstr "Путь к скрипту включения/отключения"
 msgid "Uptime"
 msgstr "Время работы"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Использовать фрагментацию IKE"
 
@@ -698,7 +775,13 @@ msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 "Используйте комбинации вида tunnel1_phase1, не превышающие 15 символов."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "Значения больше 32 поддерживаются только ядром Linux (Netlink)"
 
@@ -707,30 +790,36 @@ msgstr "Значения больше 32 поддерживаются тольк
 msgid "Version"
 msgstr "Версия"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "Версии IKE для согласования"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
-"Виртуальные IP-адреса, запрашиваемые в запросах полезной нагрузки "
-"конфигурации IKEv2"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Указывает, является ли это профилем ESP (фаза 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr "ID интерфейса XFRM, устанавливаемый на входных и выходных интерфейсах"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "обе"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "устаревшая опция"
 
@@ -742,6 +831,57 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "Статус strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Время жизни CHILD_SA до обновления ключей"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Шлюз (удалённая точка)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "IP-адрес или FQDN удалённой точки туннеля"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "IP-адрес или FQDN локальной точки туннеля"
+
+#~ msgid "Lifetime"
+#~ msgstr "Время жизни"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Локальный шлюз"
+
+#~ msgid "Local IP"
+#~ msgstr "Локальный IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "Локальный NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "Локальный IP-адрес источника"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Локальные адреса для использования в согласовании IKE"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Максимальное время жизни CHILD_SA до закрытия"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "Диапазон NAT для туннелей с пересекающимися IP-адресами"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr ""
+#~ "На этой странице выполняется настройка IPsec-туннелей и удалённых узлов."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "Удалённые узлы/туннели"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Настройка удалённых узлов/туннелей"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr ""
+#~ "Виртуальные IP-адреса, запрашиваемые в запросах полезной нагрузки "
+#~ "конфигурации IKEv2"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "Настройка strongSwan для защищённых VPN-соединений."

--- a/applications/luci-app-strongswan-swanctl/po/ta/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/ta/strongswan-swanctl.po
@@ -14,15 +14,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -31,22 +31,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr ""
 
@@ -58,16 +70,16 @@ msgstr ""
 msgid "Bytes out"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -83,7 +95,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -91,7 +103,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -104,23 +116,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr ""
 
@@ -140,7 +157,7 @@ msgstr ""
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -158,7 +175,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -167,19 +184,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -188,7 +205,7 @@ msgid "Enabled"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr ""
 
@@ -196,7 +213,7 @@ msgstr ""
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -204,12 +221,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr ""
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr ""
 
@@ -221,7 +234,7 @@ msgstr ""
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -229,7 +242,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr ""
 
@@ -245,29 +258,38 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -275,7 +297,7 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -287,41 +309,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -337,39 +368,27 @@ msgstr ""
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr ""
 
@@ -378,28 +397,32 @@ msgstr ""
 msgid "Local Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -413,10 +436,6 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:99
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
@@ -434,19 +453,27 @@ msgstr ""
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -454,45 +481,45 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -509,8 +536,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -531,11 +566,19 @@ msgstr ""
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr ""
 
@@ -543,7 +586,7 @@ msgstr ""
 msgid "Remote Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr ""
 
@@ -552,32 +595,28 @@ msgstr ""
 msgid "Remote Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -600,6 +639,20 @@ msgstr ""
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -619,7 +672,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -635,23 +688,35 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 
@@ -659,7 +724,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -667,7 +732,20 @@ msgstr ""
 msgid "Uptime"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -675,7 +753,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -684,28 +768,36 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 

--- a/applications/luci-app-strongswan-swanctl/po/templates/strongswan-swanctl.pot
+++ b/applications/luci-app-strongswan-swanctl/po/templates/strongswan-swanctl.pot
@@ -8,15 +8,15 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "%d seconds"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -25,22 +25,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr ""
 
@@ -52,16 +64,16 @@ msgstr ""
 msgid "Bytes out"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr ""
 
@@ -77,7 +89,7 @@ msgstr ""
 msgid "Class"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr ""
 
@@ -85,7 +97,7 @@ msgstr ""
 msgid "Configuration is enabled or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -98,23 +110,28 @@ msgstr ""
 msgid "Connection Details"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr ""
 
@@ -134,7 +151,7 @@ msgstr ""
 msgid "Debug Level"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -152,7 +169,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr ""
 
@@ -161,19 +178,19 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr ""
 
@@ -182,7 +199,7 @@ msgid "Enabled"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr ""
 
@@ -190,7 +207,7 @@ msgstr ""
 msgid "Encryption Keysize"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr ""
 
@@ -198,12 +215,8 @@ msgstr ""
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr ""
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr ""
 
@@ -215,7 +228,7 @@ msgstr ""
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr ""
 
@@ -223,7 +236,7 @@ msgstr ""
 msgid "Half-Open IKE_SAs"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr ""
 
@@ -239,29 +252,38 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
@@ -269,7 +291,7 @@ msgstr ""
 msgid "Inactive"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -281,41 +303,50 @@ msgstr ""
 msgid "Interfaces that accept VPN traffic."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -331,39 +362,27 @@ msgstr ""
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr ""
 
@@ -372,28 +391,32 @@ msgstr ""
 msgid "Local Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -407,10 +430,6 @@ msgstr ""
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:99
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
@@ -428,19 +447,27 @@ msgstr ""
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr ""
 
@@ -448,45 +475,45 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -503,8 +530,16 @@ msgstr ""
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -525,11 +560,19 @@ msgstr ""
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr ""
 
@@ -537,7 +580,7 @@ msgstr ""
 msgid "Remote Port"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr ""
 
@@ -546,32 +589,28 @@ msgstr ""
 msgid "Remote Traffic Selectors"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
@@ -594,6 +633,20 @@ msgstr ""
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr ""
@@ -613,7 +666,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -629,23 +682,35 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr ""
 
@@ -653,7 +718,7 @@ msgstr ""
 msgid "Unique ID"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -661,7 +726,20 @@ msgstr ""
 msgid "Uptime"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr ""
 
@@ -669,7 +747,13 @@ msgstr ""
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr ""
 
@@ -678,28 +762,36 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr ""
 

--- a/applications/luci-app-strongswan-swanctl/po/uk/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/uk/strongswan-swanctl.po
@@ -18,15 +18,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d с"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "Дія при початковому завантаженні конфігурації"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "Дія при закритті CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "Дія при тайм-ауті DPD"
 
@@ -35,22 +35,34 @@ msgid "Active IKE_SAs"
 msgstr "Активні IKE_SA"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "Розширені"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "Алгоритми, позначені *, вважаються небезпечними"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "Автентифікація"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "Метод автентифікації"
 
@@ -62,18 +74,18 @@ msgstr "Байтів отримано"
 msgid "Bytes out"
 msgstr "Байтів надіслано"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "Сертифікат CA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 "Сертифікат CA, що має бути у ланцюжку довіри сертифіката віддаленого "
 "однорангового вузла"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "Шлях до сертифіката для автентифікації"
 
@@ -89,7 +101,7 @@ msgstr "Дитина"
 msgid "Class"
 msgstr "Клас"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "Дія при закритті"
 
@@ -97,7 +109,7 @@ msgstr "Дія при закритті"
 msgid "Configuration is enabled or not"
 msgstr "Чи увімкнено конфігурацію"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -112,23 +124,28 @@ msgstr "З’єднання"
 msgid "Connection Details"
 msgstr "Деталі з’єднання"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "З’єднання"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "Криптопропозиція"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "Криптопропозиція (фаза 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "Дія DPD"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "Затримка DPD"
 
@@ -148,7 +165,7 @@ msgstr "днів"
 msgid "Debug Level"
 msgstr "Рівень налагодження"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -168,7 +185,7 @@ msgstr "Визначте віддалені конфігурації IKE."
 msgid "Details"
 msgstr "Подробиці"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Група Діффі-Геллмана"
 
@@ -177,19 +194,19 @@ msgstr "Група Діффі-Геллмана"
 msgid "Dismiss"
 msgstr "Відхилити"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "Тривалість CHILD_SA до перегенерації ключів"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "Пропозиція ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "Увімкнути апаратне розвантаження"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "Увімкнути стиснення ipcomp"
 
@@ -198,7 +215,7 @@ msgid "Enabled"
 msgstr "Увімкнено"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "Алгоритм шифрування"
 
@@ -206,7 +223,7 @@ msgstr "Алгоритм шифрування"
 msgid "Encryption Keysize"
 msgstr "Розмір ключа шифрування"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "Пропозиції шифрування"
 
@@ -214,12 +231,8 @@ msgstr "Пропозиції шифрування"
 msgid "Established"
 msgstr "Встановлено"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "Шлюз (віддалена кінцева точка)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "Загальне"
 
@@ -231,7 +244,7 @@ msgstr "Загальні налаштування"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "Надати доступ до luci-app-strongswan-swanctl"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "Апаратне розвантаження"
 
@@ -239,7 +252,7 @@ msgstr "Апаратне розвантаження"
 msgid "Half-Open IKE_SAs"
 msgstr "Напіввідкриті IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "Алгоритм хешування"
 
@@ -255,39 +268,48 @@ msgstr "годин"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "Фрагментація IKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "Автентифікація IKE (фаза 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 "Інтервал IKEv2 для оновлення ключового матеріалу; також використовується для "
 "обчислення часу життя"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "IP-адреса або FQDN віддаленої кінцевої точки тунелю"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "IP-адреса або FQDN локальної кінцевої точки тунелю"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "Неактивно"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "Неактивність"
 
@@ -299,36 +321,45 @@ msgstr "Час встановлення"
 msgid "Interfaces that accept VPN traffic."
 msgstr "Інтерфейси, що приймають VPN-трафік."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "Інтервал до закриття неактивного CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "Інтервал перевірки активності однорангового вузла"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "Обмін ключами"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "Спроби обміну ключами"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "Час життя"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "Час життя"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 "Обмеження часу на завершення перегенерації ключів/повторної автентифікації"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
@@ -336,7 +367,7 @@ msgstr ""
 "Список пропозицій ESP (фаза 2). Можна обрати лише пропозиції з позначеним "
 "прапором ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "Список пропозицій IKE (фаза 1) для використання при автентифікації"
 
@@ -352,39 +383,27 @@ msgstr "Локальна адреса"
 msgid "Local Auth"
 msgstr "Локальна автентифікація"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "Локальний сертифікат"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "Локальний шлюз"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "Локальна IP-адреса"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "Локальний ідентифікатор"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "Локальний ключ"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "Локальний NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "Локальний порт"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "Локальна IP-адреса джерела"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "Локальна підмережа"
 
@@ -393,29 +412,33 @@ msgstr "Локальна підмережа"
 msgid "Local Traffic Selectors"
 msgstr "Локальні селектори трафіку"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "Локальна(і) адреса(и) для узгодження IKE"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "Локальний ідентифікатор для IKE (фаза 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "Локальна(і) мережа(і)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (протокол мобільності та мультихостингу IKEv2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "Максимальна тривалість CHILD_SA до закриття"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -429,10 +452,6 @@ msgstr "хвилин"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "Режим"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "Діапазон NAT для тунелів із перекриттям IP-адрес"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -449,20 +468,27 @@ msgstr "Довжина імені не повинна перевищувати 1
 msgid "Number must have suffix s, m, h or d"
 msgstr "Число має мати суфікс s, m, h або d"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "Кількість спроб повторної передачі під час початкового узгодження"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "На цій сторінці ви можете налаштувати службу IPsec."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-"На цій сторінці ви можете налаштувати IPsec-тунелі та віддалені пристрої."
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "Перевищення часу"
 
@@ -470,11 +496,11 @@ msgstr "Перевищення часу"
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "Алгоритм PRF"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
@@ -482,35 +508,35 @@ msgstr ""
 "Алгоритм PRF необхідно налаштувати при використанні алгоритму "
 "автентифікованого шифрування"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr "Шлях до сценарію, що виконується при подіях up/down CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "Спочатку створіть пропозицію"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "Спочатку створіть тунель"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "Спочатку створіть пропозицію ESP"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "Спільний ключ"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "Пріоритет"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "Пріоритет CHILD_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "Шлях до приватного ключа для використання з наведеним сертифікатом"
 
@@ -527,8 +553,16 @@ msgstr "Не вдалося опитати strongSwan"
 msgid "Reauthentication Interval"
 msgstr "Інтервал повторної автентифікації"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "Час перегенерації ключів"
 
@@ -549,11 +583,19 @@ msgstr "Віддалена адреса"
 msgid "Remote Auth"
 msgstr "Віддалена автентифікація"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "Віддалена конфігурація"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "Віддалений ідентифікатор"
 
@@ -561,7 +603,7 @@ msgstr "Віддалений ідентифікатор"
 msgid "Remote Port"
 msgstr "Віддалений порт"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "Віддалена підмережа"
 
@@ -570,21 +612,13 @@ msgstr "Віддалена підмережа"
 msgid "Remote Traffic Selectors"
 msgstr "Віддалені селектори трафіку"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "Віддалений ідентифікатор для IKE (фаза 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "Віддалена(і) мережа(і)"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "Віддаленні хости / Тунель"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "Конфігурація віддалених хостів / тунелю"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
@@ -592,13 +626,17 @@ msgstr ""
 "Віддалені вузли, пропозиції шифрування та тунелі не можуть мати однакових "
 "імен."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "Вікно повторного відтворення"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "Вікно повторного відтворення CHILD_SA"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -620,6 +658,20 @@ msgstr "секунд"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "Виберіть інтерфейс або залиште поле порожнім для всіх інтерфейсів."
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "Сервіс"
@@ -640,7 +692,7 @@ msgstr ""
 msgid "Start"
 msgstr "Почати"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "Дія при запуску"
 
@@ -656,23 +708,35 @@ msgstr "Стан"
 msgid "Stop"
 msgstr "Зупинити"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "Тунель, що містить секцію ESP (фаза 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "Спільний ключ для тунелю"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "Рівень трасування: 0 — найменш докладно, 4 — найдокладніше"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "Тунель"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "Конфігурація тунелю"
 
@@ -680,7 +744,7 @@ msgstr "Конфігурація тунелю"
 msgid "Unique ID"
 msgstr "Унікальний ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "Шлях до сценарію Up/Down"
 
@@ -688,7 +752,20 @@ msgstr "Шлях до сценарію Up/Down"
 msgid "Uptime"
 msgstr "Час безперервної роботи"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "Використовувати фрагментацію IKE"
 
@@ -698,7 +775,13 @@ msgstr ""
 "Використовуйте комбінації на кшталт tunnel1_phase1, що не перевищують 15 "
 "символів."
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "Значення більше 32 підтримуються лише бекендом Netlink"
 
@@ -707,30 +790,37 @@ msgstr "Значення більше 32 підтримуються лише б�
 msgid "Version"
 msgstr "Версія"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "Версія IKE для узгодження"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
-"Віртуальна(і) IP-адреса(и) для запиту в конфігураційних повідомленнях IKEv2"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "Чи є це пропозиція ESP (фаза 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr ""
 "Ідентифікатор інтерфейсу XFRM, призначений вхідним та вихідним інтерфейсам"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "обидва"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "застаріле"
 
@@ -742,6 +832,57 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "Стан strongSwan"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "Тривалість CHILD_SA до перегенерації ключів"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "Шлюз (віддалена кінцева точка)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "IP-адреса або FQDN віддаленої кінцевої точки тунелю"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "IP-адреса або FQDN локальної кінцевої точки тунелю"
+
+#~ msgid "Lifetime"
+#~ msgstr "Час життя"
+
+#~ msgid "Local Gateway"
+#~ msgstr "Локальний шлюз"
+
+#~ msgid "Local IP"
+#~ msgstr "Локальна IP-адреса"
+
+#~ msgid "Local NAT"
+#~ msgstr "Локальний NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "Локальна IP-адреса джерела"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "Локальна(і) адреса(и) для узгодження IKE"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "Максимальна тривалість CHILD_SA до закриття"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "Діапазон NAT для тунелів із перекриттям IP-адрес"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr ""
+#~ "На цій сторінці ви можете налаштувати IPsec-тунелі та віддалені пристрої."
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "Віддаленні хости / Тунель"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "Конфігурація віддалених хостів / тунелю"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr ""
+#~ "Віртуальна(і) IP-адреса(и) для запиту в конфігураційних повідомленнях "
+#~ "IKEv2"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "Налаштуйте strongSwan для безпечних зʼєднань VPN."

--- a/applications/luci-app-strongswan-swanctl/po/zh_Hans/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/zh_Hans/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d 秒"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "初始配置加载时的动作"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr "CHILD_SA 关闭时的动作"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr "DPD 超时时的动作"
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr "活动的 IKE_SA"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "高级"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "带有 * 标记的算法被视为不安全"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "认证"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "认证方式"
 
@@ -61,16 +73,16 @@ msgstr "入站字节"
 msgid "Bytes out"
 msgstr "出站字节"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "CA 证书"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr "位于对端证书信任链路径中的 CA 证书"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "用于认证的证书文件路径"
 
@@ -86,7 +98,7 @@ msgstr "子"
 msgid "Class"
 msgstr "类"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "关闭动作"
 
@@ -94,7 +106,7 @@ msgstr "关闭动作"
 msgid "Configuration is enabled or not"
 msgstr "是否启用此配置"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr "配置密码套件以定义 IKE（阶段 1）或 ESP（阶段 2）提议。"
@@ -107,23 +119,28 @@ msgstr "连接"
 msgid "Connection Details"
 msgstr "连接详情"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "连接"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "加密提议"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "加密提议 (阶段 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "DPD 动作"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "DPD 延迟"
 
@@ -143,7 +160,7 @@ msgstr "天"
 msgid "Debug Level"
 msgstr "调试级别"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr "定义在对端配置中作为隧道使用的子连接。"
@@ -161,7 +178,7 @@ msgstr "定义对端 IKE 配置。"
 msgid "Details"
 msgstr "详情"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "DH 组 (Diffie-Hellman)"
 
@@ -170,19 +187,19 @@ msgstr "DH 组 (Diffie-Hellman)"
 msgid "Dismiss"
 msgstr "关闭"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
-msgstr "CHILD_SA 重新协商密钥前的持续时间"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "ESP 提议"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "启用硬件卸载 (Hardware Offload)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "启用 IPComp 压缩"
 
@@ -191,7 +208,7 @@ msgid "Enabled"
 msgstr "已启用"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "加密算法"
 
@@ -199,7 +216,7 @@ msgstr "加密算法"
 msgid "Encryption Keysize"
 msgstr "加密密钥长度"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "加密提议"
 
@@ -207,12 +224,8 @@ msgstr "加密提议"
 msgid "Established"
 msgstr "已建立"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "网关 (对端)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "常规"
 
@@ -224,7 +237,7 @@ msgstr "常规设置"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "授予 luci-app-strongswan-swanctl 的权限"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "硬件卸载"
 
@@ -232,7 +245,7 @@ msgstr "硬件卸载"
 msgid "Half-Open IKE_SAs"
 msgstr "半开 IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "哈希算法"
 
@@ -248,37 +261,46 @@ msgstr "小时"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "IKE 分片"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "IKE 认证 (阶段 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr "IKEv2 刷新密钥材料的间隔；也用于计算生存时间"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "隧道对端的 IP 地址或 FQDN 域名"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "隧道本端的 IP 地址或 FQDN 域名"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp 压缩"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "不活跃"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr "空闲超时"
 
@@ -290,41 +312,50 @@ msgstr "安装时间"
 msgid "Interfaces that accept VPN traffic."
 msgstr "接受 VPN 流量的接口。"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr "关闭非活动 CHILD_SA 前的间隔时间"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "检查对端存活状态的间隔时间 (Keep-alive)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "密钥交换 (Key Exchange)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr "密钥协商重试次数"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "生存时间"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "生存时间"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr "完成密钥更新/重新认证的时间限制"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr "ESP (阶段 2) 提议列表。只有勾选了 ESP 标记的提议才可选"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr "用于认证的 IKE (阶段 1) 提议列表"
 
@@ -340,39 +371,27 @@ msgstr "本地地址"
 msgid "Local Auth"
 msgstr "本地认证"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "本地证书"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "本地网关"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "本地 IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "本地标识符 (ID)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "本地密钥"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "本地 NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "本地端口"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "本地源 IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "本地子网"
 
@@ -381,29 +400,33 @@ msgstr "本地子网"
 msgid "Local Traffic Selectors"
 msgstr "本地流量选择器 (TS)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr "IKE 协商中使用的本地地址"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "IKE (阶段 1) 的本地标识符"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "本地网络"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (IKEv2 移动性与多归属协议)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
-msgstr "CHILD_SA 关闭前的最大持续时间"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
 msgid "Minute"
@@ -417,10 +440,6 @@ msgstr "分钟"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "模式"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr "针对 IP 地址重叠隧道的 NAT 范围"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -437,19 +456,27 @@ msgstr "名称长度不得超过 15 个字符"
 msgid "Number must have suffix s, m, h or d"
 msgstr "数值必须带有单位后缀 (s, m, h 或 d)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "初始协商期间的重传尝试次数"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr "你可在此页配置 IPsec 服务。"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr "你可以在此页配置 IPsec 隧道和远端。"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "超时时间"
 
@@ -457,45 +484,45 @@ msgstr "超时时间"
 msgid "Overview"
 msgstr "概况"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "PRF 伪随机函数算法"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr "使用经过身份验证的加密算法 (AEAD) 时，必须配置 PRF 算法"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr "CHILD_SA 上线/下线事件发生时运行的脚本路径"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "请先创建一个提议"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "请先创建一个隧道"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "请先创建一个 ESP 提议"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "预共享密钥 (PSK)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "优先级"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "CHILD_SA 的优先级"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr "配合上述证书使用的私钥路径"
 
@@ -512,8 +539,16 @@ msgstr "查询 strongSwan 状态失败"
 msgid "Reauthentication Interval"
 msgstr "重新认证间隔"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr "密钥更新时间"
 
@@ -534,11 +569,19 @@ msgstr "远端地址"
 msgid "Remote Auth"
 msgstr "远端认证"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "对端配置"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "对端标识符 (ID)"
 
@@ -546,7 +589,7 @@ msgstr "对端标识符 (ID)"
 msgid "Remote Port"
 msgstr "远程端口"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "对端子网"
 
@@ -555,33 +598,29 @@ msgstr "对端子网"
 msgid "Remote Traffic Selectors"
 msgstr "对端流量选择器 (TS)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "IKE (阶段 1) 的对端标识符"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "对端网络"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr "远端/隧道"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr "远端/隧道配置"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr "对端配置、加密提议和隧道不能使用相同的名称。"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "防重放窗口"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "CHILD_SA 的防重放窗口"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -603,6 +642,20 @@ msgstr "秒"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr "选择一个接口，留空表示所有接口。"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "服务"
@@ -622,7 +675,7 @@ msgstr "一些选项不可用，因 swanctl 未能加载：%s"
 msgid "Start"
 msgstr "启动"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr "启动动作"
 
@@ -638,23 +691,35 @@ msgstr "状态"
 msgid "Stop"
 msgstr "停止"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr "包含 ESP (阶段 2) 部分的隧道"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "该隧道的预共享密钥"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr "追踪级别：0 为最简要，4 为最详细"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "隧道"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "隧道配置"
 
@@ -662,7 +727,7 @@ msgstr "隧道配置"
 msgid "Unique ID"
 msgstr "唯一 ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr "上线/下线脚本路径"
 
@@ -670,7 +735,20 @@ msgstr "上线/下线脚本路径"
 msgid "Uptime"
 msgstr "运行时间"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "启用 IKE 分片"
 
@@ -678,7 +756,13 @@ msgstr "启用 IKE 分片"
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr "请使用类似 tunnel1_phase1 的组合名称，且长度不超过 15 个字符。"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "仅 Netlink 后端支持大于 32 的值"
 
@@ -687,28 +771,36 @@ msgstr "仅 Netlink 后端支持大于 32 的值"
 msgid "Version"
 msgstr "版本"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "协商使用的 IKE 版本"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
-msgstr "在 IKEv2 配置载荷请求中申请的虚拟 IP"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr "这是否是一个 ESP (阶段 2) 提议"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr "在输入和输出接口上设置的 XFRM 接口 ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "两者"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "不建议使用 (弃用)"
 
@@ -720,6 +812,54 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "strongSwan 状态"
+
+#~ msgid "Duration of the CHILD_SA before rekeying"
+#~ msgstr "CHILD_SA 重新协商密钥前的持续时间"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "网关 (对端)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "隧道对端的 IP 地址或 FQDN 域名"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "隧道本端的 IP 地址或 FQDN 域名"
+
+#~ msgid "Lifetime"
+#~ msgstr "生存时间"
+
+#~ msgid "Local Gateway"
+#~ msgstr "本地网关"
+
+#~ msgid "Local IP"
+#~ msgstr "本地 IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "本地 NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "本地源 IP"
+
+#~ msgid "Local address(es) to use in IKE negotiation"
+#~ msgstr "IKE 协商中使用的本地地址"
+
+#~ msgid "Maximum duration of the CHILD_SA before closing"
+#~ msgstr "CHILD_SA 关闭前的最大持续时间"
+
+#~ msgid "NAT range for tunnels with overlapping IP addresses"
+#~ msgstr "针对 IP 地址重叠隧道的 NAT 范围"
+
+#~ msgid "On this page, you can configure the IPsec tunnels and remotes."
+#~ msgstr "你可以在此页配置 IPsec 隧道和远端。"
+
+#~ msgid "Remote/Tunnel"
+#~ msgstr "远端/隧道"
+
+#~ msgid "Remote/Tunnel configuration"
+#~ msgstr "远端/隧道配置"
+
+#~ msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#~ msgstr "在 IKEv2 配置载荷请求中申请的虚拟 IP"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "配置 strongSwan 以实现安全的 VPN 连接。"

--- a/applications/luci-app-strongswan-swanctl/po/zh_Hant/strongswan-swanctl.po
+++ b/applications/luci-app-strongswan-swanctl/po/zh_Hant/strongswan-swanctl.po
@@ -17,15 +17,15 @@ msgstr ""
 msgid "%d seconds"
 msgstr "%d 秒"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
 msgid "Action on initial configuration load"
 msgstr "初始配置載入時的動作"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:297
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:323
 msgid "Action when CHILD_SA is closed"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:337
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:358
 msgid "Action when DPD timeout occurs"
 msgstr ""
 
@@ -34,22 +34,34 @@ msgid "Active IKE_SAs"
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:82
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:249
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:280
 msgid "Advanced"
 msgstr "進階"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:387
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:395
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:404
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:458
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:466
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:475
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:480
 msgid "Algorithms marked with * are considered insecure"
 msgstr "標有 * 的演算法被認為不安全"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:409
+msgid "Also used to derive lifebytes if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:428
+msgid "Also used to derive lifepackets if set (110% of this value)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+msgid "Also used to derive lifetime (110% of this value)."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:81
 msgid "Authentication"
 msgstr "認證"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "Authentication Method"
 msgstr "認證方式"
 
@@ -61,16 +73,16 @@ msgstr "傳入位元組"
 msgid "Bytes out"
 msgstr "傳出位元組"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:185
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:183
 msgid "CA Certificate"
 msgstr "CA 憑證"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:186
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:184
 msgid ""
 "CA certificate that need to lie in remote peer's certificate's path of trust"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:175
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:173
 msgid "Certificate pathname to use for authentication"
 msgstr "用於認證的憑證路徑名稱"
 
@@ -86,7 +98,7 @@ msgstr ""
 msgid "Class"
 msgstr "類別"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:296
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:322
 msgid "Close Action"
 msgstr "關閉動作"
 
@@ -94,7 +106,7 @@ msgstr "關閉動作"
 msgid "Configuration is enabled or not"
 msgstr "配置是否啟用"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:448
 msgid ""
 "Configure Cipher Suites to define IKE (Phase 1) or ESP (Phase 2) Proposals."
 msgstr ""
@@ -107,23 +119,28 @@ msgstr "連線"
 msgid "Connection Details"
 msgstr "連線詳細資訊"
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
+msgid "Connection configurations"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:335
+#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
 msgid "Connections"
 msgstr "連線數"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:106
 msgid "Crypto Proposal"
 msgstr "加密提案"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:305
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
 msgid "Crypto Proposal (Phase 2)"
 msgstr "加密提案 (提案 2)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:336
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:357
 msgid "DPD Action"
 msgstr "DPD 動作"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
 msgid "DPD Delay"
 msgstr "DPD 延遲"
 
@@ -143,7 +160,7 @@ msgstr "天"
 msgid "Debug Level"
 msgstr "除錯等級"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:243
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:274
 msgid ""
 "Define Connection Children to be used as Tunnels in Remote Configurations."
 msgstr ""
@@ -161,7 +178,7 @@ msgstr "定義遠端 IKE 配置。"
 msgid "Details"
 msgstr "詳情"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:474
 msgid "Diffie-Hellman Group"
 msgstr "Diffie-Hellman 群組"
 
@@ -170,19 +187,19 @@ msgstr "Diffie-Hellman 群組"
 msgid "Dismiss"
 msgstr "關閉"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:346
-msgid "Duration of the CHILD_SA before rekeying"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:256
+msgid "ESP Encapsulation"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:382
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:453
 msgid "ESP Proposal"
 msgstr "ESP 提案"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:356
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:389
 msgid "Enable Hardware offload"
 msgstr "啟用硬體卸載"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:351
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:384
 msgid "Enable ipcomp compression"
 msgstr "啟用 ipcomp 壓縮"
 
@@ -191,7 +208,7 @@ msgid "Enabled"
 msgstr "已啟用"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:104
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:386
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:457
 msgid "Encryption Algorithm"
 msgstr "加密演算法"
 
@@ -199,7 +216,7 @@ msgstr "加密演算法"
 msgid "Encryption Keysize"
 msgstr "加密金鑰大小"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:447
 msgid "Encryption Proposals"
 msgstr "加密提案"
 
@@ -207,12 +224,8 @@ msgstr "加密提案"
 msgid "Established"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
-msgid "Gateway (Remote Endpoint)"
-msgstr "閘道 (遠端端點)"
-
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:80
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:248
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:279
 msgid "General"
 msgstr "一般"
 
@@ -224,7 +237,7 @@ msgstr "一般設定"
 msgid "Grant access to luci-app-strongswan-swanctl"
 msgstr "授予存取 luci-app-strongswan-swanctl 的權限"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:355
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:388
 msgid "H/W Offload"
 msgstr "H/W 卸載"
 
@@ -232,7 +245,7 @@ msgstr "H/W 卸載"
 msgid "Half-Open IKE_SAs"
 msgstr "半開放 IKE_SA"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:394
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:465
 msgid "Hash Algorithm"
 msgstr "雜湊演算法"
 
@@ -248,37 +261,46 @@ msgstr "小時"
 msgid "ID"
 msgstr "ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
 msgid "IKE Fragmentation"
 msgstr "IKE 分片"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:149
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:147
 msgid "IKE authentication (phase 1)"
 msgstr "IKE 認證 (階段 1)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:224
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:247
 msgid ""
 "IKEv2 interval to refresh keying material; also used to compute lifetime"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:95
+msgid "IP address or FQDN name of the tunnel local endpoints."
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:89
-msgid "IP address or FQDN name of the tunnel remote endpoint"
-msgstr "隧道遠端端點的 IP 位址或 FQDN 名稱"
+msgid "IP address or FQDN name of the tunnel remote endpoints."
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
-msgid "IP address or FQDN of the tunnel local endpoint"
-msgstr "隧道本地端點的 IP 位址或 FQDN"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:350
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
 msgid "IPComp"
 msgstr "IPComp"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:90
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:96
+msgid "If no value is specified, \"%any\" is assumed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+msgid "If not configured, the default value is \"1h\"."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:142
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:306
 msgid "Inactive"
 msgstr "非活動"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:218
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:240
 msgid "Inactivity"
 msgstr ""
 
@@ -290,41 +312,50 @@ msgstr "安裝時間"
 msgid "Interfaces that accept VPN traffic."
 msgstr "接受 VPN 流量的介面。"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:219
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:367
+msgid "Interval before a CHILD_SA is rekeyed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:241
 msgid "Interval before closing an inactive CHILD_SA"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
 msgid "Interval to check liveness of a peer"
 msgstr "檢查對等點在線狀況的間隔"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:233
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
 msgid "Keyexchange"
 msgstr "金鑰交換"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
 msgid "Keying Retries"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:417
+msgid "Life Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:436
+msgid "Life Packets"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:108
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:376
 msgid "Life Time"
 msgstr "生命週期"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:331
-msgid "Lifetime"
-msgstr "生命週期"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
 msgid "Limit on time to complete rekeying/reauthentication"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:306
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
 msgid ""
 "List of ESP (phase two) proposals. Only Proposals with checked ESP flag are "
 "selectable"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:109
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:107
 msgid "List of IKE (phase 1) proposals to use for authentication"
 msgstr ""
 
@@ -340,39 +371,27 @@ msgstr "本地位址"
 msgid "Local Auth"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:174
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:172
 msgid "Local Certificate"
 msgstr "本地憑證"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:93
-msgid "Local Gateway"
-msgstr "本地閘道"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:94
+msgid "Local Endpoints"
+msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:103
-msgid "Local IP"
-msgstr "本地 IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:154
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:152
 msgid "Local Identifier"
 msgstr "本地識別碼"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:180
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:178
 msgid "Local Key"
 msgstr "本地金鑰"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:263
-msgid "Local NAT"
-msgstr "本地 NAT"
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:87
 msgid "Local Port"
 msgstr "本地連接埠"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:98
-msgid "Local Source IP"
-msgstr "本地來源 IP"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:282
 msgid "Local Subnet"
 msgstr "本地子網路"
 
@@ -381,28 +400,32 @@ msgstr "本地子網路"
 msgid "Local Traffic Selectors"
 msgstr "本地流量選擇器"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:104
-msgid "Local address(es) to use in IKE negotiation"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:155
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:153
 msgid "Local identifier for IKE (phase 1)"
 msgstr "IKE (階段 1) 本地識別碼"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:252
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:283
 msgid "Local network(s)"
 msgstr "本地網路"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:192
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:212
 msgid "MOBIKE"
 msgstr "MOBIKE"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:193
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:213
 msgid "MOBIKE (IKEv2 Mobility and Multihoming Protocol)"
 msgstr "MOBIKE (IKEv2 移動性與多重主目錄協定)"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:332
-msgid "Maximum duration of the CHILD_SA before closing"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:418
+msgid "Maximum number of bytes processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:437
+msgid "Maximum number of packets processed before the CHILD_SA gets closed."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:377
+msgid "Maximum time before the CHILD_SA gets closed, as a hard limit."
 msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:24
@@ -417,10 +440,6 @@ msgstr "分鐘"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:126
 msgid "Mode"
 msgstr "模式"
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:264
-msgid "NAT range for tunnels with overlapping IP addresses"
-msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:83
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:98
@@ -437,19 +456,27 @@ msgstr "名稱長度不得超過 15 個字元"
 msgid "Number must have suffix s, m, h or d"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+msgid "Number of bytes processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:427
+msgid "Number of packets processed before initiating CHILD_SA rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:229
 msgid "Number of retransmissions attempts during initial negotiation"
 msgstr "初始協商期間的重傳嘗試次數"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
+msgid "On this page, you can configure the IPsec connections."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:11
 msgid "On this page, you can configure the IPsec service."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:70
-msgid "On this page, you can configure the IPsec tunnels and remotes."
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:228
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:251
 msgid "Overtime"
 msgstr "逾時"
 
@@ -457,45 +484,45 @@ msgstr "逾時"
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:408
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:479
 msgid "PRF Algorithm"
 msgstr "PRF 演算法"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:415
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:486
 msgid ""
 "PRF Algorithm must be configured when using an Authenticated Encryption "
 "Algorithm"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:327
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:353
 msgid "Path to script to run on CHILD_SA up/down events"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:118
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:116
 msgid "Please create a Proposal first"
 msgstr "請先建立提案"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:137
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:135
 msgid "Please create a Tunnel first"
 msgstr "請先建立隧道"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:315
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:341
 msgid "Please create an ESP Proposal first"
 msgstr "請先建立 ESP 提案"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:166
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:164
 msgid "Pre-Shared Key"
 msgstr "預共享金鑰"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:363
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:396
 msgid "Priority"
 msgstr "優先級"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:364
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:397
 msgid "Priority of the CHILD_SA"
 msgstr "CHILD_SA 優先級"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:181
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:179
 msgid "Private key pathname to use with above certificate"
 msgstr ""
 
@@ -512,8 +539,16 @@ msgstr "查詢 strongSwan 失敗"
 msgid "Reauthentication Interval"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:223
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:345
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:407
+msgid "Rekey Bytes"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:426
+msgid "Rekey Packets"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:246
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:366
 msgid "Rekey Time"
 msgstr ""
 
@@ -534,11 +569,19 @@ msgstr "遠端位址"
 msgid "Remote Auth"
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:189
+msgid "Remote CA Certificates"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:74
 msgid "Remote Configuration"
 msgstr "遠端配置"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:160
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:88
+msgid "Remote Endpoints"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:158
 msgid "Remote Identifier"
 msgstr "遠端識別碼"
 
@@ -546,7 +589,7 @@ msgstr "遠端識別碼"
 msgid "Remote Port"
 msgstr "遠端連接埠"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
 msgid "Remote Subnet"
 msgstr "遠端子網路"
 
@@ -555,33 +598,29 @@ msgstr "遠端子網路"
 msgid "Remote Traffic Selectors"
 msgstr "遠端流量選擇器"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:161
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:159
 msgid "Remote identifier for IKE (phase 1)"
 msgstr "IKE (階段 1) 遠端識別碼"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:289
 msgid "Remote network(s)"
 msgstr "遠端網路"
-
-#: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:16
-msgid "Remote/Tunnel"
-msgstr ""
-
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:69
-msgid "Remote/Tunnel configuration"
-msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:46
 msgid "Remotes, Encryption Proposals and Tunnels may not share the same names."
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:368
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:401
 msgid "Replay Window"
 msgstr "重播視窗"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:369
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:402
 msgid "Replay Window of the CHILD_SA"
 msgstr "CHILD_SA 的重播視窗"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:190
+msgid "Restrict the remote peer's certificate to be issued by one of these CAs"
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:110
 msgid "SPI in"
@@ -603,6 +642,20 @@ msgstr "秒"
 msgid "Select an interface or leave empty for all interfaces."
 msgstr ""
 
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:196
+msgid "Send Certificate"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:206
+msgid "Send Certificate Request"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:207
+msgid ""
+"Send certificate request payloads to offer trusted root CA certificates to "
+"the peer"
+msgstr ""
+
 #: applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json:24
 msgid "Service"
 msgstr "服務"
@@ -622,7 +675,7 @@ msgstr ""
 msgid "Start"
 msgstr "啟動"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:288
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:314
 msgid "Start Action"
 msgstr ""
 
@@ -638,23 +691,35 @@ msgstr "狀態"
 msgid "Stop"
 msgstr "停止"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:130
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:128
 msgid "The Tunnel containing the ESP (phase 2) section"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:167
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:165
 msgid "The pre-shared key for the tunnel"
 msgstr "隧道預共享金鑰"
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:258
+msgid ""
+"This makes the peer believe that a NAT situation exist on the transmission "
+"path, forcing it to encapsulate ESP packets in UDP."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:257
+msgid ""
+"To enforce UDP encapsulation of ESP packets, the IKE daemon can manipulate "
+"the NAT detection payloads."
+msgstr ""
 
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/strongswan.js:25
 msgid "Trace level: 0 is least verbose, 4 is most"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:129
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:127
 msgid "Tunnel"
 msgstr "隧道"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:242
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:273
 msgid "Tunnel Configuration"
 msgstr "隧道配置"
 
@@ -662,7 +727,7 @@ msgstr "隧道配置"
 msgid "Unique ID"
 msgstr "唯一 ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:326
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:352
 msgid "Up/Down Script Path"
 msgstr ""
 
@@ -670,7 +735,20 @@ msgstr ""
 msgid "Uptime"
 msgstr "上線時間"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:198
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:419
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:438
+msgid "Use \"0\" to disable (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:410
+msgid "Use \"0\" to disable byte based rekeying."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:429
+msgid "Use \"0\" to disable packet based rekeying (default)."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:220
 msgid "Use IKE fragmentation"
 msgstr "使用 IKE 分片"
 
@@ -678,7 +756,13 @@ msgstr "使用 IKE 分片"
 msgid "Use combinations like tunnel1_phase1 that do not exceed 15 characters."
 msgstr "使用像 tunnel1_phase1 這樣不超過 15 個字元的組合。"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:370
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:259
+msgid ""
+"Usually this is not required but it can help to work around connectivity "
+"issues with too restrictive intermediary firewalls that block ESP packets."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:403
 msgid "Values larger than 32 are supported by the Netlink backend only"
 msgstr "大於 32 的值只被 Netlink 後端支援"
 
@@ -687,28 +771,36 @@ msgstr "大於 32 的值只被 Netlink 後端支援"
 msgid "Version"
 msgstr "版本"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:234
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:265
 msgid "Version of IKE for negotiation"
 msgstr "IKE 協商版本"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:99
-msgid "Virtual IP(s) to request in IKEv2 configuration payloads requests"
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:101
+msgid "Virtual IP addresses"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:383
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:102
+msgid "Virtual IP addresses used as the source IP for outgoing traffic."
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:454
 msgid "Whether this is an ESP (phase 2) proposal or not"
 msgstr ""
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:269
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:197
+msgid "Whether to send our own certificate to the remote peer"
+msgstr ""
+
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:295
 msgid "XFRM interface ID set on input and output interfaces"
 msgstr "設定在傳入和傳出介面上的 XFRM 介面 ID"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "both"
 msgstr "兩者"
 
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:235
-#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:237
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:266
+#: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/swanctl.js:268
 msgid "deprecated"
 msgstr "已棄用"
 
@@ -720,6 +812,30 @@ msgstr "strongSwan IPsec"
 #: applications/luci-app-strongswan-swanctl/htdocs/luci-static/resources/view/strongswan-swanctl/status.js:344
 msgid "strongSwan Status"
 msgstr "strongSwan 狀態"
+
+#~ msgid "Gateway (Remote Endpoint)"
+#~ msgstr "閘道 (遠端端點)"
+
+#~ msgid "IP address or FQDN name of the tunnel remote endpoint"
+#~ msgstr "隧道遠端端點的 IP 位址或 FQDN 名稱"
+
+#~ msgid "IP address or FQDN of the tunnel local endpoint"
+#~ msgstr "隧道本地端點的 IP 位址或 FQDN"
+
+#~ msgid "Lifetime"
+#~ msgstr "生命週期"
+
+#~ msgid "Local Gateway"
+#~ msgstr "本地閘道"
+
+#~ msgid "Local IP"
+#~ msgstr "本地 IP"
+
+#~ msgid "Local NAT"
+#~ msgstr "本地 NAT"
+
+#~ msgid "Local Source IP"
+#~ msgstr "本地來源 IP"
 
 #~ msgid "Configure strongSwan for secure VPN connections."
 #~ msgstr "配置 strongSwan 以建立安全 VPN 連線。"

--- a/applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json
+++ b/applications/luci-app-strongswan-swanctl/root/usr/share/luci/menu.d/luci-app-strongswan-swanctl.json
@@ -13,7 +13,7 @@
 		}
 	},
 	"admin/vpn/strongswan-swanctl/swanctl": {
-		"title": "Remote/Tunnel",
+		"title": "Connections",
 		"order": 10,
 		"action": {
 			"type": "view",


### PR DESCRIPTION

## Pull request details

### Description
```
luci-app-strongswan-swanctl: rename swanctl section to connection

The name 'Remote/Tunnel Configuration' is too narrow. Encryption settings
can also be configured on this page. To better reflect this, the section
is renamed to 'Connection'. This makes it clear that additional settings
related to the connection can also be configured there.
```

```
uci-app-strongswan-swanctl: sync I18n

Update I18n with the latest changes
```