### PR TITLE
luci-base: fix lookup of non-present menu nodes

### DIFF
--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -758,7 +758,7 @@ function lookup(...segments) {
 			push(path, name);
 
 	for (let name in path) {
-		node = node.children[name];
+		node = node.children?.[name];
 
 		if (!node)
 			return null;


### PR DESCRIPTION
## Pull request details

### Description
This surfaced when I tried developing based purely on luci-base, without any of the status, system, or network modules. The menu entries for these modules live in luci-base, while the actions (templates/views) live in the respective modules.

The header.ut template renders links to these menu entries, which fails because lookup() expects them to be present in the menu_json structure, which they are not.
The template already anticipates that lookup() might fail, just lookup() itself didn't seem to yet.

The resulting exception:

    Reference error
    Unhandled exception during request dispatching
    left-hand side expression is null

    In lookup(), file /usr/share/ucode/luci/dispatcher.uc, line 762, byte 24:
      called from function main (/usr/share/ucode/luci/template/themes/bootstrap/header.ut:61:51)
      called from function call ([C])
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:80:36)
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:127:40)
      called from function [arrow function] (/usr/share/ucode/luci/runtime.uc:183:57)
      called from function main (/usr/share/ucode/luci/template/header.ut:7:34)
      called from function call ([C])
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:80:36)
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:127:40)
      called from function [arrow function] (/usr/share/ucode/luci/runtime.uc:183:57)
      called from function main (/usr/share/ucode/luci/template/view.ut:1:20)
      called from function call ([C])
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:80:36)
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:127:40)
      called from function [arrow function] (/usr/share/ucode/luci/runtime.uc:141:63)
      called from function render ([C])
      called from function [anonymous function] (/usr/share/ucode/luci/runtime.uc:141:64)
      called from function run_action (/usr/share/ucode/luci/dispatcher.uc:815:47)
      called from function [anonymous function] (/usr/share/ucode/luci/dispatcher.uc:1107:48)
      called from anonymous function (/usr/share/ucode/walter/web/index.uc:47:15)

              node = node.children[name];
      Near here -------------------^


### Maintainer _(preferred)_
@jow- 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt snapshot
**LuCI version:** LuCI Master (26.212.49915~fe9d6b4)
**Web browser(s):** Firefox 153.0.1

