### PR TITLE
luci-app-natmap: allow reading status file under /tmp/run

### DIFF
--- a/applications/luci-app-natmap/root/usr/share/rpcd/acl.d/luci-app-natmap.json
+++ b/applications/luci-app-natmap/root/usr/share/rpcd/acl.d/luci-app-natmap.json
@@ -3,7 +3,8 @@
 		"description": "Grant access to LuCI app natmap",
 		"read": {
 			"file": {
-				"/var/run/natmap/*": [ "read" ]
+				"/var/run/natmap/*": [ "read" ],
+				"/tmp/run/natmap/*": [ "read" ]
 			},
 			"ubus": {
 				"service": [ "list" ]


### PR DESCRIPTION
## Description

Fixes natmap status not displaying in LuCI (External IP/Port shows `none`) on recent OpenWrt releases.

**Root cause:** rpcd's file plugin now performs a second ACL check against the real path of symlinks (openwrt/rpcd commit e37ed9d814699098eb7e26c8b33c054840782dfb). On OpenWrt, `/var/run` resolves to `/tmp/run`, so reading `/var/run/natmap/<pid>.json` is checked against the resolved path `/tmp/run/natmap/<pid>.json`, which is not covered by the current ACL (`/var/run/natmap/*`). The read is rejected and `natmap.js` silently ignores the error, so the status view shows nothing.

**Fix:** add the resolved path `/tmp/run/natmap/*` to the read ACL.

Reported and root-caused in heiher/natmap#134, confirmed working by multiple users.

## Test

- Confirmed by reporter (heiher) via experiment
- Confirmed by user taotaowudi: adding `"/tmp/run/natmap/*": [ "read" ]` makes the status display correctly