### PR TITLE
[openwrt-25.12] luci-app-natmap: allow reading status file under /tmp/run

### DIFF
--- a/applications/luci-app-natmap/root/usr/share/rpcd/acl.d/luci-app-natmap.json
+++ b/applications/luci-app-natmap/root/usr/share/rpcd/acl.d/luci-app-natmap.json
@@ -3,7 +3,8 @@
 		"description": "Grant access to LuCI app natmap",
 		"read": {
 			"file": {
-				"/var/run/natmap/*": [ "read" ]
+				"/var/run/natmap/*": [ "read" ],
+				"/tmp/run/natmap/*": [ "read" ]
 			},
 			"ubus": {
 				"service": [ "list" ]


### PR DESCRIPTION
Backport of #8923 to openwrt-25.12.

**Root cause:** rpcd's file plugin now checks ACL against the real path of symlinks (openwrt/rpcd e37ed9d), so /var/run/natmap/* (resolving to /tmp/run/natmap/*) is rejected and the LuCI status view shows none on 25.12.5.

**Fix:** add `/tmp/run/natmap/*` to the read ACL.

Ref: heiher/natmap#134