### PR TITLE
luci-base: include original stacktrace in render exception

### DIFF
--- a/modules/luci-base/ucode/runtime.uc
+++ b/modules/luci-base/ucode/runtime.uc
@@ -130,7 +130,16 @@ const Class = {
 		}
 		catch (ex) {
 			pop(this.scopes);
-			die(ex);
+
+			// To enable the scope bookkeeping right above,
+			// we catch and re-throw the exception, losing its original stacktrace.
+			// To keep the original stacktrace, we inject it into the message itself.
+			// The exception gets re-thrown multiple times from nested render calls,
+			// so if its message already contains a stacktrace, we don't do anything.
+			if (index(ex.message, "Near here") < 0)
+				die(`${ex.message}\n\n${ex.stacktrace[0].context}`);
+
+			die(ex)
 		}
 
 		pop(this.scopes);


### PR DESCRIPTION
## Pull request details

### Description
In order to properly handle nested variable scopes, when an exception is thrown during the rendering of the template, it is caught and then re-thrown after some scope bookkeeping is done.

This means the exception loses its stacktrace information. The exception now has the stacktrace of the re-throw location, not the original stacktrace which would be much more useful.

Let's at least include that stacktrace in the message itself. It's not a clean solution, but better than not having this info at all.

Fixes #8909 


### Maintainer _(preferred)_
@jow- 

---

## Tested on

**OpenWrt version:** OpenWrt snapshot
**LuCI version:** LuCI master
**Web browser(s):** Firefox 153
