### PR TITLE
luci-app-wifischedule: fix untranslated validation error message

### DIFF
--- a/applications/luci-app-wifischedule/htdocs/luci-static/resources/view/wifischedule/wifischedule.js
+++ b/applications/luci-app-wifischedule/htdocs/luci-static/resources/view/wifischedule/wifischedule.js
@@ -31,7 +31,7 @@ function timeValidator(value, desc) {
 			}
 		}
 	}
-	return _('The value %s is invalid'.format(desc));
+	return _('The value %s is invalid').format(desc);
 }
 
 return view.extend({


### PR DESCRIPTION
## Pull request details

### Description
Fix an issue where the error message was not being translated because the .format() method was incorrectly included inside the `_()` i18n wrapper function, preventing the i18n scanner from extracting the translation key.

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** SNAPSHOT
**LuCI version:** master
**Web browser(s):** Chrome

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
