### PR TITLE
themes: fix custom CSS via menu.d node

### DIFF
--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -350,6 +350,7 @@ function build_pagetree() {
 		action: 'object',
 		auth: 'object',
 		cors: 'bool',
+		css: 'string',
 		depends: 'object',
 		order: 'int',
 		setgroup: 'string',

--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -35,8 +35,8 @@
 		<link rel="stylesheet" media="only screen and (max-device-width: 854px)" href="{{ media }}/mobile.css" />
 		<link rel="icon" href="{{ media }}/logo_48.png" sizes="48x48">
 		<link rel="icon" href="{{ media }}/logo.svg" sizes="any">
-		{% if (node?.css): %}
-		<link rel="stylesheet" href="{{ resource }}/{{ node.css }}">
+		{% if (dispatched?.css): %}
+		<link rel="stylesheet" href="{{ resource }}/{{ dispatched.css }}">
 		{% endif %}
 		{% if (css): %}
 		<style title="text/css">{{ css }}</style>

--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -45,7 +45,7 @@
 		<script src="{{ resource }}/cbi.js"></script>
 	</head>
 
-	<body class="lang_{{ dispatcher.lang }} {{ entityencode(striptags(node?.title ?? ''), true) }}" data-page="{{ entityencode(join('-', length(ctx.request_path) ? ctx.request_path : ctx.path), true) }}">
+	<body class="lang_{{ dispatcher.lang }}" data-page="{{ entityencode(join('-', length(ctx.request_path) ? ctx.request_path : ctx.path), true) }}">
 		{% if (!blank_page): %}
 		<header>
 			<a class="brand" href="/">{{ striptags(boardinfo.hostname ?? '?') }}</a>

--- a/themes/luci-theme-material/ucode/template/themes/material/header.ut
+++ b/themes/luci-theme-material/ucode/template/themes/material/header.ut
@@ -46,8 +46,8 @@
 <link rel="stylesheet" href="{{ media }}/cascade.css">
 <link rel="icon" href="{{ media }}/logo_48.png" sizes="48x48">
 <link rel="icon" href="{{ media }}/logo.svg" sizes="any">
-{% if (node?.css): %}
-<link rel="stylesheet" href="{{ resource }}/{{ node.css }}">
+{% if (dispatched?.css): %}
+<link rel="stylesheet" href="{{ resource }}/{{ dispatched.css }}">
 {% endif %}
 <script src="{{ dispatcher.build_url('admin/translations', dispatcher.lang) }}"></script>
 <script src="{{ resource }}/cbi.js"></script>

--- a/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut
+++ b/themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut
@@ -19,6 +19,9 @@
 <link rel="stylesheet" media="screen" href="{{ media }}/cascade.css" />
 <link rel="icon" href="{{ media }}/logo.png" sizes="180x180">
 <link rel="icon" href="{{ media }}/logo.svg" sizes="any">
+{% if (dispatched?.css): %}
+<link rel="stylesheet" href="{{ resource }}/{{ dispatched.css }}">
+{% endif %}
 <script src="{{ dispatcher.build_url('admin/translations', dispatcher.lang) }}"></script>
 <script src="{{ resource }}/cbi.js"></script>
 <title>{{ striptags(`${boardinfo.hostname ?? '?'}${dispatched?.title ? ` | ${_(dispatched.title)}` : ''}`) }}</title>

--- a/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
+++ b/themes/luci-theme-openwrt/ucode/template/themes/openwrt.org/header.ut
@@ -19,8 +19,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" media="screen" href="{{ media }}/cascade.css" />
-{% if (node?.css): %}
-<link rel="stylesheet" media="screen" href="{{ resource }}/{{ node.css }}" />
+{% if (dispatched?.css): %}
+<link rel="stylesheet" media="screen" href="{{ resource }}/{{ dispatched.css }}" />
 {% endif %}
 {% if (css): %}
 <style>{{ css }}</style>


### PR DESCRIPTION
## Pull request details

### Description

#### themes: fix custom CSS via menu.d node

The themes have supported custom CSS via menu.d nodes since they
were first ported to ucode. There were two little problems though:

- The css property wasn't added to the node schema in luci.dispatcher.
- The themes used the wrong variable name.

The advantage is that the client will load the custom CSS right away,
instead of later when the view initializes. In my local development,
it has prevented visual flickering on page load.

Example menu.d entry:

    "falter": {
      "title": "Settings",
      "order": 5,
      "action": {
        "type": "view",
        "path": "falter/settings"
      },
      "css": "view/falter/falter.css"
    }

There are lots of potential users for this, since many Luci applications
inject their CSS via client-side JS. Even luci-mod-network does.

#### luci-theme-bootstrap: remove broken title class on `<body>`

When the bootstrap theme was first ported to ucode, the dispatched
menu.d title was intended to be added to the <body> CSS classes.

It never worked because it uses the wrong variable name.
It also doesn't seem useful and other themes don't do it.

So let's just remove it.


### Maintainer _(preferred)_
@jow- 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt snapshot
**LuCI version:** LuCI master
**Web browser(s):** Firefox 153
