### PR TITLE
luci-app-nut: add/update SSL configuration for full support

### DIFF
--- a/applications/luci-app-nut/Makefile
+++ b/applications/luci-app-nut/Makefile
@@ -12,7 +12,7 @@ PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca> \
 		Paul Donald <newtwen+github@gmail.com>
 
-EXTRA_DEPENDS:=nut (>= 2.8.4-3)
+LUCI_EXTRA_DEPENDS:=nut (>=2.8.4-r3)
 
 include ../../luci.mk
 

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js
@@ -1,9 +1,6 @@
 'use strict';
 'require form';
-'require fs';
 'require view';
-
-const upsmon_tool = '/usr/sbin/upsmon';
 
 function ESIFlags(o) {
 	o.value('EXEC', _('Execute notify command'));
@@ -50,19 +47,8 @@ function MonitorUserOptions(s) {
 }
 
 return view.extend({
-	load: function() {
-		return Promise.all([
-			L.resolveDefault(fs.exec_direct('/usr/bin/ldd', [upsmon_tool]), []).catch(function(err) {
-				throw new Error(_('Unable to run ldd: %s').format(err.message));
-			}).then(function(stdout) {
-				return stdout.includes('libssl.so');
-			}),
-		])
-	},
-
-	render: function(loaded_promises) {
+	render: function() {
 		let m, s, o;
-		const have_ssl_support = loaded_promises[0];
 
 		m = new form.Map('nut_monitor', _('NUT Monitor'),
 			_('Network UPS Tools Monitoring Configuration'));
@@ -94,16 +80,6 @@ return view.extend({
 		o.datatype = 'uinteger'
 		o.optional = true;
 		o.placeholder = 15;
-
-		if (have_ssl_support) {
-			o = s.option(form.Value, 'certpath', _('CA Certificate path'), _('Path containing ca certificates to match against host certificate'));
-			o.optional = true;
-			o.placeholder = '/etc/ssl/certs'
-
-			o = s.option(form.Flag, 'certverify', _('Verify all connection with SSL'), _('Require SSL and make sure server CN matches hostname'));
-			o.optional = true;
-			o.default = false;
-		}
 
 		s = m.section(form.TypedSection, 'notifications', _('Notifications settings'));
 		s.optional = true;

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js
@@ -1,14 +1,29 @@
 'use strict';
 'require form';
+'require fs';
 'require view';
+
+const ups_ssl_backend_file = '/usr/share/nut/ssl_backend';
+const upsmon_daemon = '/usr/sbin/upsmon';
 
 return view.extend({
 	load: function() {
-
+		return Promise.all([
+			fs.trimmed(ups_ssl_backend_file).then(function(backend) {
+				if (backend)
+					return backend;
+				// nut older than 2.8.5-5 does not ship ssl_backend, so probe the binary instead
+				return L.resolveDefault(fs.exec_direct('/usr/bin/ldd', [upsmon_daemon]), '').then(function(stdout) {
+					return stdout.includes('libssl.so') ? 'old_nut_openssl' : 'none';
+				});
+			}),
+		])
 	},
 
-	render: function() {
+	render: function(loaded_promises) {
 		let m, s, o;
+
+		const ssl_support_type = loaded_promises[0];
 
 		m = new form.Map('nut_monitor', _('NUT Monitor'),
 			_('Network UPS Tools Monitoring Configuration'));
@@ -26,6 +41,51 @@ return view.extend({
 		o = s.option(form.Value, 'shutdowncmd', _('Shutdown command'));
 		o.optional = true;
 		o.placeholder = '/usr/sbin/nutshutdown'
+
+		if (ssl_support_type == 'openssl') {
+			o = s.option(form.FileUpload, 'certfile', _('Client certificate chain and private key'), _('PEM file containing client certificate chain and private key (OpenSSL)'));
+			o.rmempty = true;
+			o.optional = true;
+		}
+
+		if (ssl_support_type == 'openssl' || ssl_support_type == 'old_nut_openssl') {
+			// For OpenSSL, certpath is a PEM file, not a database directory as with NSS
+			o = s.option(form.FileUpload, 'certpath', _('CA certificate(s)'), _('PEM file containing the CA certificate(s) (OpenSSL)'));
+			o.rmempty = true;
+			o.optional = true;
+		}
+
+		if (ssl_support_type == 'nss') {
+			// For NSS, certpath is a database directory, not a PEM file as with OpenSSL.
+			// We do not fill this field by default as the default database has no certificates,
+			// and must be filled to be useful. Doing this through the UI is a future task.
+			o = s.option(form.Value, 'certpath', _('Path to NSS certificate and key databases'), _('An empty database was created in /etc/nut/cert_db at package install. To use it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field.'));
+			o.optional = true;
+		}
+
+		if (ssl_support_type == 'openssl' || ssl_support_type == 'nss') {
+			o = s.option(form.Value, 'certident', _('Certificate name and password'), _('"Certificate name" and "certificate password" need to be entered in double-quotes (") if the value has a space in it. An empty password must be entered as an empty pair of double-quotes ("")'));
+			o.placeholder = '"certificate name" "certificate password"';
+			o.password = true;
+		}
+
+		if (ssl_support_type == 'openssl' || ssl_support_type == 'old_nut_openssl' || ssl_support_type == 'nss') {
+			o = s.option(form.Flag, 'certverify', _('Verify all connections with SSL'), _('Require SSL and verify host certificate'));
+			o.optional = true;
+			o.default = false;
+			o.rmempty = false
+
+			o = s.option(form.Flag, 'forcessl', _('Require SSL to connect'), _('Require SSL even if not verifying host certificates'));
+			o.optional = true;
+			o.default = false;
+			o.rmempty = false;
+		}
+
+		if (ssl_support_type == 'openssl' || ssl_support_type == 'nss') {
+			o = s.option(form.DynamicList, 'certhost', _('Per-host override for certident, certverify, and forcessl'), _('hostname "certificate name" certverify (as 0 or 1) forcessl (as 0 or 1)'));
+			o.optional = true;
+			o.placeholder = 'hostname "certificate name" certverify forcessl';
+		}
 
 		return m.render();
 	}

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js
@@ -5,7 +5,6 @@
 
 const driver_path = '/usr/libexec/nut/';
 const old_driver_path = '/lib/nut/';
-const ups_daemon = '/usr/sbin/upsd';
 
 function resolveDriverList(path) {
 	return Promise.resolve(L.resolveDefault(fs.list(path), []).then(function(entries) {
@@ -24,11 +23,6 @@ function resolveDriverList(path) {
 return view.extend({
 	load: function() {
 		return Promise.all([
-			L.resolveDefault(fs.exec_direct('/usr/bin/ldd', [ups_daemon]), []).catch(function(err) {
-				throw new Error(_('Unable to run ldd: %s').format(err.message));
-			}).then(function(stdout) {
-				return stdout.includes('libssl.so');
-			}),
 			resolveDriverList(driver_path),
 			resolveDriverList(old_driver_path),
 		])
@@ -36,8 +30,8 @@ return view.extend({
 
 	render: function(loaded_promises) {
 		let m, s, o;
-		const have_ssl_support = loaded_promises[0];
-		const driver_list = (loaded_promises[1].length > 0) ? loaded_promises[1] : loaded_promises[2];
+
+		const driver_list = (loaded_promises[0].length > 0) ? loaded_promises[0] : loaded_promises[1];
 
 		m = new form.Map('nut_server', _('NUT Server'),
 			_('Network UPS Tools Server Configuration'));
@@ -98,11 +92,6 @@ return view.extend({
 		o.optional = true;
 		o.datatype = 'uinteger'
 		o.placeholder = 24;
-
-		if (have_ssl_support) {
-			o = s.option(form.Value, 'certfile', _('Certificate file (SSL)'));
-			o.optional = true;
-		}
 
 		// Drivers global settings
 		s = m.section(form.NamedSection, 'driver_global', 'driver_global', _('Driver Global Settings'));

--- a/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js
+++ b/applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js
@@ -1,14 +1,29 @@
 'use strict';
 'require form';
+'require fs';
 'require view';
+
+const ups_ssl_backend_file = '/usr/share/nut/ssl_backend';
+const ups_daemon = '/usr/sbin/upsd';
 
 return view.extend({
 	load: function() {
-
+		return Promise.all([
+			fs.trimmed(ups_ssl_backend_file).then(function(backend) {
+				if (backend)
+					return backend;
+				// nut older than 2.8.5-5 does not ship ssl_backend, so probe the binary instead
+				return L.resolveDefault(fs.exec_direct('/usr/bin/ldd', [ups_daemon]), '').then(function(stdout) {
+					return stdout.includes('libssl.so') ? 'old_nut_openssl' : 'none';
+				});
+			}),
+		])
 	},
 
-	render: function() {
+	render: function(loaded_promises) {
 		let m, s, o;
+
+		const ssl_support_type = loaded_promises[0];
 
 		m = new form.Map('nut_server', _('NUT Server'),
 			_('Network UPS Tools Server Configuration'));
@@ -24,6 +39,43 @@ return view.extend({
 		o = s.option(form.Value, 'statepath', _('Path to state file'));
 		o.optional = true;
 		o.placeholder = '/var/run/nut'
+
+		if (ssl_support_type == 'openssl' || ssl_support_type == 'old_nut_openssl') {
+			o = s.option(form.FileUpload, 'certfile', _('Server certificate chain and private key'), _('PEM file containing server certificate chain and private key (OpenSSL)'));
+			o.rmempty = true;
+			o.optional = true;
+		}
+
+		if (ssl_support_type == 'openssl') {
+			// For OpenSSL, certpath is a PEM file, not a database directory as with NSS
+			o = s.option(form.FileUpload, 'certpath', _('CA certificate(s)'), _('PEM file containing the CA certificate(s) (OpenSSL)'));
+			o.rmempty = true;
+			o.optional = true;
+		}
+
+		if (ssl_support_type == 'nss') {
+			// For NSS, certpath is a database directory, not a PEM file as with OpenSSL.
+			// We do not fill this field by default as the default database has no certificates,
+			// and must be filled to be useful. Doing this through the UI is a future task.
+			o = s.option(form.Value, 'certpath', _('Path to NSS certificate and key databases'), _('An empty database was created in /etc/nut/cert_db at package install. To use it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field.'));
+			o.optional = true;
+		}
+
+		if (ssl_support_type == 'openssl' || ssl_support_type == 'nss') {
+			o = s.option(form.Value, 'certident', _('Certificate name and password'), _('"Certificate name" and "certificate password" need to be entered in double-quotes (") if the value has a space in it. An empty password must be entered as an empty pair of double-quotes ("")'));
+			o.placeholder = '"certificate name" "certificate password"';
+			o.password = true;
+
+			o = s.option(form.ListValue, 'certrequest', _('Certificate request level'), _('Whether to request a client certificate and whether to validate a requested client certificate'));
+			o.value('0', _('NO (do not request or verify a client certificate)'));
+			o.value('1', _('REQUEST (any client certificate)'));
+			o.value('2', _('REQUIRE (and verify)'));
+
+			o = s.option(form.Flag, 'disable_weak_ssl', _('Disable weak SSL'), _('Require at least TLSv1.2 for SSL communications'));
+			o.rmempty = false;
+			o.optional = false;
+			o.default = true;
+		}
 
 		return m.render();
 	}

--- a/applications/luci-app-nut/po/ar/nut.po
+++ b/applications/luci-app-nut/po/ar/nut.po
@@ -13,101 +13,130 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "برنامج تشغيل"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -115,41 +144,41 @@ msgstr ""
 msgid "Enable"
 msgstr "شغل"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "الاعدادات العامة"
 
@@ -158,7 +187,7 @@ msgstr "الاعدادات العامة"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -170,7 +199,7 @@ msgstr ""
 msgid "Host"
 msgstr "ضيف"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -178,77 +207,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "عنوان الـ IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "تجاهل"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -264,17 +297,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -294,7 +327,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -307,204 +340,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "كلمة المرور"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "المنفذ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "سيد"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -512,65 +587,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "اسم المستخدم"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/az/nut.po
+++ b/applications/luci-app-nut/po/az/nut.po
@@ -7,101 +7,130 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -109,41 +138,41 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -152,7 +181,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -164,7 +193,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -172,77 +201,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -258,17 +291,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -288,7 +321,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -301,204 +334,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -506,65 +581,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/be/nut.po
+++ b/applications/luci-app-nut/po/be/nut.po
@@ -11,101 +11,130 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -113,41 +142,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Уключыць"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -156,7 +185,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -168,7 +197,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -176,77 +205,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -262,17 +295,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -292,7 +325,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -305,204 +338,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -510,65 +585,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/bg/nut.po
+++ b/applications/luci-app-nut/po/bg/nut.po
@@ -12,104 +12,133 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Допълнително време за изключване"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Адреси на които да слуша"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Позволени действия"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Управление на UPS чрез CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Мъртво време"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "По подразбиране за UPS-ите без това поле."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 #, fuzzy
 msgid "Delay for kill power command"
 msgstr "Закъснение преди команда за спиране (kill)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Закъснение за включване на UPS, ако захранването се възстанови след спиране "
 "на захранването"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Описание (Дисплей)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Показано име"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Не заключвайте порта при стартиране на драйвъра"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Драйвър"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Конфигурация на Драйвър"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Глобални настройки на Драйвър"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Премахване на правата на този потребител"
 
@@ -117,41 +146,41 @@ msgstr "Премахване на правата на този потребит�
 msgid "Enable"
 msgstr "Активиране"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Принудително изключване"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Глобални настройки"
 
@@ -160,7 +189,7 @@ msgstr "Глобални настройки"
 msgid "Go to NUT CGI"
 msgstr "Отиди към NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -172,7 +201,7 @@ msgstr ""
 msgid "Host"
 msgstr "Хост"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -180,78 +209,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Hostname или IP адрес"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP адрес"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Игнориране"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Игнориране на изтощена батерия"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Само прекъсване"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Размер на прекъсване"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 #, fuzzy
 msgid "Manufacturer (Display)"
 msgstr "Производител (Дисплей)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Максимална отчетена дължина на USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Максимална възраст на данни"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Максимален брой повторения"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -267,17 +300,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -297,7 +330,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -310,204 +343,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Мастер"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -515,66 +590,72 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Потребителско име"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
 

--- a/applications/luci-app-nut/po/bn_BD/nut.po
+++ b/applications/luci-app-nut/po/bn_BD/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "সক্রিয় করুন"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "আইপি এড্রেস"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "পোর্ট"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/ca/nut.po
+++ b/applications/luci-app-nut/po/ca/nut.po
@@ -13,101 +13,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Temps Addicional d'Apagat"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Direccions en les que escoltar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Accions permeses"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Tal com està configurat per NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes per llegir del tub d’interrupció"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Ruta del Certificat CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Certificat SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Controlar UPS mitjançant CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -115,41 +144,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Activa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Configuració global"
 
@@ -158,7 +187,7 @@ msgstr "Configuració global"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -170,7 +199,7 @@ msgstr ""
 msgid "Host"
 msgstr "Amfitrió"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -178,77 +207,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -264,17 +297,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -294,7 +327,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -307,204 +340,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Contrasenya"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -512,68 +587,80 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nom d'usuari"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Ruta del Certificat CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Certificat SSL"
 
 #~ msgid "Communications lost message"
 #~ msgstr "Missatge perdut de comunicacions"

--- a/applications/luci-app-nut/po/cs/nut.po
+++ b/applications/luci-app-nut/po/cs/nut.po
@@ -12,103 +12,132 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Dodatečný čas k vypnutí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresy na kterých očekávat spojení"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Povolené akce"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Jak nastaveno NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Pomocné"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Pomocné (zastaralé)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Kolik bajtů číst z roury přerušení"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Popis umístění certifikátu cert. autority"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Soubor s certifikátem (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Ovládat záložní zdroj prostřednictvím CGI rozhraní"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Uživatelsky určená zpráva upozornění pro typ zprávy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Délka nekomunikace pro považování za vybitou"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Výchozí pro UPS zdroje bez této kolonky."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Prodleva pro příkaz utínající napájení"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Po utnutí napájení do připojených zařízení, odložit zapnutí UPS zdroje po "
 "obnovení dodávek elektřiny ze sítě"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Popis (zobrazení)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Zobrazovaný název"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Nezamykat port při spouštění ovladače"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Ovladač"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Nastavení ovladače"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Globální nastavení ovladače"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Pořadí vypínání ovladače"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "Ovladač čeká až budou data použita upsd a až pak odešle další."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Snížit práva na úroveň tohoto uživatele"
 
@@ -116,7 +145,7 @@ msgstr "Snížit práva na úroveň tohoto uživatele"
 msgid "Enable"
 msgstr "Povolit"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -124,11 +153,11 @@ msgstr ""
 "Povoluje skript pro připojování za chodu, který dělá skupinu všech ttyUSB "
 "zařízení (např. sériové USB) čitelnou-zapisovatelnou pro uživatele %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Spustit notifikační příkaz"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -136,7 +165,7 @@ msgstr ""
 "Pro UPS zdroje, založené na USB HID, je pro NUT potřeba USB product id "
 "(kvůli nastavení oprávnění, aby ovladač k UPS mohl přistupovat)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -144,7 +173,7 @@ msgstr ""
 "Pro UPS zdroje, založené na USB HID, je pro NUT potřeba USB vendor id (kvůli "
 "nastavení oprávnění, aby ovladač k UPS mohl přistupovat)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -154,12 +183,12 @@ msgstr ""
 "stejného typu (USB product a USB vendor jsou totožné). Ostatní UPS zdroje "
 "mohou také použít tuto hodnotu."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Vynucené vypnutí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Globální nastavení"
 
@@ -168,7 +197,7 @@ msgstr "Globální nastavení"
 msgid "Go to NUT CGI"
 msgstr "Přejít do NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Udělit luci-app-nut správcovský přístup do UCI nastavování"
 
@@ -180,7 +209,7 @@ msgstr "Udělit luci-app-nut omezený přístup pro čtení do UCI nastavování
 msgid "Host"
 msgstr "Hostitel"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Synchronizace hostitele"
 
@@ -188,78 +217,82 @@ msgstr "Synchronizace hostitele"
 msgid "Hostname or IP address"
 msgstr "Název hostitele nebo IP adresa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Název stroje nebo adresa UPS zdroje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP adresa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Pokud je tento seznam prázdný, je zapotřebí %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorovat"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorovat nízké nabití akumulátoru"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Okamžité příkazy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Pouze přerušit"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Velikost přerušení"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Výrobce (zobrazení)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Hlášená délka USB HID nejvýše"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Nejvyšší umožněné stáří dat"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Opakovaných pokusů nejvýše"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Prodleva spuštění nejvýše"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Počet spojení nejvýše"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Kolikrát nanejvýš se pokoušet ovladač spustit."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Nejdelší čas (v sekundách) mezi znovunačteními stavu UPS zdroje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Nejnižší potřebný počet napájecích zdrojů"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Model (zobrazení)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -274,17 +307,17 @@ msgstr "NUT CGI – správce"
 msgid "NUT CGI - main"
 msgstr "NUT CGI – hlavní"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "NUT monitor"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "NUT server"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT uživatelé"
 
@@ -304,7 +337,7 @@ msgstr "NUT server – správce"
 msgid "NUT server - main"
 msgstr "NUT server – hlavní"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Název UPS zdroje"
 
@@ -317,180 +350,220 @@ msgstr "Network UPS Tools"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Nastavení Network UPS Tools CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Nastavení monitorování v Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Nastavení serveru Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Žádný zámek"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Žádná OID přenosu nízké/vysoké napětí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Příznaky notifikace"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Nastavení notifikací"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Příkaz notifikace"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Prodlevy vypnutí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Prodlevy zapnutí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Heslo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Popis umístění obsahujícího certifikáty cert. autorit mezi kterými hledat "
-"shodu vůči certifikátu hostitele"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Popis umístění souboru se stavy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Doba, po jejímž uplynutí jsou data považována za už neaktuální"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Interval dotazování"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Četnost dotazování"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Dotazovat na výstrahu ohledně frekvence"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Četnosti dotazování"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Hodnota energie"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Hlavní"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Hlavní (zastaralé)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produkt (regulární výraz)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Vyžadovat SSL a ověřovat, že CN serveru se shoduje s názvem stroje"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Prodleva opakovaného pokusu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Role"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Spouštět ovladače v chroot(2) prostředí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Spouštět jako uživatel"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP komunita"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP opakované pokusy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP časové limity"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Verze SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Sériové číslo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Nastavit oprávnění k USB sériovému portu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Nastavit proměnné"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Příkaz pro vypnutí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Synchronní komunikace"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 "Název této sekce bude na ostatních místech používán jako název UPS zdroje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -498,30 +571,30 @@ msgstr ""
 "Toto je předáno ovladači, proto ověřte, zda tuto volbu konkrétní ovladač "
 "podporuje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Prodleva (v sekundách) mezi opětovnými pokusy o spuštění ovladače."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Doba (v sekundách), po kterou upsdrvctl bude čekat na dokončení spuštění "
 "ovladače"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "UPS pomocné (zastaralé)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "Nastavení uživatele monitoru UPS zdroje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "UPS hlavní (zastaralé)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Globální nastavení UPS serveru"
 
@@ -529,70 +602,96 @@ msgstr "Globální nastavení UPS serveru"
 msgid "UPS name"
 msgstr "Název UPS zdroje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB sběrnice (regulární výraz)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB identif. produktu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB identif. výrobce"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Není možné spustit ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Úplný seznam příkazů, které vámi používaný UPS zdroj podporuje, si zobrazíte "
 "pomocí %s (vyžaduje balíček %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Typ uživatele (hlavní/pomocný)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Výrobce (regulární výraz)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Ověřovat veškerá spojení pomocí SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Obejití problému pro chybový firmware"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Zapsat do syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Zapsat do syslog a spustit příkaz notify"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "nainstalovat ovladače"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon zredukuje svá privilegia na úroveň tohoto uživatele"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Popis umístění certifikátu cert. autority"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Soubor s certifikátem (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Popis umístění obsahujícího certifikáty cert. autorit mezi kterými hledat "
+#~ "shodu vůči certifikátu hostitele"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Vyžadovat SSL a ověřovat, že CN serveru se shoduje s názvem stroje"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Není možné spustit ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Ověřovat veškerá spojení pomocí SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Popis umístění ovladače"

--- a/applications/luci-app-nut/po/da/nut.po
+++ b/applications/luci-app-nut/po/da/nut.po
@@ -12,103 +12,132 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Yderligere nedlukningstid(er)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresser, hvor der skal lyttes"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Tilladte handlinger"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Som konfigureret af NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Auxiliary"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes, der skal læses fra interrupt pipe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA-certifikatsti"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Certifikatfil (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Styr UPS via CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Deadtime"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Standard for UPS'er uden dette felt."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Forsinkelse af kommando til at slukke strøm"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Forsinkelse af tænding af UPS, hvis strømmen vender tilbage efter at "
 "strømmen er blevet afbrudt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Beskrivelse (Visning)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Vis navn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Lås ikke porten, når du starter driveren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Driver konfiguration"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Driver globale indstillinger"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Driver Nedlukningsordre"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "Driver venter på, at data forbruges af upsd, før den udgiver mere."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Drop privilegier til denne bruger"
 
@@ -116,7 +145,7 @@ msgstr "Drop privilegier til denne bruger"
 msgid "Enable"
 msgstr "Aktiver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -124,35 +153,35 @@ msgstr ""
 "Aktiverer et hotplug-script, der gør alle ttyUSB-enheder (f.eks. seriel USB) "
 "til en gruppe, der læser og skriver som bruger 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Kør underretningskommando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Tvunget nedlukning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Globale indstillinger"
 
@@ -161,7 +190,7 @@ msgstr "Globale indstillinger"
 msgid "Go to NUT CGI"
 msgstr "Gå til NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -173,7 +202,7 @@ msgstr ""
 msgid "Host"
 msgstr "Vært"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -181,78 +210,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Værtsnavn eller IP-adresse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Værtsnavn eller adresse på UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP Address"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorer lavt batteri"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Direkte kommandoer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Kun afbrydelse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Afbrydelsesstørrelse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Producent (skærm)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Maksimal USB HID-længde rapporteret"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Maksimal alder af data"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Maksimalt antal genforsøg"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Maksimal startforsinkelse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Maksimale antal forbindelser"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Maksimalt antal forsøg på at starte en driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Maksimal tid i sekunder mellem opdatering af UPS-status"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Minimum nødvendigt antal eller strømforsyninger"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Model (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -267,17 +300,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "UPS-værktøjer til netværk (overvågning)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "UPS-værktøjer til netværk (server)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT-brugere"
 
@@ -297,7 +330,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Navn på UPS"
 
@@ -310,206 +343,248 @@ msgstr "UPS-værktøjer til netværk"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Netværk UPS-værktøjer CGI-konfiguration"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Netværk UPS-værktøjer Overvågningskonfiguration"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Konfiguration af serverkonfiguration af UPS-værktøjer til netværk"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Ingen lås"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Ingen OID'er for overførsel af lav/høj spænding"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Underret kommando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Off Forsinkelse(s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "On Forsinkelse(r)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Adgangskode"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Sti med ca-certifikater, der skal matches med værtscertifikatet"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Sti til tilstandsfil"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Periode, efter hvilken data anses for forældet"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Poll Interval"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Poll frekvens"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Poll frekvens alarm"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Polling frekvens(er)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Effektværdi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primary"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produkt (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Kræv SSL, og sørg for, at serverens CN passer til værtsnavnet"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Forsinkelse af gentagelsesforsøg"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rolle"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Kør drivere i et chroot(2)-miljø"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Kør som bruger"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP-fællesskab"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP-genforsøg"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP-timeout(s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP-version"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Serienummer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Indstil tilladelser til USB-serielport"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Indstil variabler"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Kommando til nedlukning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Synkron kommunikation"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Navnet på denne sektion vil blive brugt som UPS-navn andre steder"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tid i sekunder mellem forsøg på at genstarte driveren igen."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Tid i sekunder, som upsdrvctl vil vente på, at driveren er færdig med at "
 "starte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Globale indstillinger for UPS Server"
 
@@ -517,70 +592,91 @@ msgstr "Globale indstillinger for UPS Server"
 msgid "UPS name"
 msgstr "UPS-navn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB-bus(er) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB-produkt-id"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB-leverandør-id"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Brug %s til at se en komplet liste over de kommandoer, som din UPS "
 "understøtter (kræver %s-pakken)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Brugernavn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Leverandør (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Kontroller alle forbindelser med SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Løsning for fejlbehæftet firmware"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Skriv til syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon dropper privilegier til denne bruger"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA-certifikatsti"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Certifikatfil (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "Sti med ca-certifikater, der skal matches med værtscertifikatet"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Kræv SSL, og sørg for, at serverens CN passer til værtsnavnet"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Kontroller alle forbindelser med SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Driver sti"

--- a/applications/luci-app-nut/po/de/nut.po
+++ b/applications/luci-app-nut/po/de/nut.po
@@ -12,105 +12,134 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17.1\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Zusätzliche Abschaltzeit(en)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adressen welche zu Überwachen sind"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Erlaubte Aktionen"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Wie von NUT konfiguriert"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Helfer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes zum Lesen aus der Interrupt-Pipe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA Zertifikatspfad"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Zertifikatsdatei (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Steuere die USV über CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Benutzerdefinierte Benachrichtigung für Nachrichtentyp"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Totzeit"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Standard für USVs ohne dieses Feld."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Zeitverzögerung für Ausschaltbefehl"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Verzögerung vor dem Einschalten der USV, wenn die Stromversorgung nach dem "
 "Ausschalten wiederhergestellt wird"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Beschreibung (Anzeige)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Port beim Starten des Treibers nicht sperren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Treiber"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Treiberkonfiguration"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Globale Treibereinstellungen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Reihenfolge des Herunterfahrens von Treibern"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Der Treiber wartet, bis die Daten von upsd verarbeitet sind, bevor er "
 "weitere Daten veröffentlicht."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Entferne Rechte für diesen Benutzer"
 
@@ -118,7 +147,7 @@ msgstr "Entferne Rechte für diesen Benutzer"
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -126,35 +155,35 @@ msgstr ""
 "Aktiviert ein Hotplug-Skript, das alle ttyUSB-Geräte (z.B. serielle USB-"
 "Geräte) als Benutzer 'nut' in die Gruppe read-write einordnet"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Benachrichtigungsbefehl ausführen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Erzwungenes Herunterfahren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Globale Einstellungen"
 
@@ -163,7 +192,7 @@ msgstr "Globale Einstellungen"
 msgid "Go to NUT CGI"
 msgstr "Zum NUT CGI gehen"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -175,7 +204,7 @@ msgstr ""
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Host-Sync"
 
@@ -183,78 +212,82 @@ msgstr "Host-Sync"
 msgid "Hostname or IP address"
 msgstr "Hostname oder IP-Adresse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Hostname oder Adresse der USV"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-Adresse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Wenn diese Liste leer ist, müssen Sie %"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorieren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignoriere niedrigen Batteriestand"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Direkte Befehle"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Nur Unterbrechung"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Unterbrechungsgröße"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Hersteller (Display)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Max. gemeldete USB-HID-Länge"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Maximales Alter der Daten"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Maximale Wiederversuche"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Maximale Startverzögerung"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Maximale Verbindungen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Maximale Anzahl von Versuchen, einen Treiber zu starten."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Maximale Zeit in Sekunden zwischen der Aktualisierung des USV-Status"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Mindestanzahl von Netzteilen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modell (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -269,17 +302,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Netzwerk-USV-Tools (Monitor)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Netzwerk-USV-Tools (Server)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT Benutzer"
 
@@ -299,7 +332,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Name der USV"
 
@@ -312,180 +345,220 @@ msgstr "Netzwerk-USV-Tools"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Netzwerk-USV-Tools CGI-Konfiguration"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Netzwerk-USV-Tools Konfiguration der Überwachung"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Netzwerk-USV-Tools Konfiguration des Servers"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Keine Sperre"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Keine Nieder-/Hochspannungsübertragungs-OIDs"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Benachrichtigungseinstellungen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Benachrichtigungsbefehl"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Ausschaltverzögerung(en)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Einschaltverzögerung(en)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Passwort"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Pfad mit CA-Zertifikaten zum Abgleich mit dem Host-Zertifikat"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Pfad zur Zustandsdatei"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Zeitraum, nach dem Daten als veraltet gelten"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Aktualisierungsintervall"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Aktualisierungshäufigkeit"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Abfragehäufigkeitswarnung"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Abfragefrequenz(en)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Leistungswert"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primär"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produkt (Regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"SSL voraussetzen und sicherstellen, dass der CN des Servers mit dem "
-"Hostnamen übereinstimmt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Verzögerung bei Wiederholungsversuchen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rolle"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Treiber in einer chroot(2)-Umgebung ausführen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Ausführen als Benutzer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP Community"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP Wiederversuche"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP Zeitüberschreitung (en)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP-Version"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Seriennummer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Festlegen von USB-Berechtigungen für serielle Anschlüsse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Setze Variablen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Befehl zum Herunterfahren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Synchrone Kommunikation"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 "Der Name dieses Abschnitts wird an anderer Stelle als USV-Name verwendet"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -493,31 +566,31 @@ msgstr ""
 "Dies wird an den Treiber weitergeleitet, also versichern Sie sich, dass Ihr "
 "Treiber diese Option unterstützt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Zeit in Sekunden zwischen den wiederholten Startversuchen des Treibers."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Zeit in Sekunden, die upsdrvctl darauf wartet, dass der Treiber den "
 "Startvorgang beendet"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Globale Einstellungen des USV-Servers"
 
@@ -525,70 +598,96 @@ msgstr "Globale Einstellungen des USV-Servers"
 msgid "UPS name"
 msgstr "USV-Name"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB-Bus(se) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB Produkt ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB Hersteller ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Kann ldd nicht ausführen: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Verwenden Sie %s, um die vollständige Liste der von Ihrer USV unterstützten "
 "Befehle anzuzeigen (erfordert das Paket %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Benutzername"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Anbieter (Regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Überprüfe alle Verbindungen mit SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Workaround für fehlerhafte Firmware"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Schreibe Systemlog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "An syslog schreiben und Benachrichtigungsbefehl ausführen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "Treiber installieren"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon entzieht diesem Benutzer die Privilegien"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA Zertifikatspfad"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Zertifikatsdatei (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "Pfad mit CA-Zertifikaten zum Abgleich mit dem Host-Zertifikat"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "SSL voraussetzen und sicherstellen, dass der CN des Servers mit dem "
+#~ "Hostnamen übereinstimmt"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Kann ldd nicht ausführen: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Überprüfe alle Verbindungen mit SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Treiberpfad"

--- a/applications/luci-app-nut/po/el/nut.po
+++ b/applications/luci-app-nut/po/el/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.13-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Οδηγός"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Ενεργοποίηση"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Διεύθυνση IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Θύρα"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/es/nut.po
+++ b/applications/luci-app-nut/po/es/nut.po
@@ -13,105 +13,134 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Tiempo adicional de apagado (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Direcciones donde escuchar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Acciones permitidas"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Según lo configurado por NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Esclavo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Auxiliar (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes para leer desde tubo de interrupción"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Ruta del certificado de CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Archivo de certificado (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Control del SAI a través de CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Mensaje de notificación personalizado para el tipo de mensaje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Tiempo muerto"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Predeterminado para sistemas SAI sin este campo."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Retraso para el comando kill power"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Retraso para encender el SAI si la energía regresa después de apagar la "
 "unidad"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Descripción (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Nombre para mostrar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "No bloquee el puerto al iniciar el controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Configuración del controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Configuración global del controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Orden de apagado del controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "El controlador espera que los datos sean consumidos por upsd antes de "
 "publicar más."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Soltar privilegios a este usuario"
 
@@ -119,7 +148,7 @@ msgstr "Soltar privilegios a este usuario"
 msgid "Enable"
 msgstr "Activar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -128,11 +157,11 @@ msgstr ""
 "los dispositivos ttyUSB (por ejemplo, USB serie) sean de lectura y escritura "
 "como usuario 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Ejecutar comando de notificación"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -140,7 +169,7 @@ msgstr ""
 "Para los sistemas SAI basados en USB HID, se requiere el ID del producto USB "
 "para que NUT configure los permisos y el controlador pueda acceder al SAI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -148,7 +177,7 @@ msgstr ""
 "Para los sistemas SAI basados en USB HID, se requiere el ID del proveedor "
 "USB para que NUT configure los permisos y el controlador pueda acceder al SAI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -158,12 +187,12 @@ msgstr ""
 "dispositivos USB del mismo tipo (el producto USB y el fabricante USB son "
 "idénticos). Otros sistemas SAI también pueden usar este valor."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Forzar apagado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Configuración global"
 
@@ -172,7 +201,7 @@ msgstr "Configuración global"
 msgid "Go to NUT CGI"
 msgstr "Ir a CGI de NUT"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Conceder acceso UCI de administrador para luci-app-nut"
 
@@ -184,7 +213,7 @@ msgstr "Conceder acceso UCI de lectura limitado para luci-app-nut"
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Sincronización del host"
 
@@ -192,78 +221,82 @@ msgstr "Sincronización del host"
 msgid "Hostname or IP address"
 msgstr "Nombre de host o dirección IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Nombre de host o dirección del SAI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Dirección IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Si esta lista está vacía, necesitas %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorar batería baja"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Comandos instantáneos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Solo Interrumpir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Tamaño de la interrupción"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Fabricante (Display)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Longitud máxima de USB HID informada"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Edad máxima de los datos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Reintentos máximos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Retardo de arranque máximo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Conexiones máximas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Número máximo de veces para intentar iniciar un controlador."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tiempo máximo en segundos para la actualización del estado del SAI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Número mínimo requerido o fuentes de alimentación"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modelo (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -278,17 +311,17 @@ msgstr "NUT CGI - administrador"
 msgid "NUT CGI - main"
 msgstr "NUT CGI - principal"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Monitor de NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Herramientas del SAI de red (servidor)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Usuarios de NUT"
 
@@ -308,7 +341,7 @@ msgstr "NUT servidor - administrador"
 msgid "NUT server - main"
 msgstr "NUT servidor - principal"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Nombre del SAI"
 
@@ -321,180 +354,219 @@ msgstr "Herramientas del SAI de red"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Configuración de CGI de herramientas del SAI de red"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Configuración de monitoreo de herramientas del SAI de red"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Configuración del servidor de herramientas del SAI de red"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Sin bloqueo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Sin OID de transferencia de baja/alta tensión"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Indicadores de notificación"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Configuración de notificaciones"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Orden de notificación"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Retardo de apagado (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Retardo de encendido (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Contraseña"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Ruta que contiene certificados de CA para compararlos con el certificado del "
-"host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Ruta al archivo de estado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Período después del cual los datos se consideran obsoletos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Intervalo de encuesta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Frecuencia de encuesta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Alerta de frecuencia de sondeo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Frecuencia de sondeo(s)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Puerto"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Valor de potencia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primario"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Primario (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Producto (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"Requiere SSL y asegúrese de que el servidor CN coincida con el nombre de host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Retraso de reintento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Ejecutar controladores en un entorno chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Ejecutar como usuario"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Comunidad SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Reintentos SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Tiempo de espera de SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Versión de SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Número de serie"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Establecer permisos de puerto serie USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Establecer variables"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Orden de apagado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Comunicación sincrónica"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "El nombre de esta sección se usará como nombre del SAI en otra parte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -502,31 +574,31 @@ msgstr ""
 "Esto se transmite al controlador, así que asegúrese de que su controlador "
 "admite esta opción"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Tiempo en segundos entre los intentos de reintento de inicio del controlador."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Tiempo en segundos que upsdrvctl esperará a que el controlador termine de "
 "iniciarse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "SAI auxiliar (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "Configuración de usuario del monitor del SAI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "SAI principal (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Configuración global del servidor SAI"
 
@@ -534,70 +606,98 @@ msgstr "Configuración global del servidor SAI"
 msgid "UPS name"
 msgstr "Nombre del SAI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Bus(es) USB (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "ID de producto USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "ID de proveedor USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "No se puede ejecutar ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Use %s para ver la lista completa de las órdenes que admite su SAI (requiere "
 "el paquete %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Tipo de usuario (Principal/Auxiliar)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Proveedor (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Verificar toda la conexión con SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Solución para el firmware de buggy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Escribir en syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Escribe en syslog y ejecuta el comando notify"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "instalar controladores"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon le quita privilegios a este usuario"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Ruta del certificado de CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Archivo de certificado (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Ruta que contiene certificados de CA para compararlos con el certificado "
+#~ "del host"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "Requiere SSL y asegúrese de que el servidor CN coincida con el nombre de "
+#~ "host"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "No se puede ejecutar ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Verificar toda la conexión con SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Ruta del controlador"

--- a/applications/luci-app-nut/po/et/nut.po
+++ b/applications/luci-app-nut/po/et/nut.po
@@ -7,101 +7,130 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -109,41 +138,41 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -152,7 +181,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -164,7 +193,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -172,77 +201,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -258,17 +291,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -288,7 +321,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -301,204 +334,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -506,65 +581,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/fi/nut.po
+++ b/applications/luci-app-nut/po/fi/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Sallitut toiminnot"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA-varmenteen polku"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Varmennetiedosto (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Ohjaa UPS:ää CGI:n kautta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Näyttönimi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Ajuri"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Ajurin määritys"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Ajurin yleiset asetukset"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Ajurin sammutusjärjestys"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Ota käyttöön"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Pakotettu sammutus"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Yleiset asetukset"
 
@@ -157,7 +186,7 @@ msgstr "Yleiset asetukset"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "Palvelin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Laitenimi tai IP-osoite"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS-varavirtalähteen laitenimi tai osoite"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-osoite"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Ilmoituskomento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Salasana"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Polku tilatiedostoon"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Portti"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primary"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP-yhteisö"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP-uudelleenyritykset"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP-versio"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Sarjanumero"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Aseta USB-sarjaportin oikeudet"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Aseta muuttujat"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Sammutuskomento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS-palvelimen yleiset asetukset"
 
@@ -511,68 +586,80 @@ msgstr "UPS-palvelimen yleiset asetukset"
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Kirjoita syslogiin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA-varmenteen polku"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Varmennetiedosto (SSL)"
 
 #~ msgid "Driver Path"
 #~ msgstr "Ajurin polku"

--- a/applications/luci-app-nut/po/fr/nut.po
+++ b/applications/luci-app-nut/po/fr/nut.po
@@ -12,105 +12,134 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.9-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Temps additionnel d'arrêt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresses à écouter"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Actions permises"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Comme configuré par NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Esclave"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Octets à lire du tube d'interruption"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Chemin du certificat CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Fichier de certificat (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Contrôler l'ASI via le CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Temps mort"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Standard pour les ASI sans ce champ."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Délai pour la commande de coupure de courant"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Délai pour le démarrage de l'ASI si le courant revient après la commande de "
 "coupure du courant"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Description (affichage)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Nom d'affichage"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Ne pas fermer le port lors du démarrage du pilote"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Pilote"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Configuration du pilote"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Paramètres globales du pilote"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Ordre d'arrêt du pilote"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Le pilote est en attente de données encore à consommer par upsd avant de "
 "publier davantage."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Retirer des droits à cet utilisateur"
 
@@ -118,7 +147,7 @@ msgstr "Retirer des droits à cet utilisateur"
 msgid "Enable"
 msgstr "Activer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -126,35 +155,35 @@ msgstr ""
 "Active un scripte d'échange à chaud qui permet chaque groupe d'appareils "
 "ttyUSB l'écriture et la lecture en tant qu'utilisateur 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Exécuter la commande de notification"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Arrêt forcé"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Paramètres généraux"
 
@@ -163,7 +192,7 @@ msgstr "Paramètres généraux"
 msgid "Go to NUT CGI"
 msgstr "Aller à NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -175,7 +204,7 @@ msgstr ""
 msgid "Host"
 msgstr "Hôte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -183,78 +212,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Nom d'hôte ou adresse IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Nom d'hôte ou adresse de l'ASI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Adresse IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorer la batterie faible"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Commandes instantanées"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Interruption seulement"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Taille d'interruption"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Fabricant (affichage)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Longueur USB HID maximale rapporté"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Âge maximal des données"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Nombre maximal de tentatives"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Délai maximal de démarrage"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Nombre maximal de connexions"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Nombre maximal de tentatives de démarrage d'un pilote."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Temps maximal en secondes entre le rafraichissement du statut ASI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Nombre minimal requis d'alimentations électriques"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modèle (affichage)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -269,17 +302,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Outils d'ASI réseaux (moniteur)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Outils d'ASI réseau (serveur)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Utilisateurs NUT"
 
@@ -299,7 +332,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Nom de l'ASI"
 
@@ -312,207 +345,247 @@ msgstr "Outils d'ASI réseau"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Configuration CGI des outils ASI réseau"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Configuration de la surveillance des outils d'ASI réseau"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Configuration du serveur des outils d'ASI réseau"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Verrouillage fait défaut"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "OIDs de transfer de voltage bas/haut font défaut"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Commande de notification"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Retard d'extinction"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Retard d'allumage"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Mot de passe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Chemin d'accès contenant des certificats CA à faire correspondre au "
-"certificat d'hôte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Chemin d'accès aux fichiers d'état"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Période à l'issue de laquelle les données sont considérées confinées"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Intervalle d'actualisation"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Fréquence d'actualisation"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Alerte de fréquence d'actualisation"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Fréquences d'actualisation"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Valeur de courant"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Maître"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produit (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Requiers SSL et assure que le CN du serveur corresponde au nom d'hôte"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Retard de réessai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rôle"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Exécute les pilotes dans un environnement chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Exécute en tant qu'utilisateur"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Communauté SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Réessais SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Épuisement(s) de délai SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Version SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Numéro de série"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Assignes les permissions de port de série USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Assigne des variables"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Commande d'arrêt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Communication synchrone"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Le nom de cette section sera utilisé ailleurs en tant que nom ISA"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Temps en secondes entre les réessais de démarrage du pilote."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Temps en secondes upsdrvctl attend le pilote afin de finaliser le démarrage"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Paramètres globaux du serveur ISA"
 
@@ -520,70 +593,94 @@ msgstr "Paramètres globaux du serveur ISA"
 msgid "UPS name"
 msgstr "Nom d'ISA"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Bus USB (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "Id de produit USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "Id de vendeur USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Utilise %s afin de voir la liste complète des commandes que ton ASI supporte "
 "(requiers le paquet %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Vendeur (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Vérifie chaque connexion à l'aide d'SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Palliatif pour logiciel fautif"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Inscrits à syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon cède ses droits à cet utilisateur"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Chemin du certificat CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Fichier de certificat (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Chemin d'accès contenant des certificats CA à faire correspondre au "
+#~ "certificat d'hôte"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "Requiers SSL et assure que le CN du serveur corresponde au nom d'hôte"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Vérifie chaque connexion à l'aide d'SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Chemin d'accès du pilote"

--- a/applications/luci-app-nut/po/ga/nut.po
+++ b/applications/luci-app-nut/po/ga/nut.po
@@ -13,102 +13,131 @@ msgstr ""
 "6 && n<11) ? 3 : 4;\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Am (anna) Múchta Breise"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Seoltaí le héisteacht orthu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "gníomhartha ceadaithe"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Mar atá cumraithe ag NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Sclábhaí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Cúnta (I léig)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes le léamh ó phíopa cur isteach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Conair Teastais CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Comhad deimhnithe (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Rialú UPS trí CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Teachtaireacht fógra saincheaptha do chineál teachtaireachta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Am marbh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Réamhshocraithe do UPSEanna gan an réimse seo."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Moill le haghaidh ordú cumhachta marú"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Moill ar chumhacht ar UPS má fhilleann cumhacht tar éis cumhacht a mharú"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Cur síos (Taispeáin)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Ainm taispeána"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Ná glac an calafort agus tú ag tosú tiománaí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Tiománaí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Cumraíocht Tiománaí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Socruithe Domhanda Tiománaí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Ordú Múchadh Tiománaithe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "Fanann tiománaí go n-ídíonn upsd sonraí sula bhfoilsíonn sé níos mó."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Scaoil pribhléidí don úsáideoir seo"
 
@@ -116,7 +145,7 @@ msgstr "Scaoil pribhléidí don úsáideoir seo"
 msgid "Enable"
 msgstr "Cumasaigh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -124,11 +153,11 @@ msgstr ""
 "Cumasaíonn sé script hotplug a dhéanann gach feiste ttyUSB (m.sh. USB "
 "sraitheach) grúpa léamh-scríobh mar 'cnó' úsáideora"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Forghníomhú ordú fógra"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -137,7 +166,7 @@ msgstr ""
 "go socróidh NUT ceadanna ionas gur féidir leis an tiománaí rochtain a fháil "
 "ar an UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -146,7 +175,7 @@ msgstr ""
 "le go socróidh NUT ceadanna ionas gur féidir leis an tiománaí rochtain a "
 "fháil ar an UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -156,12 +185,12 @@ msgstr ""
 "ilghléasanna USB den chineál céanna (tá an táirge USB agus an díoltóir USB "
 "mar an gcéanna). Féadfaidh UPSanna eile an luach seo a úsáid freisin."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Múchadh Éigeantach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Socruithe Domhanda"
 
@@ -170,7 +199,7 @@ msgstr "Socruithe Domhanda"
 msgid "Go to NUT CGI"
 msgstr "Téigh go NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Deonaigh rochtain UCI riarthóra do luci-app-nut"
 
@@ -182,7 +211,7 @@ msgstr "Deonaigh rochtain léite teoranta UCI do luci-app-nut"
 msgid "Host"
 msgstr "Óstach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Sioncrónú Óstach"
 
@@ -190,78 +219,82 @@ msgstr "Sioncrónú Óstach"
 msgid "Hostname or IP address"
 msgstr "Ainm óstach nó seoladh IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Ainm óstach nó seoladh UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Seoladh IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Má tá an liosta seo folamh ní mór duit %s a dhéanamh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Déan neamhaird de"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Déan neamhaird de Battery Íseal"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Orduithe láithreacha"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Cuir isteach Amháin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Méid Cuir isteach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Monaróir (Taispeáin)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Tuairiscíodh Fad Uasta USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Aois Uasta na Sonraí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Athbhreithnithe Uasta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Moill Tosaigh Uasta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Naisc uasta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Uaslíon uaireanta chun iarracht a dhéanamh tiománaí a thosú."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "An t-am uasta i soicindí idir athnuachan stádas UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Líon íosta riachtanach nó soláthairtí cumh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Múnla (Taispeáin)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -276,17 +309,17 @@ msgstr "CGI Cnó - riarthóir"
 msgid "NUT CGI - main"
 msgstr "CGI Cnó - príomh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Uirlisí UPS Líonra (Monatóireacht)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Uirlisí UPS Líonra (Freastalaí)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Úsáideoirí NUT"
 
@@ -306,7 +339,7 @@ msgstr "Freastalaí NUT - riarthóir"
 msgid "NUT server - main"
 msgstr "freastalaí NUT - príomh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Ainm UPS"
 
@@ -319,177 +352,219 @@ msgstr "Uirlisí UPS Líonra"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Cumraíocht CGI Uirlisí UPS Líonra"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Cumraíocht Monatóireachta Uirlisí UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Cumraíocht Freastalaí Uirlisí UPS Network"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Gan Glas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Gan aon OIDanna aistrithe íseal/ardvoltais"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Bratacha fógra"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Socruithe fógraí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Ordú a chur in iúl"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Moill (í) as"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Ar Mhoill (í)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Pasfhocal"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Conair ina bhfuil teastais ca le comhoiriúnú i gcoinne deimhniú"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Conair chuig comhad stáit"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Tréimhse ina dhiaidh sin meastar go measfar sonraí"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Eatraimh Vótaíochta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Minicíocht vótaíochta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Foláireamh minicíochta pota"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Minicíocht (í) vótaíochta"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Luach cumhachta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Príomhúil"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Príomhúil (I léig)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Táirge (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Teastaíonn SSL ag teastáil agus déan cinnte go n-oireann freastalaí"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Athbhreithnigh Mhoill"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Ról"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Rith tiománaithe i dtimpeallacht chroot (2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "RithMar Úsáideoir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Pobal SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Athbhreithniú SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "An t-am (í) SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Leagan SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Sraithuimhir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Socraigh ceadanna calafort sraitheach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Socraigh athróga"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Ordú múchadh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Cumarsáid Sioncrónach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Úsáidfear ainm an chuid seo mar ainm UPS in áiteanna eile"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -497,28 +572,28 @@ msgstr ""
 "Cuirtear seo ar aghaidh chuig an tiománaí, mar sin déan cinnte go dtacaíonn "
 "do thiománaí leis an rogha seo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Am i soicindí idir iarrachtaí arís a thosú le tiománaí."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr "Am i soicindí a fanfaidh upsdrvctl go gcríochnóidh an tiománaí ag tosú"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "UPS Cúnta (Imithe as Feidhm)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "Socruithe Úsáideora Monatóireachta UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "Príomh-UPS (Imithe as Feidhm)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Socruithe Domhanda Freastalaí UPS"
 
@@ -526,70 +601,94 @@ msgstr "Socruithe Domhanda Freastalaí UPS"
 msgid "UPS name"
 msgstr "Ainm UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Bus USB (s) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "ID Táirge USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "ID Díoltóra USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Ní féidir ldd a rith: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Úsáid %s chun liosta iomlán a fheiceáil ar na horduithe a dtacaíonn do UPS "
 "(teastaíonn pacáiste %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Cineál úsáideora (Príomhúil/Cúnta)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Ainm úsáideora"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Díoltóir (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Fíoraigh gach nasc le SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Réiteach le haghaidh dochtearraí fabhtúil"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Scríobh chuig syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Scríobh chuig syslog agus cuir an t-ordú fógra i gcrích"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "tiománaithe a shuiteáil"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "Titeann upsmon pribhléidí don úsáideoir seo"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Conair Teastais CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Comhad deimhnithe (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "Conair ina bhfuil teastais ca le comhoiriúnú i gcoinne deimhniú"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Teastaíonn SSL ag teastáil agus déan cinnte go n-oireann freastalaí"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Ní féidir ldd a rith: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Fíoraigh gach nasc le SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Conair Tiománaí"

--- a/applications/luci-app-nut/po/he/nut.po
+++ b/applications/luci-app-nut/po/he/nut.po
@@ -13,101 +13,130 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "זמן כיבוי נוסף"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "כתובות להאזנה דרכן"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "פעולות מורשות"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "כפי שמוגדר על ידי NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "בתים לקריאה מצינור הפרעה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "נתיב אישור רשות אישורים"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "קובץ אישור (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "שליטה באל־פסק דרך CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "ברירת מחדל למאגרי אל־פסק בלי השדה הזה."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "השהיה לפקודת הפסקת חשמל"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "השהיה להפעלת אל־פסק אם החשמל חוזר לאחר קטיעת החשמל"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "תיאור (תצוגה)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "שם תצוגה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "לא לנעול את הפתחה בעת הפעלת מנהל ההתקן"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "מנהל התקן"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "הגדרות מנהל התקן"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "הגדרות כלליות למנהל התקן"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "סדר כיבוי מנהל התקן"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "מנהל ההתקן ממתין לצריכת הנתונים על ידי upsd בטרם פרסום עוד."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "השמטת הרשאות למשתמש הזה"
 
@@ -115,41 +144,41 @@ msgstr "השמטת הרשאות למשתמש הזה"
 msgid "Enable"
 msgstr "הפעלה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "הפעלת פקודת התראה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "כיבוי כפוי"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "הגדרות גלובליות"
 
@@ -158,7 +187,7 @@ msgstr "הגדרות גלובליות"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -170,7 +199,7 @@ msgstr ""
 msgid "Host"
 msgstr "מארח"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -178,78 +207,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "שם מארח או כתובת IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "שם מארח או כתובת אל־פסק"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "כתובת IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "התעלמות"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "התעלמות מסוללה חלשה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "פקודות מיידיות"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "פסיקה בלבד"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "גודל פסיקה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "יצרן (תצוגה)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "גיל הנתונים המרבי"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "מספר ניסיונות מרבי"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "השהיית התחלה מרבית"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "כמות חיבורים מרבית"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "מספר הפעמים המרבי להתחלת מנהל התקן."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "הזמן המרבי בשניות בין רענוני מצב האל־פסק"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "מספר ספקי הכוח הקטן ביותר הנדרש"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "דגם (תצוגה)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -264,17 +297,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -294,7 +327,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -307,204 +340,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "פתחה"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -512,68 +587,80 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "CA Certificate path"
+#~ msgstr "נתיב אישור רשות אישורים"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "קובץ אישור (SSL)"
 
 #~ msgid "Driver Path"
 #~ msgstr "נתיב מנהל התקן"

--- a/applications/luci-app-nut/po/hi/nut.po
+++ b/applications/luci-app-nut/po/hi/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "ड्राइवर"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/hu/nut.po
+++ b/applications/luci-app-nut/po/hu/nut.po
@@ -12,105 +12,134 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "További leállítási idők"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Címek, amelyeken figyelni kell"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Engedélyezett műveletek"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Ahogy a NUT beállította"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Szolga"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Megszakított csőből olvasandó bájtok"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA-tanúsítvány útvonala"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Tanúsítványfájl (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "UPS vezérlése CGI-n keresztül"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Holtidő"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Alapértelmezett a UPS-eknél ezen mező nélkül."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Az energia kilövése parancs késleltetése"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Az UPS bekapcsolásának késleltetése, ha visszatér az energia az energia "
 "kilövése után"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Leírás (megjelenítés)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Megjelenített név"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Ne zárolja a portot az illesztőprogram indításakor"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Illesztőprogram"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Illesztőprogram beállítása"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Illesztőprogram globális beállításai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Illesztőprogram leállítási sorrendje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Az illesztőprogram várakozik az upsd által elfogyasztott adatokra, mielőtt "
 "többet tesz közzé."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Jogosultságok dobása a felhasználónak"
 
@@ -118,7 +147,7 @@ msgstr "Jogosultságok dobása a felhasználónak"
 msgid "Enable"
 msgstr "Engedélyezés"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -127,35 +156,35 @@ msgstr ""
 "írhatóvá és olvashatóvá teszi az összes ttyUSB eszköz (például soros USB) "
 "csoportját"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Értesítési parancs végrehajtása"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Kényszerített leállítás"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Globális beállítások"
 
@@ -164,7 +193,7 @@ msgstr "Globális beállítások"
 msgid "Go to NUT CGI"
 msgstr "Ugrás a NUT CGI-hez"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -176,7 +205,7 @@ msgstr ""
 msgid "Host"
 msgstr "Gép"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -184,78 +213,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Gépnév vagy IP-cím"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "A UPS gépneve vagy címe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-cím"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Mellőzés"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Alacsony akkumulátor mellőzése"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Azonnali parancsok"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Csak megszakítás"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Megszakítás mérete"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Gyártó (megjelenítés)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Legnagyobb USB HID hossz jelentve"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Adatok legnagyobb életkora"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Legtöbb újrapróbálás"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Legnagyobb indítási késleltetés"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Legtöbb kapcsolat"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Egy illesztőprogram indítási kísérleteinek legnagyobb száma."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Legnagyobb idő másodpercben az UPS állapot frissítése között"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Legkisebb szükséges szám vagy áramforrás"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modell (megjelenítés)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -270,17 +303,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Hálózati UPS eszközök (megfigyelő)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Hálózati UPS eszközök (kiszolgáló)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT felhasználók"
 
@@ -300,7 +333,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Az UPS neve"
 
@@ -313,211 +346,249 @@ msgstr "Hálózati UPS eszközök"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Hálózati UPS eszközök CGI beállítások"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Hálózati UPS eszközök megfigyelési beállítások"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Hálózati UPS eszközök kiszolgáló beállítások"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Nincs zárolás"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Nincsenek alacsony/magas feszültség átviteli OID-k"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Értesítési parancs"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Ki késleltetések"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Be késleltetések"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Jelszó"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Útvonal, amely a CA-tanúsítványt tartalmazza a gép tanúsítványának "
-"egyeztetéséhez"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Útvonal az állapotfájlhoz"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Az időszak, amely után az adat elavultnak tekinthető"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Lekérdezési időköz"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Lekérdezési gyakoriság"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Lekérdezési gyakoriság riasztás"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Lekérdezési gyakoriságok"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Energiaérték"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Mester"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Termék (reguláris kifejezés)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"SSL szükséges, és győződjön meg arról, hogy a kiszolgáló CN-je egyezik-e a "
-"gépnévvel"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Újrapróbálás késleltetése"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Szerep"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Illesztőprogramok futtatása egy chroot(2) környezetben"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "RunAs felhasználó"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP közösség"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP újrapróbálások"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP időkorlátok"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP verzió"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Sorozatszám"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "USB soros port jogosultságainak beállítása"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Változók beállítása"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Leállítási parancs"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Egyidejű kommunikáció"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "A munkamenet neve lesz használva UPS névként máshol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Az illesztőprogram-indítás újrapróbálási kísérletei közti idő másodpercben."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Az idő másodpercben, ameddig az upsdrvctl várakozni fog az illesztőprogram-"
 "indítás befejeződésére"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS kiszolgáló globális beállításai"
 
@@ -525,70 +596,95 @@ msgstr "UPS kiszolgáló globális beállításai"
 msgid "UPS name"
 msgstr "UPS neve"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB buszok (reguláris kifejezés)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB termékazonosító"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB gyártóazonosító"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Használja az %s parancsot a teljes lista megtekintéséhez, hogy mely "
 "parancsokat támogatja az UPS-e (az %s csomagot igényli)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Gyártó (reguláris kifejezés)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Minden SSL-lel rendelkező kapcsolat ellenőrzése"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Kerülő megoldás a hibás firmware-hez"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Írás a rendszernaplóba"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "Az upsmon jogosultságokat dob a felhasználónak"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA-tanúsítvány útvonala"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Tanúsítványfájl (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Útvonal, amely a CA-tanúsítványt tartalmazza a gép tanúsítványának "
+#~ "egyeztetéséhez"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "SSL szükséges, és győződjön meg arról, hogy a kiszolgáló CN-je egyezik-e "
+#~ "a gépnévvel"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Minden SSL-lel rendelkező kapcsolat ellenőrzése"
 
 #~ msgid "Driver Path"
 #~ msgstr "Illesztőprogram útvonala"

--- a/applications/luci-app-nut/po/it/nut.po
+++ b/applications/luci-app-nut/po/it/nut.po
@@ -12,103 +12,132 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Tempo di spegnimento aggiuntivo(s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Indirizzi sui quali mettersi in ascolto"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Azioni consentite"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Come configurato da NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Ausiliario"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Byte da leggere dalla pipe di interrupt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Percorso dei certificati CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "File certificato (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Controlla UPS tramite CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Ritardo per il comando di spegnimento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Ritardo nell'accensione dell' UPS se l'alimentazione viene ripristinata dopo "
 "l'interruzione dell'alimentazione"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Descrizione (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -116,41 +145,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Abilitare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Spegnimento Forzato"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Impostazioni globali"
 
@@ -159,7 +188,7 @@ msgstr "Impostazioni globali"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -171,7 +200,7 @@ msgstr ""
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -179,77 +208,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Nome Host o indirizzo IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Nome Host o indirizzo dell' UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Indirizzo IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignora"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Comandi instantanei"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -265,17 +298,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -295,7 +328,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -308,204 +341,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Password"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primary"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -513,68 +588,80 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nome utente"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Percorso dei certificati CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "File certificato (SSL)"
 
 #~ msgid "%s is mutually exclusive to other choices"
 #~ msgstr "%s è mutuamente esclusivo rispetto ad altre scelte"

--- a/applications/luci-app-nut/po/ja/nut.po
+++ b/applications/luci-app-nut/po/ja/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "追加シャットダウン秒数"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "リッスンするアドレス"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "スレーブ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "証明書ファイル（SSL）"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "CGI で UPS を制御"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "説明（表示）"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "表示名"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "ドライバ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "ドライバー構成"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "ドライバー シャットダウン順序"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "有効化"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "通知コマンドを実行"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "強制シャットダウン"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "全体設定"
 
@@ -157,7 +186,7 @@ msgstr "全体設定"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "ホスト"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "ホスト名または IP アドレス"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS のホスト名またはアドレス"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP アドレス"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "無視"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "低バッテリーを無視"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "割り込みのみ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "割り込みサイズ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "メーカー（ディスプレイ）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "最大の再試行回数"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "最大の接続数"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "ネットワーク UPS ツール (モニター)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "ネットワーク UPS ツール (サーバー)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT ユーザー"
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "UPS の名前"
 
@@ -306,204 +339,246 @@ msgstr "ネットワーク UPS ツール"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "ネットワーク UPS ツール CGI 構成"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "ネットワーク UPS ツール モニタリング構成"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "ネットワーク UPS ツール サーバー構成"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "ロックがありません"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "通知コマンド"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "遅延をオフにする"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "遅延をオンにする"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "パスワード"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "ポーリング間隔"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "ポーリング頻度"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "ポーリング頻度"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "ポート"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "マスター"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "再試行遅延"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "役割"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "chroot(2) 環境でドライバーを実行"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP コミュニティ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP 再試行"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP タイムアウト"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP のバージョン"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "シリアル番号"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "変数を設定"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "シャットダウン コマンド"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS サーバー グローバル設定"
 
@@ -511,68 +586,77 @@ msgstr "UPS サーバー グローバル設定"
 msgid "UPS name"
 msgstr "UPS 名"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB ベンダー ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "ユーザー名"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "syslog へ書き込み"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "証明書ファイル（SSL）"
 
 #~ msgid "Grant UCI access for luci-app-nut"
 #~ msgstr "luci-app-nutにUCIアクセスを許可"

--- a/applications/luci-app-nut/po/ko/nut.po
+++ b/applications/luci-app-nut/po/ko/nut.po
@@ -12,103 +12,132 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.7.1.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "추가 시스템 종료 시간"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "NUT에 의해 설정됨"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "보조(Auxiliary)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "슬레이브 (권장되지 않음)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA 인증서 경로"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "인증서 파일(SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "CGI를 통한 UPS 제어"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "설명 (디스플레이)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "디스플레이 이름"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "드라이버 시작할 때 포트 잠그지 않음"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "드라이버"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "드라이버 구성"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "드라이버 전역 설정"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "드라이버 종료 순서"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "드라이버는 더 많은 데이터를 게시하기 전에 upsd가 데이터를 사용할 때까지 기다"
 "립니다."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "이 사용자에 대한 권한 삭제"
 
@@ -116,41 +145,41 @@ msgstr "이 사용자에 대한 권한 삭제"
 msgid "Enable"
 msgstr "활성화"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "강제 시스템 종료"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "전역 설정"
 
@@ -159,7 +188,7 @@ msgstr "전역 설정"
 msgid "Go to NUT CGI"
 msgstr "NUT CGI 바로가기"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -171,7 +200,7 @@ msgstr ""
 msgid "Host"
 msgstr "호스트"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -179,77 +208,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "호스트 이름 또는 IP 주소"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS의 호스트 이름 또는 주소"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP 주소"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "무시"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "저전압 무시"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "인터럽트 전용"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "인터럽트 크기"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "최대 시작 지연 시간"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -265,17 +298,17 @@ msgstr "NUT CGI - 관리"
 msgid "NUT CGI - main"
 msgstr "NUT CGI - 메인"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "NUT 모니터"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "NUT 서버"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT 사용자"
 
@@ -295,7 +328,7 @@ msgstr "NUT 서버 - 관리"
 msgid "NUT server - main"
 msgstr "NUT 서버 - 메인"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "UPS 이름"
 
@@ -308,204 +341,246 @@ msgstr "네트워크 UPS 도구"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "네트워크 UPS 도구의 CGI 인터페이스를 설정합니다"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "네트워크 UPS 도구의 모니터링 서비스를 설정합니다"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "네트워크 UPS 도구의 서버를 설정합니다"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "알림 설정"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "암호"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "포트"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "주(Primary)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "마스터 (권장되지 않음)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "역할"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "실행 사용자"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP 버전"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "시스템 종료 명령"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "UPS 슬레이브 (권장되지 않음)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "UPS 모니터 사용자 설정"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "UPS 마스터 (권장되지 않음)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS 서버 전역 설정"
 
@@ -513,68 +588,80 @@ msgstr "UPS 서버 전역 설정"
 msgid "UPS name"
 msgstr "UPS 이름"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB 제품 ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB 벤더 ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "사용자 유형 (주/보조)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "사용자 이름"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "벤더 (정규식)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA 인증서 경로"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "인증서 파일(SSL)"
 
 #~ msgid "Driver Path"
 #~ msgstr "드라이버 경로"

--- a/applications/luci-app-nut/po/lo/nut.po
+++ b/applications/luci-app-nut/po/lo/nut.po
@@ -10,101 +10,130 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "ເວລາປິດເຄື່ອງເພີ່ມເຕີມ (ວິນາທີ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "ທີ່ຢູ່ສຳລັບຮັບຟັງການເຊື່ອມຕໍ່"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "ການກະທຳທີ່ອະນຸຍາດ"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "ຕາມທີ່ຕັ້ງຄ່າໄວ້ໂດຍ NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "ສຳຮອງ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "ສຳຮອງ (ບໍ່ແນະນຳໃຫ້ໃຊ້)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "ຈຳນວນໄບຕ໌ທີ່ຈະອ່ານຈາກທໍ່ສົ່ງຂໍ້ມູນຂັດຈັງຫວະ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "ເສັ້ນທາງໄຟລ໌ໃບຢັ້ງຢືນ CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "ໄຟລ໌ໃບຢັ້ງຢືນ (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "ຄວບຄຸມ UPS ຜ່ານ CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "ຂໍ້ຄວາມແຈ້ງເຕືອນແບບກຳນົດເອງສຳລັບປະເພດຂໍ້ຄວາມ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "ເວລາຕັດການເຊື່ອມຕໍ່ (Deadtime)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "ຄ່າເລີ່ມຕົ້ນສຳລັບ UPS ທີ່ບໍ່ມີຊ່ອງຂໍ້ມູນນີ້."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "ເວລາໜ່ວງສຳລັບຄຳສັ່ງຕັດໄຟ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "ເວລາໜ່ວງສຳລັບການເປີດ UPS ຖ້າໄຟກັບມາຫຼັງຈາກການຕັດໄຟ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "ຄຳອະທິບາຍ (ສຳລັບສະແດງຜົນ)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "ຊື່ສະແດງຜົນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "ບໍ່ຕ້ອງລັອກພອດເວລາເລີ່ມການເຮັດວຽກຂອງໄດຣເວີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "ໄດຣເວີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "ການຕັ້ງຄ່າໄດຣເວີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "ການຕັ້ງຄ່າທົ່ວໄປຂອງໄດຣເວີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "ລຳດັບການປິດໄດຣເວີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "ໄດຣເວີຈະລໍຖ້າໃຫ້ upsd ອ່ານຂໍ້ມູນໄປກ່ອນ ຈຶ່ງຈະສົ່ງຂໍ້ມູນໃໝ່."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "ຫຼຸດສິດການໃຊ້ງານໃຫ້ເປັນຜູ້ໃຊ້ນີ້"
 
@@ -112,7 +141,7 @@ msgstr "ຫຼຸດສິດການໃຊ້ງານໃຫ້ເປັນຜ
 msgid "Enable"
 msgstr "ເປີດໃຊ້ງານ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -120,19 +149,19 @@ msgstr ""
 "ເປີດໃຊ້ງານສະຄຣິບ hotplug ເພື່ອປ່ຽນສິດການອ່ານ-ຂຽນຂອງອຸປະກອນ ttyUSB ທັງໝົດ (ເຊັ່ນ: serial "
 "USB) ໃຫ້ເປັນຂອງຜູ້ໃຊ້ %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "ດຳເນີນການຄຳສັ່ງແຈ້ງເຕືອນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
-"ສຳລັບ UPS ທີ່ໃຊ້ USB HID, ຈຳເປັນຕ້ອງມີ USB Product Id ເພື່ອໃຫ້ NUT ສາມາດກຳນົດສິດການເຂົ້າເຖິ"
-"ງ ເພື່ອໃຫ້ໄດເວີສາມາດເຊື່ອມຕໍ່ກັບ UPS ໄດ້"
+"ສຳລັບ UPS ທີ່ໃຊ້ USB HID, ຈຳເປັນຕ້ອງມີ USB Product Id ເພື່ອໃຫ້ NUT "
+"ສາມາດກຳນົດສິດການເຂົ້າເຖິງ ເພື່ອໃຫ້ໄດເວີສາມາດເຊື່ອມຕໍ່ກັບ UPS ໄດ້"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -140,7 +169,7 @@ msgstr ""
 "ສຳລັບ UPS ທີ່ໃຊ້ USB HID, ຈຳເປັນຕ້ອງມີ USB Vendor Id ເພື່ອໃຫ້ NUT ສາມາດກຳນົດສິດການເຂົ້າເຖິງ "
 "ເພື່ອໃຫ້ໄດເວີສາມາດເຊື່ອມຕໍ່ກັບ UPS ໄດ້"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -149,12 +178,12 @@ msgstr ""
 "ສຳລັບ UPS ທີ່ໃຊ້ USB HID, ອະນຸຍາດໃຫ້ໃຊ້ງານອຸປະກອນ USB ຫຼາຍອັນທີ່ເປັນປະເພດດຽວກັນ (USB "
 "product ແລະ USB vendor ຄືກັນ). UPS ປະເພດອື່ນກໍສາມາດໃຊ້ຄ່ານີ້ໄດ້ຄືກັນ."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "ບັງຄັບປິດເຄື່ອງ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 
@@ -163,7 +192,7 @@ msgstr "ການຕັ້ງຄ່າທົ່ວໄປ"
 msgid "Go to NUT CGI"
 msgstr "ໄປທີ່ NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "ອະນຸຍາດສິດຜູ້ດູແລລະບົບໃນການເຂົ້າເຖິງ UCI ສຳລັບ luci-app-nut"
 
@@ -175,7 +204,7 @@ msgstr "ອະນຸຍາດສິດອ່ານ UCI ແບບຈຳກັດ 
 msgid "Host"
 msgstr "ໂຮສ (Host)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "ການຊິງໂຄຣໄນໂຮສ (Host Sync)"
 
@@ -183,78 +212,82 @@ msgstr "ການຊິງໂຄຣໄນໂຮສ (Host Sync)"
 msgid "Hostname or IP address"
 msgstr "ຊື່ໂຮສ ຫຼື ທີ່ຢູ່ IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "ຊື່ໂຮສ ຫຼື ທີ່ຢູ່ຂອງ UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "ທີ່ຢູ່ IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "ຖ້າລາຍການນີ້ຫວ່າງເປົ່າ ເຈົ້າຈຳເປັນຕ້ອງ %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "ລະເລີຍ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "ລະເລີຍສະຖານະແບັດເຕີຣີຕໍ່າ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "ຄຳສັ່ງທັນທີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "ສະເພາະ Interrupt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "ຂະໜາດ Interrupt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "ຜູ້ຜະລິດ (ສຳລັບສະແດງຜົນ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "ຄວາມຍາວສູງສຸດຂອງ USB HID ທີ່ລາຍງານ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "ອາຍຸຂໍ້ມູນສູງສຸດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "ຈຳນວນຄັ້ງທີ່ລອງໃໝ່ສູງສຸດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "ເວລາໜ່ວງໃນການເລີ່ມຕົ້ນສູງສຸດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "ຈຳນວນການເຊື່ອມຕໍ່ສູງສຸດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "ຈຳນວນຄັ້ງສູງສຸດທີ່ຈະລອງເລີ່ມຕົ້ນໄດຣເວີ."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "ເວລາສູງສຸດ (ວິນາທີ) ລະຫວ່າງການຣີເຟຣຊສະຖານະ UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "ຈຳນວນແຫຼ່ງຈ່າຍໄຟທີ່ຕ້ອງການຂັ້ນຕໍ່າ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "ຮຸ່ນ (ສຳລັບສະແດງຜົນ)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -269,17 +302,17 @@ msgstr "NUT CGI - ຜູ້ດູແລລະບົບ"
 msgid "NUT CGI - main"
 msgstr "NUT CGI - ຫຼັກ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "NUT Monitor"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "NUT Server"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "ຜູ້ໃຊ້ NUT"
 
@@ -299,7 +332,7 @@ msgstr "ເຊີເວີ NUT - ຜູ້ດູແລລະບົບ"
 msgid "NUT server - main"
 msgstr "ເຊີເວີ NUT - ຫຼັກ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "ຊື່ຂອງ UPS"
 
@@ -312,204 +345,246 @@ msgstr "Network UPS Tools"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "ການຕັ້ງຄ່າ Network UPS Tools CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "ການຕັ້ງຄ່າການຕິດຕາມ Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "ການຕັ້ງຄ່າເຊີບເວີ Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "ບໍ່ລັອກ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "ບໍ່ມີ OID ການໂອນຍ້າຍແຮງດັນຕໍ່າ/ສູງ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "ທຸງການແຈ້ງເຕືອນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "ການຕັ້ງຄ່າການແຈ້ງເຕືອນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "ຄຳສັ່ງແຈ້ງເຕືອນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "ເວລາໜ່ວງກ່ອນປິດ (ວິນາທີ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "ເວລາໜ່ວງກ່ອນເປີດ (ວິນາທີ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "ລະຫັດຜ່ານ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "ເສັ້ນທາງທີ່ເກັບໄຟລ໌ໃບຢັ້ງຢືນ CA ເພື່ອກວດສອບກັບໃບຢັ້ງຢືນຂອງໂຮສ"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "ທີ່ຢູ່ໄຟລ໌ສະຖານະ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "ໄລຍະເວລາທີ່ຂໍ້ມູນຈະຖືກຖືວ່າເກົ່າ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "ໄລຍະຫ່າງການດຶງຂໍ້ມູນ (Poll Interval)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "ຄວາມຖີ່ການດຶງຂໍ້ມູນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "ການແຈ້ງເຕືອນຄວາມຖີ່ການດຶງຂໍ້ມູນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "ຄວາມຖີ່ການດຶງຂໍ້ມູນ (ວິນາທີ)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "ພອດ (Port)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "ຄ່າພະລັງງານ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "ຫຼັກ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "ຫຼັກ (ບໍ່ແນະນຳໃຫ້ໃຊ້)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "ສິນຄ້າ (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "ຕ້ອງການ SSL ແລະ ກວດສອບໃຫ້ແນ່ໃຈວ່າ CN ຂອງເຊີບເວີຕົງກັບຊື່ໂຮສ"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "ເວລາໜ່ວງໃນການລອງໃໝ່"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "ບົດບາດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "ລັນໄດຣເວີໃນສະພາບແວດລ້ອມ chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "ຜູ້ໃຊ້ທີ່ໃຊ້ລັນໂປຣແກຣມ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP Community"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "ຈຳນວນຄັ້ງການລອງ SNMP ໃໝ່"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "ເວລາໝົດອາຍຸ SNMP (ວິນາທີ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "ເວີຊັນ SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "ເລກລຳດັບ (Serial Number)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "ຕັ້ງຄ່າສິດການເຂົ້າເຖິງພອດ USB serial"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "ຕັ້ງຄ່າຕົວປ່ຽນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "ຄຳສັ່ງປິດເຄື່ອງ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "ການສື່ສານແບບ Synchronous"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "ຊື່ຂອງພາກນີ້ຈະຖືກໃຊ້ເປັນຊື່ UPS ໃນບ່ອນອື່ນໆ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr "ຄ່ານີ້ຈະຖືກສົ່ງຕໍ່ໃຫ້ໄດຣເວີ, ສະນັ້ນກວດສອບໃຫ້ແນ່ໃຈວ່າໄດຣເວີຂອງເຈົ້າຮອງຮັບຕົວເລືອກນີ້"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "ເວລາເປັນວິນາທີລະຫວ່າງການລອງເລີ່ມຕົ້ນໄດຣເວີໃໝ່."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr "ເວລາເປັນວິນາທີທີ່ upsdrvctl ຈະລໍຖ້າໃຫ້ໄດຣເວີເລີ່ມຕົ້ນເຮັດວຽກຈົນສຳເລັດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "UPS ສຳຮອງ (ບໍ່ແນະນຳໃຫ້ໃຊ້)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "ການຕັ້ງຄ່າຜູ້ໃຊ້ສຳລັບການຕິດຕາມ UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "UPS ຫຼັກ (ບໍ່ແນະນຳໃຫ້ໃຊ້)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "ການຕັ້ງຄ່າທົ່ວໄປຂອງ UPS Server"
 
@@ -517,68 +592,92 @@ msgstr "ການຕັ້ງຄ່າທົ່ວໄປຂອງ UPS Server"
 msgid "UPS name"
 msgstr "ຊື່ UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB Bus (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB Product Id"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB Vendor Id"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "ບໍ່ສາມາດລັນ ldd ໄດ້: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr "ໃຊ້ %s ເພື່ອເບິ່ງລາຍການຄຳສັ່ງທັງໝົດທີ່ UPS ຂອງເຈົ້າຮອງຮັບ (ຕ້ອງການແພັກເກັດ %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "ປະເພດຜູ້ໃຊ້ (ຫຼັກ/ສຳຮອງ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "ຊື່ຜູ້ໃຊ້"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "ຜູ້ຂາຍ (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "ກວດສອບທຸກການເຊື່ອມຕໍ່ດ້ວຍ SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "ວິທີແກ້ໄຂບັນຫາສຳລັບເຟີມແວທີ່ມີຂໍ້ຜິດພາດ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "ຂຽນລົງ syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "ຂຽນລົງ syslog ແລະ ດຳເນີນການຄຳສັ່ງແຈ້ງເຕືອນ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "ຕິດຕັ້ງໄດຣເວີ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon ຈະຫຼຸດສິດການໃຊ້ງານໃຫ້ເປັນຜູ້ໃຊ້ນີ້"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "ເສັ້ນທາງໄຟລ໌ໃບຢັ້ງຢືນ CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "ໄຟລ໌ໃບຢັ້ງຢືນ (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "ເສັ້ນທາງທີ່ເກັບໄຟລ໌ໃບຢັ້ງຢືນ CA ເພື່ອກວດສອບກັບໃບຢັ້ງຢືນຂອງໂຮສ"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "ຕ້ອງການ SSL ແລະ ກວດສອບໃຫ້ແນ່ໃຈວ່າ CN ຂອງເຊີບເວີຕົງກັບຊື່ໂຮສ"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "ບໍ່ສາມາດລັນ ldd ໄດ້: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "ກວດສອບທຸກການເຊື່ອມຕໍ່ດ້ວຍ SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "ທີ່ຢູ່ໄດຣເວີ (Path)"

--- a/applications/luci-app-nut/po/lt/nut.po
+++ b/applications/luci-app-nut/po/lt/nut.po
@@ -13,42 +13,67 @@ msgstr ""
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Papildomas/-i išjungimo laikas/-ai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresai, ant kurių laukti prisijungimo/jungties ryšio"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Leidžiami veiksmai"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Taip, Kaip sukonfigūravo – „NUT“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Pagalbinis/-ė"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Pagalbinis (nebenaudojamas)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Baitai, kuriuos reikia perskaityti iš pertraukimo vamzdelio"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "„CA sertifikato“ kelias"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Sertifikatų failas („SSL“)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
@@ -56,63 +81,67 @@ msgstr ""
 "Valdyti nenutrūkstamo maitinimo šaltinį per – Tipine tinklo tarpuvartes; "
 "kompiuterijos sąsają"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Pasirinktinė pranešimo žinutė, skirta žinutės tipui"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "„Deadtime“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Numatyti nenutrūkstamo maitinimo šaltiniai, be šio lauko."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Elektros sustabdymo atidėjimo komanda"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Nenutrūkstamo maitinimo šaltinio elektros atidėjimas, jeigu elektra grįžta "
 "po jos nutrūkimo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Aprašymas (Rodymas/-ti)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Rodomasis pavadinimas/vardas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Neužrakinti prievado, kai pajungiama tvarkyklė"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Tvarkyklė"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Tvarkyklės konfigūracija"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Bendri tvarkyklės nustatymai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Tvarkyklių išjungimo tvarka"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Prieš paskelbdamas daugiau, tvarkyklė laukia, kol „upsd“ sunaudos duomenis."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Mesti/Šalinti šio naudotojo/vartotojo privilegijas"
 
@@ -120,7 +149,7 @@ msgstr "Mesti/Šalinti šio naudotojo/vartotojo privilegijas"
 msgid "Enable"
 msgstr "Įjungti/Įgalinti"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -129,11 +158,11 @@ msgstr ""
 "įrenginius (pvz., nuoseklųjį „USB“) skaityti ir rašyti kaip naudoto/"
 "vartotojo – „nut“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Vykdyti pranešimo komandą"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -142,7 +171,7 @@ msgstr ""
 "reikalingas, kad „NUT“ galėtų nustatyti leidimus, tad tvarkyklė galėtų "
 "pasiekti – „UPS“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -151,7 +180,7 @@ msgstr ""
 "reikalingas, kad „NUT“ galėtų nustatyti leidimus, tad tvarkyklė galėtų "
 "pasiekti – „UPS“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -161,12 +190,12 @@ msgstr ""
 "tipo „USB“ įrenginius („USB“ produktas ir USB pardavėjas/tiekėjas yra "
 "identiški). Kiti „UPS“ (dgs.) taip pat gali naudoti šią reikšmę."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Priverstas išjungimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Pagrindiniai/Visuotiniai nustatymai"
 
@@ -175,7 +204,7 @@ msgstr "Pagrindiniai/Visuotiniai nustatymai"
 msgid "Go to NUT CGI"
 msgstr "Eiti į – „NUT CGI“"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Suteikti administratoriaus „UCI“ prieigą prie – „luci-app-nut“"
 
@@ -187,7 +216,7 @@ msgstr "Suteikti ribotą „UCI“ skaitymo prieigą skirtai – „luci-app-nut
 msgid "Host"
 msgstr "Skleidėjas/Vedėjas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Skleidėjo/Vedėjo sinchronizavimas"
 
@@ -195,82 +224,86 @@ msgstr "Skleidėjo/Vedėjo sinchronizavimas"
 msgid "Hostname or IP address"
 msgstr "Įrenginio (t.y skleidėjo/vedėjo) pavadinimas arba IP adresas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 "Nenutrūkstamo maitinimo šaltinio įrenginio (t.y skleidėjo/vedėjo) "
 "pavadinimas arba adresas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP adresas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Jei šis sąrašas yra tuščias, Jūs turite – „%s“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignoruoti"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignoruoti mažos baterijos/akumuliatoriaus būseną"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Akimirkos komandos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Tik pertraukimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Pertraukimo dydis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Gamintojas (Rodymas/-ti)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Praneštas maksimalus „USB HID“ ilgis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Maksimalus duomenų amžius"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Maksimalus pakartojimų/bandymų iš naujo skaičius"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Maksimalus paleidimo/-sties atidėjimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Maksimalus prisijungimų skaičius"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Maksimalus bandymų paleisti tvarkyklę skaičius."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 "Maksimalus laikas sekundėmis, tarp nenutrūkstamo maitinimo šaltinio būklės/"
 "būsenos atnaujinimo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Minimalus reikalingas skaičius arba maitinimo šaltiniai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modelis (Rodymas/-ti)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -287,17 +320,17 @@ msgstr "„NUT CGI“ – administratorius"
 msgid "NUT CGI - main"
 msgstr "„NUT CGI“ – pagrindinis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Tinklo nenutrūkstamo maitinimo šaltinio įrankiai (Monitorius)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Tinklo nenutrūkstamo maitinimo šaltinio įrankiai (Serveris)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "„NUT“ naudotojai/vartotojai"
 
@@ -317,7 +350,7 @@ msgstr "„NUT“ serveris – administratorius"
 msgid "NUT server - main"
 msgstr "„NUT“ serveris – pagrindinis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Nenutrūkstamo maitinimo šaltinio pavadinimas"
 
@@ -332,187 +365,225 @@ msgstr ""
 "Tinklo nenutrūkstamo maitinimo šaltinio įrankiai; tipinė tinklo tarpuvartės; "
 "kompiuterijos sąsajos konfigūracija"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 "Tinklo nenutrūkstamo maitinimo šaltinio įrankių stebėjimo konfigūracija"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 "Tinklo nenutrūkstamo maitinimo šaltinio įrankiai; serverio konfigūracija"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Jokio užrakto"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 "Nėra žemos/aukštos įtampos perdavime; objektų atributikų identifikatorių "
 "(„OID“)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Pranešimo vėliavos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Pranešimų nustatymai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Pranešimo komanda"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Išjungimo atidėjimas/-ai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Įjungimo atidėjimas/-ai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Kelias, kuriame yra – „CA“ sertifikatai, atitinkantys skleidėjo/vedėjo "
-"sertifikatą"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Kelias į būsenos/būklės failą"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Laikotarpis, po kurio duomenys yra laikomi pasenusiais"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Apklausos intervalas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Apklausos dažnis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Apklausos dažnio įspėjimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Apklausos dažnis (-iai)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Prievadas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Galios reikšmė"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Pirminis/Pagrindinis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Pirminis/Pagrindinis (nebenaudojamas)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produktas (reguliarusis reiškinys)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"Reikalauti „SSL“ ir įsitikinti, kad serverio „CN“ sulygina įrenginio (t.y "
-"skleidėjo/vedėjo) pavadinimą"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Pakartojimo/Bandymo iš naujo atidėjimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Vaidmuo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Vykdyti tvarkykles „chroot(2)“ sąsajoje"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Vykdyti kaip naudotojas/vartotojas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "„SNMP“ bendruomenė"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "„SNMP“ bandymai iš naujo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "„SNMP“ pasibaigusios užklausos laikas (-ai)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "„SNMP“ versija"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "„SNMPv1“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "„SNMPv2c“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "„SNMPv3“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Serijos numeris"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Nustatyti „USB“ nuoseklaus/-iojo prievado leidimus"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Nustatyti kintamuosius"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Išjungimo komanda"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Sinchroninė komunikacija"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 "Šio skyriaus pavadinimas bus naudojamas kaip nenutrūkstamo maitinimo "
 "šaltinio pavadinimas kitur"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -520,31 +591,31 @@ msgstr ""
 "Tai yra perduodama tvarkyklei, todėl įsitikinkite, kad Jūsų tvarkyklė "
 "palaiko šią parinktį"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Laikas sekundėmis, tarp tvarkyklės paleidimo/-sties pakartojimų/bandymų iš "
 "naujo."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Laikas sekundėmis, kurį „upsdrvctl“ lauks, kol tvarkyklė baigs pasikrauti"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "Nenutrūkstamo maitinimo šaltinio pagalbinis (nebenaudojamas)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "„UPS“ stebėjimo naudotojo/vartotojo nustatymai"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "Nenutrūkstamo maitinimo šaltinio pirminis/pagrindinis (nebenaudojamas)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Visuotiniai nenutrūkstamo maitinimo šaltinio serverio nustatymai"
 
@@ -552,70 +623,98 @@ msgstr "Visuotiniai nenutrūkstamo maitinimo šaltinio serverio nustatymai"
 msgid "UPS name"
 msgstr "Nenutrūkstamo maitinimo šaltinio pavadinimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "„USB“ (reguliarusis reiškinys)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "„USB“ produkto ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "„USB“ pardavėjo/tiekėjo ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Nepavyksta/Negalima paleisti – „ldd: %s“"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Naudokite – „%s“, kad pamatytumėte visą – nenutrūkstamo maitinimo šaltinio "
 "palaikomų komandų sąrašą (reikalingas – „%s“ paketas)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Naudotojo/Vartotojo tipas (pirminis/pagrindinis┃pagalbinis)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Naudotojo/Vartotojo vardas (t.y. Slapyvardis)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Pardavėjas/Tiekėjas (reguliarusis reiškinys)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Patvirtinti visus prisijungimus su „SSL“"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Klaidingos programinės įrangos laikinas apėjimas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Rašyti į „syslog“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Rašyti į – „syslog“ ir vykdyti komandą – „notify“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "„chroot“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "įdiegti tvarkykles"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "„upsmon“ atmeta šio naudotojo/vartotojo privilegijas"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "„CA sertifikato“ kelias"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Sertifikatų failas („SSL“)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Kelias, kuriame yra – „CA“ sertifikatai, atitinkantys skleidėjo/vedėjo "
+#~ "sertifikatą"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "Reikalauti „SSL“ ir įsitikinti, kad serverio „CN“ sulygina įrenginio (t.y "
+#~ "skleidėjo/vedėjo) pavadinimą"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Nepavyksta/Negalima paleisti – „ldd: %s“"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Patvirtinti visus prisijungimus su „SSL“"
 
 #~ msgid "Driver Path"
 #~ msgstr "Tvarkyklės kelias"

--- a/applications/luci-app-nut/po/mr/nut.po
+++ b/applications/luci-app-nut/po/mr/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "ड्रायव्हर"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "सक्षम करा"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "संकेतशब्द"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "पोर्ट"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "वापरकर्तानाव"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/ms/nut.po
+++ b/applications/luci-app-nut/po/ms/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Pemboleh"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Tetapan Global"
 
@@ -157,7 +186,7 @@ msgstr "Tetapan Global"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "Hos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Alamat IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nama pengguna"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/nb_NO/nut.po
+++ b/applications/luci-app-nut/po/nb_NO/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresser det skal lyttes til"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Skru på"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "Vert"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-adresse"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Passord"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/nl/nut.po
+++ b/applications/luci-app-nut/po/nl/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.15.1\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Additionele Afsluit Tijd(en)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adressen naarwaar geluisterd moet worden"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Inschakelen"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "Hostnaam"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP adres"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Poort"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,66 +586,72 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
 

--- a/applications/luci-app-nut/po/pl/nut.po
+++ b/applications/luci-app-nut/po/pl/nut.po
@@ -13,105 +13,134 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Dodatkowy(-e) czas(y) wyłączenia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresy, na których można słuchać"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Dozwolone akcje"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Zgodnie z konfiguracją NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Dodatkowy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Dodatkowy (przestarzały)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bajty do odczytania z potoku przerwań"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Ścieżka certyfikatu CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Plik certyfikatu (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Sterowanie zasilaczem UPS przez CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Niestandardowy komunikat powiadomienia dla typu wiadomości"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Czas zwłoki"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Domyślnie dla zasilaczy UPS bez tego pola."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Opóźnienie komendy zabijania zasilania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Opóźnienie włączenia zasilania UPS w przypadku powrotu zasilania po zabiciu "
 "zasilania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Opis"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Wyświetlana nazwa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Nie blokuj portu podczas uruchamiania sterownika"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Sterownik"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Konfiguracja sterownika"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Ustawienia globalne sterownika"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Rozkaz wyłączenia sterownika"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Sterownik czeka na dane, które zostaną zużyte przez upsd, zanim opublikuje "
 "ich więcej."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Porzuć przywileje dla tego użytkownika"
 
@@ -119,7 +148,7 @@ msgstr "Porzuć przywileje dla tego użytkownika"
 msgid "Enable"
 msgstr "Włącz"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -128,11 +157,11 @@ msgstr ""
 "szeregowe USB) mają uprawnienia grupowe do odczytu i zapisu jako użytkownik "
 "%s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Wykonaj polecenie powiadomienia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -141,7 +170,7 @@ msgstr ""
 "USB Product ID, aby NUT mógł ustawić odpowiednie uprawnienia i umożliwić "
 "sterownikowi dostęp do UPS‑a"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -150,7 +179,7 @@ msgstr ""
 "USB Vendor ID, aby NUT mógł ustawić odpowiednie uprawnienia i umożliwić "
 "sterownikowi dostęp do UPS‑a"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -160,12 +189,12 @@ msgstr ""
 "urządzeń USB tego samego typu (z identycznym identyfikatorem producenta i "
 "produktu). Inne UPS‑y również mogą korzystać z tej wartości."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Wymuszone wyłączenie"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Ustawienia globalne"
 
@@ -174,7 +203,7 @@ msgstr "Ustawienia globalne"
 msgid "Go to NUT CGI"
 msgstr "Idź do CGI NUT"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Przyznaj luci-app-nut dostęp administracyjny do UCI"
 
@@ -186,7 +215,7 @@ msgstr "Przyznaj luci‑app‑nut ograniczony dostęp tylko do odczytu w UCI"
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Synchronizacja hosta"
 
@@ -194,78 +223,82 @@ msgstr "Synchronizacja hosta"
 msgid "Hostname or IP address"
 msgstr "Nazwa hosta lub adres IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Nazwa hosta lub adres zasilacza UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Adres IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Jeśli ta lista jest pusta, musisz %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignoruj"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignoruj niski poziom baterii"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Szybkie komendy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Tylko przerwanie"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Rozmiar przerwania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Producent"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Maksymalna zgłoszona długość USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Maksymalny okres ważności danych"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Maksymalna liczba powtórzeń"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Maksymalne opóźnienie startu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Maksymalna liczba połączeń"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Maksymalna liczba prób uruchomienia sterownika."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Maksymalny czas w sekundach miedzy odświeżaniem informacji o UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Minimalna wymagana liczba lub zasilacze"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Model"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -280,17 +313,17 @@ msgstr "CGI NUT - administrator"
 msgid "NUT CGI - main"
 msgstr "CGI NUT - główny"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Monitor NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Serwer NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Użytkownicy NUT"
 
@@ -310,7 +343,7 @@ msgstr "Serwer NUT - administrator"
 msgid "NUT server - main"
 msgstr "Serwer NUT - główny"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Nazwa UPS"
 
@@ -323,179 +356,219 @@ msgstr "Sieciowe narzędzia UPS"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Konfiguracja CGI narzędzi sieciowych UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Konfiguracja monitorowania narzędzi sieciowych UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Konfiguracja serwera narzędzi sieciowych UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Bez blokady"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Brak OID-ów transferu niskiego/wysokiego napięcia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Flagi powiadomień"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Ustawienia powiadomień"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Polecenie powiadomienia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Opóźnienie wyłączenia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Opóźnienie włączenia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Hasło"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Ścieżka zawierająca certyfikaty urzędów certyfikacji, które odpowiadają "
-"certyfikatowi hosta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Ścieżka do pliku stanu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Okres, po którym dane są uznawane za nieaktualne"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Interwał sondowania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Częstotliwość sondowania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Alert o częstotliwości sondowania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Częstotliwość sondowań"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Wartość mocy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Główny"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Główny (przestarzały)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produkt (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Wymagaj SSL i upewnij się, że serwer CN pasuje do nazwy hosta"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Opóźnienie powtarzania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rola"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Uruchom sterowniki w środowisku chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Użytkownik RunAs"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Społeczność SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Próby SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Limit czasu SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Wersja SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Numer seryjny"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Ustawienie uprawnień portu szeregowego USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Ustaw zmienne"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Polecenie wyłączenia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Komunikacja synchroniczna"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Nazwa tej sekcji będzie używana jako nazwa UPS w innych miejscach"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -503,29 +576,29 @@ msgstr ""
 "Przekazywane jest to do sterownika, więc upewnij się, że obsługuje on tę "
 "opcję"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Czas w sekundach między ponownymi próbami uruchomienia sterownika."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Czas w sekundach, jaki upsdrvctl będzie czekać na zakończenie uruchamiania"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "Dodatkowy UPS (przestarzały)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "Ustawienia użytkownika monitora UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "Główny UPS (przestarzały)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Ustawienia globalne serwera UPS"
 
@@ -533,70 +606,96 @@ msgstr "Ustawienia globalne serwera UPS"
 msgid "UPS name"
 msgstr "Nazwa UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Magistrala(-e) USB (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "Identyfikator produktu USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "Identyfikator dostawcy USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Nie można uruchomić ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Użyj %s, aby zobaczyć pełną listę poleceń obsługiwanych przez UPS (wymaga "
 "pakietu %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Typ użytkownika (Główny/Dodatkowy)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Dostawca (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Zweryfikuj wszystkie połączenia z SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Obejście dla błędnego firmware"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Zapis do dziennika systemowego"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Zapisz do dziennika systemowego i wykonaj polecenie powiadomienia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "zainstalować sterowniki"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon porzuca uprawnienia dla tego użytkownika"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Ścieżka certyfikatu CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Plik certyfikatu (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Ścieżka zawierająca certyfikaty urzędów certyfikacji, które odpowiadają "
+#~ "certyfikatowi hosta"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Wymagaj SSL i upewnij się, że serwer CN pasuje do nazwy hosta"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Nie można uruchomić ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Zweryfikuj wszystkie połączenia z SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Ścieżka sterownika"

--- a/applications/luci-app-nut/po/pt/nut.po
+++ b/applications/luci-app-nut/po/pt/nut.po
@@ -12,105 +12,134 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.6.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Tempo(s) adicionais para desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Endereços para ouvir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Ações permitidas"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Como configurado pelo NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Escravo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Auxiliar (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes a serem lidos do pipe de interrupção"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Caminho do Certificado CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Ficheiro do certificado (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Controle do UPS via CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Mensagem de notificação personalizada para tipo de mensagem"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Tempo inerte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Predefinição para UPSs sem este campo."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Atraso para desligar forçadamente via comando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Atraso para ligar o UPS caso a energia volte depois de um comando de "
 "desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Descrição (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Nome de exibição"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Não bloquear a porta ao iniciar o driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Configuração do Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Configurações Globais do Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Ordem de Desligamento do Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "O driver espera que os dados sejam consumidos pelo upsd antes de publicar "
 "mais."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Derrubar os privilégios deste utilizador"
 
@@ -118,7 +147,7 @@ msgstr "Derrubar os privilégios deste utilizador"
 msgid "Enable"
 msgstr "Ativar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -126,35 +155,35 @@ msgstr ""
 "Ativa um script hotplug que faz com que todos os aparelhos ttyUSB (por "
 "exemplo, USB serial) sejam feitos ler-escrever para utilizadores 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Executar um comando de notificação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Desligamento Forçado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Configurações Globais"
 
@@ -163,7 +192,7 @@ msgstr "Configurações Globais"
 msgid "Go to NUT CGI"
 msgstr "Ir para o NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -175,7 +204,7 @@ msgstr ""
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Sincronização de anfitrião"
 
@@ -183,78 +212,82 @@ msgstr "Sincronização de anfitrião"
 msgid "Hostname or IP address"
 msgstr "Nome de host ou endereço IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Nome de host ou endereço do UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Endereço IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Se esta lista estiver vazia, precisa de %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorar o Nível de Bateria Fraca"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Comandos instantâneos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Apenas Interromper"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Tamanho da Interrupção"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Fabricante (Display)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Relatório de comprimento máximo do USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Idade Máxima dos Dados"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Quantidade Máxima de Tentativas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Atraso Máximo de Arranque"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Quantidade máxima de conexões"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Quantidade máxima de vezes para tentar iniciar o driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Tempo máximo em segundos para atualizar a condição do estado do UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Número de quantidade mínima necessária ou fontes de alimentação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modelo (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -269,17 +302,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Ferramentas de Rede do UPS (Monitoramento)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Ferramentas de Rede do UPS (Servidor)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Utilizadores NUT"
 
@@ -299,7 +332,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Nome do UPS"
 
@@ -312,181 +345,219 @@ msgstr "Ferramentas de Rede do UPS"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Configuração CGI das Ferramentas de Rede do UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Configuração das Ferramentas de Monitoramento da Rede do UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Configuração do Servidor das Ferramentas de Rede do UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Sem Bloqueio"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Não há OIDs de transferência de baixa/alta tensão"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Sinalizadores de notificação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Configurações de notificação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Comando de notificação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Atraso(s) para desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Atraso(s) para Ligar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Caminho contendo os certificados AC para combinar com o certificado do "
-"equipamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Caminho para o ficheiro de estado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Período quando os dados serão considerados obsoletos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Intervalo de Sondagem"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Frequência da sondagem"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Frequência de alerta da sondagem"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Frequência(s) da sondagem"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Valor de potência"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primário"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Primário (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produto (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"Exigir o SSL e certificar-se de que o servidor CN corresponde com o nome do "
-"host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Atraso de Nova Tentativa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Função"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Executar o driver num ambiente chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Executar como o Utilizador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Comunicação SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Tentativas SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Tempo limite do SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Versão do SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Número de Série"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Definir as permissões da porta serial USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Definir as variáveis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Comando de desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Comunicação Síncrona"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "O nome desta secção será usado como o nome do UPS em outros lugares"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -494,30 +565,30 @@ msgstr ""
 "Isto é passado para o driver, então certifique-se de que o driver suporte "
 "esta opção"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tempo em segundos entre as tentativas de reinício do driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Tempo de espera em segundos onde o upsdrvctl irá aguardar que o driver "
 "finalize a inicialização"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "Auxiliar UPS (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "UPS Primário (Obsoleto)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Configurações Globais do Servidor UPS"
 
@@ -525,70 +596,98 @@ msgstr "Configurações Globais do Servidor UPS"
 msgid "UPS name"
 msgstr "Nome do UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Bus(es) USB (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "ID do Produto USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "ID do Fornecedor USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Incapaz de executar ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Use %s para ver a lista completa dos comandos compatíveis com o seu UPS "
 "(requer o pacote '%s')"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Tipo de utilizador (Primário/Auxiliar)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nome do utilizador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Fornecedor (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Verificar todas as conexões com SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Solução alternativa para firmware com problemas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Registar no syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Escrever para syslog e executar o comando notify"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "instalar drivers"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "O upsmon derrubou os privilégios para este utilizador"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Caminho do Certificado CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Ficheiro do certificado (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Caminho contendo os certificados AC para combinar com o certificado do "
+#~ "equipamento"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "Exigir o SSL e certificar-se de que o servidor CN corresponde com o nome "
+#~ "do host"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Incapaz de executar ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Verificar todas as conexões com SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Caminho do Driver"

--- a/applications/luci-app-nut/po/pt_BR/nut.po
+++ b/applications/luci-app-nut/po/pt_BR/nut.po
@@ -12,105 +12,134 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2026.6.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Tempo(s) adicionais para desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Endereços para ouvir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Ações permitidas"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Como configurado pelo NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Escravo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Bytes a serem lidos do pipe de interrupção"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Caminho do Certificado CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Arquivo do certificado (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Controle do Nobreak via CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Tempo inerte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Predefinição para Nobreaks sem este campo."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Atraso para desligar a força via comando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Atraso para ligar o Nobreak caso a energia volte depois de um comando de "
 "desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Descrição (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Nome de exibição"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Não bloqueie a porta ao iniciar o driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Controlador"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Configuração do Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Configurações Globais do Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Ordem de Desligamento do Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "O driver espera que os dados sejam consumidos pelo nobreak antes de publicar "
 "mais."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Derrubar os privilégios deste usuário"
 
@@ -118,7 +147,7 @@ msgstr "Derrubar os privilégios deste usuário"
 msgid "Enable"
 msgstr "Ativar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -126,35 +155,35 @@ msgstr ""
 "Habilita um script hotplug que faz com que todos os dispositivos ttyUSB (por "
 "exemplo, serial USB) sejam lidos-escritos como usuários 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Executar um comando de notificação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Desligamento Forçado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Configurações Globais"
 
@@ -163,7 +192,7 @@ msgstr "Configurações Globais"
 msgid "Go to NUT CGI"
 msgstr "Ir para o NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -175,7 +204,7 @@ msgstr ""
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -183,79 +212,83 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Nome de host ou endereço IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Nome de host ou endereço do Nobreak"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Endereço IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Se esta lista estiver vazia, você precisa %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorar o Nível de Bateria Fraca"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Comandos instantâneos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Interromper Apenas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Tamanho da Interrupção"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Fabricante (Display)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Relatório de comprimento máximo do USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Idade Máxima dos Dados"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Quantidade Máxima de Tentativas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Atraso Máximo de Arranque"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Quantidade máxima de conexões"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Quantidade máxima de vezes para tentar iniciar o driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 "Tempo máximo em segundos para atualizar a condição do estado do Nobreak"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Número de quantidade mínima necessária ou fontes de alimentação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modelo (Display)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -270,17 +303,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Ferramentas de Rede do Nobreak (Monitoramento)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Ferramentas de Rede do Nobreak (Servidor)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Usuários NUT"
 
@@ -300,7 +333,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Nome do Nobreak"
 
@@ -313,209 +346,248 @@ msgstr "Ferramentas de Rede do Nobreak"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Configuração CGI das Ferramentas de Rede do Nobreak"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Configuração das Ferramentas de Monitoramento da Rede do Nobreak"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Configuração do Servidor das Ferramentas de Rede do Nobreak"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Sem Bloqueio"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Não há OIDs de transferência de baixa/alta tensão"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Comando de notificação"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Atraso(s) para desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Atraso(s) para Ligar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Senha"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Caminho contendo os certificados CA para combinar com o certificado do "
-"equipamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Caminho para o arquivo de estado"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Período onde os dados serão considerados obsoletos"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Intervalo do poll"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Frequência do poll"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Frequência de alerta do Pool"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Frequência(s) do poll"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Porta"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Valor de potência"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primário"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produto (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"Exigir o SSL e certificar-se de que o servidor CN coincide com o nome do host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Atraso de Tentativas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Papel"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Executar o driver em um ambiente chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Executar como um Usuário"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Comunicação SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Tentativas SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Tempo limite do SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Versão do SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Número de Série"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Definir as permissões da porta serial USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Definir as variáveis"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Comando de desligamento"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Comunicação Síncrona"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "O nome desta seção será usado como o nome do Nobreak em outros lugares"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tempo em segundos entre as tentativas de reinício do driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Tempo de espera em segundos onde o upsdrvctl vai aguardar o driver para "
 "finalizar a inicialização"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Configurações Globais do Servidor Nobreak"
 
@@ -523,70 +595,98 @@ msgstr "Configurações Globais do Servidor Nobreak"
 msgid "UPS name"
 msgstr "Nome do Nobreak"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Barramento(s) USB (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "ID do Produto USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "ID do Fornecedor USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Não foi possível executar o ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Use %s para ver a lista completa dos comandos compatíveis com o seu Nobreak "
 "(requer o pacote '%s')"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Fornecedor (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Verifique todas as conexões com SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Solução alternativa para firmware com problemas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Registrar no syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "Instalar controladores"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "O upsmon derrubou os privilégios para este usuário"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Caminho do Certificado CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Arquivo do certificado (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Caminho contendo os certificados CA para combinar com o certificado do "
+#~ "equipamento"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "Exigir o SSL e certificar-se de que o servidor CN coincide com o nome do "
+#~ "host"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Não foi possível executar o ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Verifique todas as conexões com SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Caminho do Driver"

--- a/applications/luci-app-nut/po/ro/nut.po
+++ b/applications/luci-app-nut/po/ro/nut.po
@@ -13,105 +13,134 @@ msgstr ""
 "(n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 "X-Generator: Weblate 5.14.1-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Timp(i) suplimentar(i) de oprire"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresele la care se ascultă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Acțiuni permise"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "După cum este configurat de NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Secundar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Byte de citit din conducta de întrerupere"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Calea certificatului CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Fișier de certificat (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Controlul UPS prin CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Timp mort"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Implicit pentru UPS-urile fără acest câmp."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Întârziere pentru comanda de oprire a puterii"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Întârzierea de a porni UPS-ul în cazul în care revine curentul după "
 "întreruperea alimentării"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Descriere (Afișare)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Afișați numele"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Nu blocați portul la pornirea driverului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Configurația șoferului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Setări globale ale driverului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Ordinul de oprire a șoferului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Driverul așteaptă ca datele să fie consumate de upsd înainte de a publica "
 "mai multe."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Eliminați privilegiile acestui utilizator"
 
@@ -119,7 +148,7 @@ msgstr "Eliminați privilegiile acestui utilizator"
 msgid "Enable"
 msgstr "Activați"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -127,35 +156,35 @@ msgstr ""
 "Activează un script hotplug care face ca toate dispozitivele ttyUSB (de "
 "exemplu, USB serial) să fie citite-scrise în grup ca utilizator 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Executarea comenzii de notificare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Oprire forțată"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Setări generale"
 
@@ -164,7 +193,7 @@ msgstr "Setări generale"
 msgid "Go to NUT CGI"
 msgstr "Mergeți la NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -176,7 +205,7 @@ msgstr ""
 msgid "Host"
 msgstr "Gazdă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -184,78 +213,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Numele de gazdă sau adresa IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Numele de gazdă sau adresa UPS-ului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Adresă IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignoră"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignoră bateria descărcată"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Comenzi instantanee"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Numai întrerupere"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Dimensiunea întreruperii"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Producător (Afișaj)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Lungimea maximă USB HID raportată"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Vârsta maximă a datelor"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Reîncercări maxime"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Întârziere maximă de pornire"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Conexiuni maxime"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Numărul maxim de încercări de pornire a unui driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Timp maxim în secunde între actualizarea stării UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Numărul minim necesar de surse de alimentare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Model (Afișaj)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -270,17 +303,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Instrumente de rețea UPS (Monitor)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Instrumente de rețea UPS (server)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Utilizatori NUT"
 
@@ -300,7 +333,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Numele UPS"
 
@@ -313,211 +346,250 @@ msgstr "Instrumente de rețea UPS"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Instrumente de rețea UPS Instrumente de configurare CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Rețea UPS Instrumente de monitorizare Configurație"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Rețeaua UPS Tools Configurarea serverului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Fără blocare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Nu există OID-uri de transfer de tensiune joasă/înaltă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Comanda de notificare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Oprire Întârziere (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Întârziere de pornire (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Parolă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Calea care conține certificatele ca pentru a se compara cu certificatul de "
-"gazdă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Calea către fișierul de stare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Perioada după care datele sunt considerate expirate"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Intervalul de interogare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Frecvența sondajului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Alertă de frecvență a sondajului"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Frecvența de interogare (s)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Valoarea puterii"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Principal"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produs (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"Cereți SSL și asigurați-vă că CN-ul serverului corespunde cu numele de gazdă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Întârziere de reîncercare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Rulați driverele într-un mediu chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "RunAs Utilizator"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Comunitatea SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Reîncercări SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Timpul de așteptare SNMP (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Versiunea SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Numărul de serie"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Setați permisiunile pentru portul serial USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Setați variabilele"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Comandă de oprire"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Comunicare sincronă"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Numele acestei secțiuni va fi folosit ca nume UPS în altă parte"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Timpul, exprimat în secunde, dintre încercările de reluare a pornirii "
 "șoferului."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Timpul în secunde în care upsdrvctl va aștepta ca driverul să termine de "
 "pornit"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Setări globale ale serverului UPS"
 
@@ -525,70 +597,95 @@ msgstr "Setări globale ale serverului UPS"
 msgid "UPS name"
 msgstr "UPS nume"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB Bus(e) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "ID produs USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "Identitatea furnizorului USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Folosiți %s pentru a vedea lista completă a comenzilor pe care le suportă "
 "UPS-ul dumneavoastră (necesită pachetul %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Nume Utilizator"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Furnizor (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Verifică toate conexiunile cu SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Soluție de rezolvare pentru firmware-ul eronat"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Scrieți în syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon renunță privilegiile pentru acest utilizator"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Calea certificatului CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Fișier de certificat (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Calea care conține certificatele ca pentru a se compara cu certificatul "
+#~ "de gazdă"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "Cereți SSL și asigurați-vă că CN-ul serverului corespunde cu numele de "
+#~ "gazdă"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Verifică toate conexiunile cu SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Traiectoria șoferului"

--- a/applications/luci-app-nut/po/ru/nut.po
+++ b/applications/luci-app-nut/po/ru/nut.po
@@ -14,104 +14,133 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Дополнительное время выключения"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Адреса для прослушивания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Разрешённые действия"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Настройка с помощью NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Слейв"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Вспомогательный (устарело)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Байты для чтения из канала прерывания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Путь к сертификату CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Файл сертификата (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Управление ИБП через CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Пользовательское сообщение для типа события"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Простой"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "По умолчанию для ИБП без этого поля."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Задержка для команды отключения питания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Задержка включения ИБП при возобновлении подачи питания после отключения "
 "питания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Описание (показать)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Отображаемое название"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Не блокировать порт при запуске драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Драйвер"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Настройки драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Глобальные настройки драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Порядок выключения драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Драйвер ожидает пока upsd обработает новые данных перед их публикацией."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Сбросить привилегии для этого пользователя"
 
@@ -119,7 +148,7 @@ msgstr "Сбросить привилегии для этого пользова
 msgid "Enable"
 msgstr "Включить"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -127,11 +156,11 @@ msgstr ""
 "Включает скрипт hotplug, который делает все устройства ttyUSB (например, "
 "последовательный USB) группой чтения-записи от имени пользователя 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Выполнить команду уведомления"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -140,7 +169,7 @@ msgstr ""
 "Product ID), чтобы NUT мог настроить права и драйвер получил доступ к "
 "устройству"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -149,7 +178,7 @@ msgstr ""
 "(USB Vendor ID), чтобы NUT мог настроить права и драйвер получил доступ к "
 "устройству"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -159,12 +188,12 @@ msgstr ""
 "типа (когда USB Product ID и USB Vendor ID совпадают). Может применяться и "
 "для других ИБП."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Принудительное выключение"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Глобальные настройки"
 
@@ -173,7 +202,7 @@ msgstr "Глобальные настройки"
 msgid "Go to NUT CGI"
 msgstr "Перейти к NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Предоставить доступ с правами администратора к UCI для luci-app-nut"
 
@@ -185,7 +214,7 @@ msgstr "Предоставить ограниченный доступ к UCI д
 msgid "Host"
 msgstr "Хост"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Синхронизация хоста"
 
@@ -193,78 +222,82 @@ msgstr "Синхронизация хоста"
 msgid "Hostname or IP address"
 msgstr "Имя хоста или IP адрес"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Имя или адрес хоста UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-адрес"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Если этот список пуст, вам нужно %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Игнорировать"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Игнорировать низкий уровень заряда батареи"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Мгновенные команды"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Только прерывания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Размер прерывания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Производитель (отображаемый)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Максимальная заявленная длина USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Максимальный срок хранения"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Максимальное количество попыток"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Максимальная задержка запуска"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Максимальное количество подключений"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Максимальное количество попыток запуска драйвера."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Максимальное количество секунд между обновлением статуса UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Минимально необходимое количество источников питания"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Модель (дисплей)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -279,17 +312,17 @@ msgstr "NUT CGI — администрирование"
 msgid "NUT CGI - main"
 msgstr "NUT CGI — главная"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Сетевые инструменты ИБП (монитор)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Сетевые инструменты ИБП (сервер)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Пользователи NUT"
 
@@ -309,7 +342,7 @@ msgstr "Сервер NUT — администрирование"
 msgid "NUT server - main"
 msgstr "Сервер NUT — главная"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Имя ИБП"
 
@@ -322,179 +355,221 @@ msgstr "Утилиты Сетевого ИБП"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Сетевые инструменты ИБП Конфигурация CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Сетевые инструменты ИБП Настройка мониторинга"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Сетевые инструменты ИБП Конфигурация сервера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Нет защиты"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Отсутствие OID для передачи низкого/высокого напряжения"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Флаги уведомлений"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Настройки уведомлений"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Команда уведомления"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Задержка выключения (сек.)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Задержка включения (сек.)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Пароль"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Путь, содержащий CA-сертификаты для сопоставления с сертификатом хоста"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Путь к файлу состояния"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Период, после которого данные считаются устаревшими"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Интервал опроса"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Частота опроса"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Оповещение о частоте опроса"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Частота опроса"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Значение мощности"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Мастер"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Основной (устарело)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Продукт (регулярное выражение)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Требовать SSL и проверять соответствие CN-сервера имени хоста"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Задержка повтора"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Роль"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Запуск драйверов в среде chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Выполнить как пользователь"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP-сообщество"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Повторные попытки SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Время ожидания SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Версия SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Серийный номер"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Установите разрешения последовательного порта USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Объявить переменные"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Команда выключения"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Синхронная связь"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 "Название этого раздела будет использоваться в качестве названия ИБП в других "
 "местах"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -502,31 +577,31 @@ msgstr ""
 "Параметр передаётся драйверу напрямую. Убедитесь, что ваш драйвер "
 "поддерживает эту опцию"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Время в секундах между повторными попытками запуска драйвера."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Время в секундах, в течение которого upsdrvctl будет ждать завершения "
 "запуска драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "Вспомогательный ИБП (устарело)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 "Пользовательские настройки мониторинга источника бесперебойного питания (UPS)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "Основной ИБП (устарело)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Глобальные настройки сервера ИБП"
 
@@ -534,70 +609,95 @@ msgstr "Глобальные настройки сервера ИБП"
 msgid "UPS name"
 msgstr "Имя ИБП"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB шина(шины) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB ИД устройства"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB ИД Вендора"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Невозможно запустить ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Используйте %s для просмотра полного списка команд, которые поддерживает ваш "
 "ИБП (требуется пакет %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Тип пользователя (основной/вспомогательный)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Вендор (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Проверка всех соединений с помощью SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Костыль для кривой прошивки"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Запись в syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Записать в syslog и выполнить команду уведомления"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "установить драйверы"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon передаёт привилегии этому пользователю"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Путь к сертификату CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Файл сертификата (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Путь, содержащий CA-сертификаты для сопоставления с сертификатом хоста"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Требовать SSL и проверять соответствие CN-сервера имени хоста"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Невозможно запустить ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Проверка всех соединений с помощью SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Путь к драйверу"

--- a/applications/luci-app-nut/po/sgs/nut.po
+++ b/applications/luci-app-nut/po/sgs/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.7-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -157,7 +186,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "„SNMPv1“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "„SNMPv2c“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "„SNMPv3“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,65 +586,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "„chroot“"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/sk/nut.po
+++ b/applications/luci-app-nut/po/sk/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
 "X-Generator: Weblate 5.12-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Dodatočný čas vypnutia"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresy na ktorých načúvať"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Povolené akcie"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Ovládač"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -114,41 +143,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Povoliť"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Globálne nastavenia"
 
@@ -157,7 +186,7 @@ msgstr "Globálne nastavenia"
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "Hostiteľ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,77 +206,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Adresa IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -306,204 +339,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Heslo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -511,66 +586,72 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Používateľské meno"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
 

--- a/applications/luci-app-nut/po/sr/nut.po
+++ b/applications/luci-app-nut/po/sr/nut.po
@@ -13,101 +13,130 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.13-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Dodatno Ugasi Vreme(na)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adrese na kojim da slusa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Dozvoljene akcije"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Kao konfigurisano po NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Pomocni"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Бајтови за читање из цеви прекида"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Путања CA сертификата"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Датотека сертификата (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Контролишите UPS преко CGI-ја"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -115,41 +144,41 @@ msgstr ""
 msgid "Enable"
 msgstr "Омогући"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -158,7 +187,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -170,7 +199,7 @@ msgstr ""
 msgid "Host"
 msgstr "Домаћин"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -178,77 +207,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -264,17 +297,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -294,7 +327,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -307,204 +340,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Лозинка"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -512,68 +587,80 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Путања CA сертификата"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Датотека сертификата (SSL)"
 
 #~ msgid "%s is mutually exclusive to other choices"
 #~ msgstr "je promenljivo pogotovo za druge izbore"

--- a/applications/luci-app-nut/po/sv/nut.po
+++ b/applications/luci-app-nut/po/sv/nut.po
@@ -12,103 +12,132 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Ytterligare avstängningstid(er)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Adresser att lyssna på"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Tillåtna åtgärder"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Som konfigurerat av NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Sekundär"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Sekundär (föråldrad)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Antal byte att läsa från interrupt-pipe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Sökväg till CA-certifikat"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Certifikatfil (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Styr UPS via CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Anpassat aviseringsmeddelande för meddelandetyp"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Dödtid"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Standard för UPS:er utan detta fält."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Fördröjning för kommandot kill power"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Fördröjning innan UPS:en slås på om strömmen återkommer efter avstängning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Beskrivning (visning)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Visningsnamn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Lås inte porten när drivrutinen startas"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "drivrutin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Konfiguration för drivrutin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Globala inställningar för drivrutin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Drivrutinernas avstängningsordning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Drivrutinen väntar tills data har konsumerats av upsd innan mer publiceras."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Sänk behörigheterna till denna användare"
 
@@ -116,7 +145,7 @@ msgstr "Sänk behörigheterna till denna användare"
 msgid "Enable"
 msgstr "Aktivera"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -124,11 +153,11 @@ msgstr ""
 "Aktiverar ett hotplug-skript som ger gruppen läs- och skrivbehörighet till "
 "alla ttyUSB-enheter (t.ex. seriell USB) som användaren %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Kör aviseringskommando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -136,7 +165,7 @@ msgstr ""
 "För USB HID-baserade UPS:er krävs USB-produkt-ID för att NUT ska kunna ange "
 "behörigheter så att drivrutinen får åtkomst till UPS:en."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -144,7 +173,7 @@ msgstr ""
 "För USB HID-baserade UPS:er krävs USB-tillverkar-ID för att NUT ska kunna "
 "ange behörigheter så att drivrutinen får åtkomst till UPS:en."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -154,12 +183,12 @@ msgstr ""
 "(identiskt USB-produkt- och tillverkar-ID). Även andra UPS:er kan använda "
 "värdet."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Tvingad avstängning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Globala inställningar"
 
@@ -168,7 +197,7 @@ msgstr "Globala inställningar"
 msgid "Go to NUT CGI"
 msgstr "Gå till CGI för NUT"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Ge luci-app-nut administrativ UCI-åtkomst"
 
@@ -180,7 +209,7 @@ msgstr "Ge luci-app-nut begränsad UCI-läsåtkomst"
 msgid "Host"
 msgstr "Värd"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Värdsynkronisering"
 
@@ -188,78 +217,82 @@ msgstr "Värdsynkronisering"
 msgid "Hostname or IP address"
 msgstr "Värdnamn eller IP-adress"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS:ens värdnamn eller adress"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-adress"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Om listan är tom måste du %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ignorera"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ignorera låg batterinivå"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Direktkommandon"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Endast avbrott"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Avbrottsstorlek"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Tillverkare (visning)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Högsta rapporterade USB HID-längd"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Högsta dataålder"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Högsta antal försök"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Högsta startfördröjning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Högsta antal anslutningar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Högsta antal försök att starta en drivrutin."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Högsta tid i sekunder mellan uppdateringar av UPS-status"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Minsta antal strömförsörjningar som krävs"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Modell (visning)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -274,17 +307,17 @@ msgstr "NUT CGI – administration"
 msgid "NUT CGI - main"
 msgstr "NUT CGI – huvud"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "NUT-övervakning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "NUT-server"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT-användare"
 
@@ -304,7 +337,7 @@ msgstr "NUT-server – administration"
 msgid "NUT server - main"
 msgstr "NUT-server – huvud"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "UPS-namn"
 
@@ -317,177 +350,219 @@ msgstr "Network UPS Tools"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Konfiguration av Network UPS Tools CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Övervakningskonfiguration för Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Serverkonfiguration för Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Ingen låsning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Inga OID:er för övergång vid låg/hög spänning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Aviseringsflaggor"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Aviseringsinställningar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Aviseringskommando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Avstängningsfördröjning(ar)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Startfördröjning(ar)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Lösenord"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Sökväg med CA-certifikat som ska matchas mot värdcertifikatet"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Sökväg till tillståndsfil"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Tid efter vilken data betraktas som inaktuella"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Avsökningsintervall"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Avsökningsfrekvens"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Avsökningsfrekvens vid varning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Avsökningsfrekvens(er)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Effektvärde"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Primär"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Primär (föråldrad)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Produkt (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Kräv SSL och kontrollera att serverns CN matchar värdnamnet"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Fördröjning före nytt försök"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Roll"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Kör drivrutiner i en chroot(2)-miljö"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Kör som användare"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP-community"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP-försök"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP-tidsgräns(er)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP-version"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Serienummer"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Ange behörigheter för seriell USB-port"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Ange variabler"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Avstängningskommando"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Synkron kommunikation"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Namnet på det här avsnittet används som UPS-namn på andra ställen."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -495,29 +570,29 @@ msgstr ""
 "Detta skickas vidare till drivrutinen, så kontrollera att drivrutinen stöder "
 "alternativet."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Tid i sekunder mellan nya försök att starta drivrutinen."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Tid i sekunder som upsdrvctl väntar på att drivrutinen ska starta färdigt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "Sekundär UPS (föråldrad)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "Användarinställningar för UPS-övervakning"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "Primär UPS (föråldrad)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Globala inställningar för UPS-server"
 
@@ -525,70 +600,82 @@ msgstr "Globala inställningar för UPS-server"
 msgid "UPS name"
 msgstr "UPS-namn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB-buss(ar) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB-produkt-ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB-tillverkar-ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Det gick inte att köra ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Använd %s för att se hela listan över kommandon som UPS:en stöder (kräver "
 "paketet %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Användartyp (primär/sekundär)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Användarnamn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Tillverkare (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr "Verifiera alla anslutningar med SSL"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Lösning för felaktig firmware"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Skriv till syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Skriv till syslog och kör aviseringskommandot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "installera drivrutiner"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon släpper behörigheter till denna användare"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Genväg för CA-certifikat"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Certifikat-fil (SSL)"
 
 #~ msgid "Driver Path"
 #~ msgstr "Genväg för drivrutin"

--- a/applications/luci-app-nut/po/ta/nut.po
+++ b/applications/luci-app-nut/po/ta/nut.po
@@ -10,101 +10,130 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "கூடுதல் பணிநிறுத்தம் நேரம் (கள்)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "கேட்க வேண்டிய முகவரிகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "அனுமதிக்கப்பட்ட செயல்கள்"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "நட்டு கட்டமைக்கப்பட்டபடி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "துணை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "குறுக்கீடு குழாயிலிருந்து படிக்க பைட்டுகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA சான்றிதழ் பாதை"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "சான்றிதழ் கோப்பு (எச்.எச்.எல்)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "சிசிஐ வழியாக அப்களை கட்டுப்படுத்தவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "காலக்கெடு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "இந்த புலம் இல்லாமல் அப்சசுக்கு இயல்புநிலை."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "பவர் கட்டளையை கொல்ல நேரந்தவறுகை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "சக்தியைக் கொன்ற பிறகு ஆற்றல் திரும்பினால் யுபிஎச் மீது அதிகாரத்திற்கு நேரந்தவறுகை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "விளக்கம் (காட்சி)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "காட்சி பெயர்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "டிரைவரைத் தொடங்கும்போது துறைமுகத்தை பூட்ட வேண்டாம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "இயக்கி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "இயக்கி உள்ளமைவு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "டிரைவர் உலகளாவிய அமைப்புகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "இயக்கி பணிநிறுத்தம் ஆர்டர்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "மேலும் வெளியிடுவதற்கு முன்பு தரவுகளை யுபிஎச்டி நுகர இயக்கி காத்திருக்கிறது."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "இந்த பயனருக்கு சலுகைகளை விடுங்கள்"
 
@@ -112,7 +141,7 @@ msgstr "இந்த பயனருக்கு சலுகைகளை வி
 msgid "Enable"
 msgstr "இயக்கு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -120,35 +149,35 @@ msgstr ""
 "அனைத்து Ttyusb சாதனங்களையும் (எ.கா. சீரியல் யூ.எச்.பி) குழுவை வாசிக்க-எழுதும் அனைத்து "
 "TTYUSB சாதனங்களையும் பயனர் %s ஆக மாற்றும் ஆட் பிளக் ச்கிரிப்டை இயக்குகிறது"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "அறிவிப்பு கட்டளையை செயல்படுத்தவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "கட்டாய பணிநிறுத்தம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "உலகளாவிய அமைப்புகள்"
 
@@ -157,7 +186,7 @@ msgstr "உலகளாவிய அமைப்புகள்"
 msgid "Go to NUT CGI"
 msgstr "நட் சிசிஐக்குச் செல்லுங்கள்"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -169,7 +198,7 @@ msgstr ""
 msgid "Host"
 msgstr "விருந்தோம்பி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -177,78 +206,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "ஓச்ட்பெயர் அல்லது ஐபி முகவரி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "ஓச்ட்பெயர் அல்லது யுபிஎச் முகவரி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "ஐபி முகவரி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "இந்த பட்டியல் காலியாக இருந்தால் நீங்கள் %s தேவை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "புறக்கணிக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "குறைந்த பேட்டரியை புறக்கணிக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "உடனடி கட்டளைகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "குறுக்கீடு மட்டுமே"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "குறுக்கீடு அளவு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "உற்பத்தியாளர் (காட்சி)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "மேக்ச் யூ.எச்.பி மறைக்கப்பட்ட நீளம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "தரவின் அதிகபட்ச அகவை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "அதிகபட்ச முயற்சிகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "அதிகபட்ச தொடக்க நேரந்தவறுகை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "அதிகபட்ச இணைப்புகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "இயக்கி தொடங்க முயற்சிக்க அதிகபட்சம்."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "யுபிஎச் நிலையின் புதுப்பிப்புக்கு இடையில் விநாடிகளில் அதிகபட்ச நேரம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "குறைந்தபட்ச தேவையான எண் அல்லது மின்சாரம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "மாதிரி (காட்சி)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -263,17 +296,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "நட்டு மானிட்டர்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "நட்டு சேவையகம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "நட்டு பயனர்கள்"
 
@@ -293,7 +326,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "யுபிஎச் பெயர்"
 
@@ -306,205 +339,246 @@ msgstr "பிணையம் யுபிஎச் கருவிகள்"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "பிணையம் யுபிஎச் கருவிகள் சிசிஐ உள்ளமைவு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "பிணையம் யுபிஎச் கருவிகள் கண்காணிப்பு உள்ளமைவு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "பிணையம் யுபிஎச் கருவிகள் சேவையக உள்ளமைவு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "பூட்டு இல்லை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "குறைந்த/உயர் மின்னழுத்த பரிமாற்ற OIDS இல்லை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "கட்டளைக்கு அறிவிக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "முடக்கப்பட்ட நேரந்தவறுகை (கள்)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "நேரந்தவறுகை (கள்) மீது"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "கடவுச்சொல்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "புரவலன் சான்றிதழுடன் பொருந்தக்கூடிய CA சான்றிதழ்கள் கொண்ட பாதை"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "மாநில கோப்பிற்கான பாதை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "தரவு பழையதாகக் கருதப்படும் காலம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "வாக்கெடுப்பு இடைவெளி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "வாக்கெடுப்பு அதிர்வெண்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "வாக்கெடுப்பு அதிர்வெண் எச்சரிக்கை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "வாக்களிப்பு அதிர்வெண்"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "துறைமுகம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "ஆற்றல் மதிப்பு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "முதன்மை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "தயாரிப்பு (ரீசெக்ச்)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"எச்.எச்.எல் தேவை மற்றும் சேவையக சி.என் ஓச்ட்பெயருடன் பொருந்துகிறது என்பதை உறுதிப்படுத்தவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "தாமதத்தை மீண்டும் முயற்சிக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "பங்கு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "க்ரூட் (2) சூழலில் டிரைவர்களை இயக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "ரனாச் பயனர்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "எச்.என்.எம்.பி சமூகம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP முயற்சிகள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP நேரம் முடிந்தது (கள்)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP பதிப்பு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "வரிசை எண்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "யூ.எச்.பி சீரியல் துறைமுகம் அனுமதிகளை அமைக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "மாறிகள் அமைக்கவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "பணிநிறுத்தம் கட்டளை"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "ஒத்திசைவான தொடர்பு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "இந்த பிரிவின் பெயர் வேறு இடங்களில் யுபிஎச் பெயராகப் பயன்படுத்தப்படும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "ஓட்டுநருக்கு இடையிலான விநாடிகளில் நேரம் மீண்டும் முயற்சிகளைத் தொடங்குகிறது."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr "இயக்கி தொடங்கும் வரை அப்ச்டிர்விசிடிஎல் காத்திருக்கும் விநாடிகளில் நேரம்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "யுபிஎச் சேவையகம் உலகளாவிய அமைப்புகள்"
 
@@ -512,70 +586,96 @@ msgstr "யுபிஎச் சேவையகம் உலகளாவிய 
 msgid "UPS name"
 msgstr "யுபிஎச் பெயர்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "யூ.எச்.பி பச் (எச்) (ரீசெக்ச்)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "யூ.எச்.பி தயாரிப்பு ஐடி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "யூ.எச்.பி விற்பனையாளர் ஐடி"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "எல்.டி.டி இயக்க முடியவில்லை: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "உங்கள் யுபிஎச் ஆதரிக்கும் கட்டளைகளின் முழு பட்டியலையும் காண %s ஐப் பயன்படுத்தவும் ( %s "
 "தொகுப்பு தேவை)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "பயனர்பெயர்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "விற்பனையாளர் (ரீசெக்ச்)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "SSL உடனான அனைத்து தொடர்புகளையும் சரிபார்க்கவும்"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "தரமற்ற ஃபார்ம்வேர்க்கான பணித்தொகுப்பு"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "சிச்லாக் எழுதுங்கள்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "க்ரூட்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "இயக்கிகளை நிறுவவும்"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "இந்த பயனருக்கு யுப்ச்மோன் சலுகைகளை குறைக்கிறது"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA சான்றிதழ் பாதை"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "சான்றிதழ் கோப்பு (எச்.எச்.எல்)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "புரவலன் சான்றிதழுடன் பொருந்தக்கூடிய CA சான்றிதழ்கள் கொண்ட பாதை"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "எச்.எச்.எல் தேவை மற்றும் சேவையக சி.என் ஓச்ட்பெயருடன் பொருந்துகிறது என்பதை "
+#~ "உறுதிப்படுத்தவும்"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "எல்.டி.டி இயக்க முடியவில்லை: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "SSL உடனான அனைத்து தொடர்புகளையும் சரிபார்க்கவும்"
 
 #~ msgid "Driver Path"
 #~ msgstr "இயக்கி பாதை"

--- a/applications/luci-app-nut/po/templates/nut.pot
+++ b/applications/luci-app-nut/po/templates/nut.pot
@@ -1,101 +1,130 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr ""
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr ""
 
@@ -103,41 +132,41 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr ""
 
@@ -146,7 +175,7 @@ msgstr ""
 msgid "Go to NUT CGI"
 msgstr ""
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -158,7 +187,7 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -166,77 +195,81 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
@@ -252,17 +285,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr ""
 
@@ -282,7 +315,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr ""
 
@@ -295,204 +328,246 @@ msgstr ""
 msgid "Network UPS Tools CGI Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr ""
 
@@ -500,65 +575,71 @@ msgstr ""
 msgid "UPS name"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr ""

--- a/applications/luci-app-nut/po/tr/nut.po
+++ b/applications/luci-app-nut/po/tr/nut.po
@@ -12,103 +12,132 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Ek Kapanma Süre(leri)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Dinlenecek adresler"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "İzin verilen eylemler"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "NUT tarafından yapılandırıldığı gibi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "İkincil"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Kesinti hattından okunacak bayt sayısı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA Sertifikası yolu"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Sertifika dosyası (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "UPS'i CGI aracılığıyla kontrol edin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Ölü zaman"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Bu alanı olmayan UPS'ler için varsayılan."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Güç kesme komutu için gecikme"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "Kapatma gücünden sonra güç geri gelirse UPS'i çalıştırma gecikmesi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Açıklama (Ekran)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Ekran adı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Sürücüyü başlatırken bağlantı noktasını kilitlemeyin"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Sürücü"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Sürücü Yapılandırması"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Sürücü Global Ayarları"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Sürücü Kapatma Sırası"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr ""
 "Sürücü, daha fazla yayınlamadan önce verilerin upsd tarafından tüketilmesini "
 "bekler."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Bu kullanıcıya ayrıcalıkları bırakın"
 
@@ -116,7 +145,7 @@ msgstr "Bu kullanıcıya ayrıcalıkları bırakın"
 msgid "Enable"
 msgstr "Etkinleştir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -124,35 +153,35 @@ msgstr ""
 "Tüm ttyUSB aygıtları (örneğin: seri USB) grubunu %s kullanıcısı olarak "
 "okunur-yazılır yapan tak çıkar betiğini etkinleştirir"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Bildirim komutunu yürütün"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Zorla Kapatma"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Genel Ayarlar"
 
@@ -161,7 +190,7 @@ msgstr "Genel Ayarlar"
 msgid "Go to NUT CGI"
 msgstr "NUT CGI'ye git"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -173,7 +202,7 @@ msgstr ""
 msgid "Host"
 msgstr "Ana bilgisayar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -181,78 +210,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Ana makine adı veya IP adresi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS'in ana bilgisayar adı veya adresi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP Adresi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Göz ardı et"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Düşük Bataryayı Göz ardı et"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Anında komutlar"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Yalnızca Kes"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Kesme Boyutu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Üretici (Ekran)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Maks.USB HID Uzunluğu Bildirildi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Maksimum Veri Yaşı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Maksimum Yeniden Deneme"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Maksimum Başlatma Gecikmesi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Maksimum bağlantı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Bir sürücüyü başlatmayı denemek için maksimum sayı."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "UPS durumunun yenilenmesi arasındaki saniye cinsinden maksimum süre"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Minimum gerekli sayı veya güç kaynakları"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Model (Ekran)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -267,17 +300,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Ağ UPS Araçları (İzleme)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Ağ UPS Araçları (Sunucu)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT Kullanıcıları"
 
@@ -297,7 +330,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "UPS adı"
 
@@ -310,210 +343,250 @@ msgstr "Ağ UPS Araçları"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Ağ UPS Araçları CGI Yapılandırması"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Ağ UPS Araçları İzleme Yapılandırması"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Ağ UPS Araçları Sunucu Yapılandırması"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Kilit yok"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Düşük / yüksek voltaj transfer OID'leri yok"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Bildir komutu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Kapatma Gecikmesi (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Açma Gecikmesi (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Parola"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
 msgstr ""
-"Ana bilgisayar sertifikasıyla eşleştirmek için ca sertifikalarını içeren yol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Durum dosyasına giden yol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Verilerin eski olarak kabul edilmesi için geçmesi gereken süre"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Örnek alma Aralığı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Örnek alma sıklığı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Örnek alma sıklığı uyarısı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Örnek alma sıklığı(s)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 #, fuzzy
 msgid "Port"
 msgstr "Bağlantı noktası"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Güç değeri"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Ana"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Ürün (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
 msgstr ""
-"SSL gerektir ve sunucu CN'nin ana bilgisayar adıyla eşleştiğinden emin ol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Yeniden Deneme Gecikmesi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Rol"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Sürücüleri chroot(2) ortamında çalıştırın"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Kullanıcı Olarak Çalıştır"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP Topluluğu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP yeniden deneme sayısı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP zaman aşımı(s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP versiyonu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Seri numarası"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "USB seri bağlantı noktası izinlerini ayarlayın"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Değişkenleri ayarlayın"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Kapatma komutu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Senkronize İletişim"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Bu bölümün adı, başka bir yerde UPS adı olarak kullanılacaktır"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Sürücünün yeniden başlatma denemeleri arasındaki saniye cinsinden süre."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Upsdrvctl'nin sürücünün başlatmayı bitirmesini bekleyeceği saniye cinsinden "
 "süre"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS Sunucusu Global Ayarları"
 
@@ -521,70 +594,94 @@ msgstr "UPS Sunucusu Global Ayarları"
 msgid "UPS name"
 msgstr "UPS adı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB Veriyolu(lar) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB Ürün Kimliği"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB Satıcı Kimliği"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "UPS'inizin desteklediği komutların tam listesini görmek için %s kullanın (%s "
 "paketi gerektirir)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Satıcı (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Tüm bağlantıyı SSL ile doğrulayın"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Hatalı ürün yazılımı için geçici çözüm"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Sistem günlüğüne yaz"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon bu kullanıcıya ayrıcalıklar bırakır"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA Sertifikası yolu"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Sertifika dosyası (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr ""
+#~ "Ana bilgisayar sertifikasıyla eşleştirmek için ca sertifikalarını içeren "
+#~ "yol"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr ""
+#~ "SSL gerektir ve sunucu CN'nin ana bilgisayar adıyla eşleştiğinden emin ol"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Tüm bağlantıyı SSL ile doğrulayın"
 
 #~ msgid "Driver Path"
 #~ msgstr "Sürücü Yolu"

--- a/applications/luci-app-nut/po/uk/nut.po
+++ b/applications/luci-app-nut/po/uk/nut.po
@@ -13,103 +13,132 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "Додатковий час вимкнення (с)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Адреси для прослуховування"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Дозволені дії"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Як налаштовано NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Допоміжний"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "Допоміжний (застаріле)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Байти для читання з каналу переривання"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Шлях сертифіката ЦС"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Файл сертифікату (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Керувати ПБЖ за допомогою CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "Власне повідомлення для типу сповіщення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Мертвий час"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Типово для UPS без цього поля."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Затримка для команди вимкнення живлення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr ""
 "Затримка вмикання UPS, якщо живлення відновиться після його примусового "
 "вимкнення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Опис (відображення)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Відображуване імʼя"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Не блокувати порт під час запуску драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Драйвер"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Конфігурація драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Глобальні налаштування драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Послідовність вимкнення драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "Перед публікацією драйвер очікує, поки дані будуть використані upsd."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Знизити привілеї до цього користувача"
 
@@ -117,7 +146,7 @@ msgstr "Знизити привілеї до цього користувача"
 msgid "Enable"
 msgstr "Увімкнути"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -125,11 +154,11 @@ msgstr ""
 "Вмикає сценарій гарячого підключення, який надає всім пристроям ttyUSB "
 "(напр., послідовний USB) права на читання та запис у групі як користувачу %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Виконувати команду сповіщення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -137,7 +166,7 @@ msgstr ""
 "Для ДБЖ на базі USB HID потрібен USB Product Id, щоб NUT міг налаштувати "
 "дозволи для доступу драйвера до ДБЖ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -145,7 +174,7 @@ msgstr ""
 "Для ДБЖ на базі USB HID ідентифікатор виробника USB є обов’язковим, щоб NUT "
 "міг налаштувати дозволи для доступу драйвера до пристрою"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -155,12 +184,12 @@ msgstr ""
 "типу (з ідентичними кодами продукту та виробника). Інші ДБЖ також можуть "
 "використовувати це значення."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Примусове вимкнення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Загальні налаштування"
 
@@ -169,7 +198,7 @@ msgstr "Загальні налаштування"
 msgid "Go to NUT CGI"
 msgstr "Перейти до NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "Надати адміністратору доступ до UCI для luci-app-nut"
 
@@ -181,7 +210,7 @@ msgstr "Надати обмежений доступ до читання UCI д�
 msgid "Host"
 msgstr "Вузол"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "Синхронізація вузла"
 
@@ -189,78 +218,82 @@ msgstr "Синхронізація вузла"
 msgid "Hostname or IP address"
 msgstr "Імʼя вузла або IP-адреса"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Імʼя вузла або адреса UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP-адреса"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "Якщо цей список порожній, потрібно %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Ігнорувати"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Ігнорувати низький рівень заряду акумулятора"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Миттєві команди"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Лише переривання"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Розмір переривання"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Виробник (відображення)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Повідомлена максимальна довжина USB HID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Максимальний вік даних"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Максимальна кількість повторних спроб"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Максимальна затримка запуску"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Максимальна кількість підключень"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Максимальна кількість спроб запуску драйвера."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Максимальний час у секундах між оновленнями стану UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Мінімальна потрібна кількість джерел живлення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Модель (відображення)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -275,17 +308,17 @@ msgstr "NUT CGI: адмін"
 msgid "NUT CGI - main"
 msgstr "NUT CGI: головний"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Монітор NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Сервер NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Користувачі NUT"
 
@@ -305,7 +338,7 @@ msgstr "NUT-сервер: адмін"
 msgid "NUT server - main"
 msgstr "NUT-сервер: головний"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Назва UPS"
 
@@ -318,177 +351,219 @@ msgstr "Інструменти мережевих ДБЖ"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Конфігурація CGI Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Конфігурація моніторингу Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Конфігурація сервера Network UPS Tools"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Без блокування"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Немає OID передачі низької/високої напруги"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "Прапорці сповіщень"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "Налаштування сповіщень"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Команда сповіщення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Затримка вимкнення (с)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Затримка вмикання (с)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Пароль"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Шлях із сертифікатами ca для звірення з сертифікатом вузла"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Шлях до файлу стану"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Період, після якого дані вважаються застарілими"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Інтервал опитування"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Частота опитування"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Попередження про частоту опитування"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Частота(и) опитування"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Значення потужності"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Основний"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "Основний (застаріле)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Продукт (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Вимагати SSL та упевнитися, що CN сервера відповідає імені вузла"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Затримка повторної спроби"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Роль"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Запускати драйвери в середовищі chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Виконувати від імені користувача"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Спільнота SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Повторні спроби SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Тайм-аут(и) SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Версія SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Серійний номер"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Задати дозволи для послідовного порту USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Задати змінні"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Команда вимкнення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Синхронний звʼязок"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Назва цього розділу використовуватиметься як імʼя UPS в інших місцях"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
@@ -496,30 +571,30 @@ msgstr ""
 "Це передається драйверу, тому переконайтеся, що ваш драйвер підтримує цей "
 "параметр"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "Час у секундах між спробами повторного запуску драйвера."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Час у секундах, протягом якого upsdrvctl очікуватиме завершення запуску "
 "драйвера"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "Допоміжний UPS (застаріле)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "Налаштування користувача для моніторингу ДБЖ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "Основний UPS (застаріле)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Глобальні налаштування сервера UPS"
 
@@ -527,70 +602,94 @@ msgstr "Глобальні налаштування сервера UPS"
 msgid "UPS name"
 msgstr "Імʼя UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "Шина(и) USB (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "Ідентифікатор продукту USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "Ідентифікатор постачальника USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "Не вдалося запустити ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Використовуйте %s, щоб побачити повний список команд, які підтримує ваш UPS "
 "(потрібен пакунок %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "Тип користувача (Основний/Допоміжний)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Імʼя користувача"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Постачальник (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Засвідчувати всі зʼєднання за допомогою SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Обхідне рішення для помилкової прошивки"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Записувати в syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "Записувати в syslog і виконувати команду сповіщення"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "встановити драйвери"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon знижує привілеї до цього користувача"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Шлях сертифіката ЦС"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Файл сертифікату (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "Шлях із сертифікатами ca для звірення з сертифікатом вузла"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Вимагати SSL та упевнитися, що CN сервера відповідає імені вузла"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "Не вдалося запустити ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Засвідчувати всі зʼєднання за допомогою SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Шлях до драйвера"

--- a/applications/luci-app-nut/po/vi/nut.po
+++ b/applications/luci-app-nut/po/vi/nut.po
@@ -12,101 +12,130 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.14-dev\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "(s) Thời gian Tắt máy Bổ sung"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "Địa chỉ để nghe"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "Các hành động được cho phép"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "Như đã cấu hình bởi NUT"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "Phục vụ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "Số byte đọc từ ống nối trực tiếp"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "Đường dẫn Chứng chỉ CA"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "Tệp chứng chỉ (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "Điều khiển UPS qua CGI"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "Thời gian chờ tắt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "Giá trị mặc định cho UPS không có trường này."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "Độ trễ cho lệnh tắt nguồn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "Độ trễ để bật nguồn UPS nếu có nguồn trở lại sau khi tắt nguồn"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "Mô tả (Hiển thị)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "Tên hiển thị"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "Không khóa cổng khi bắt đầu driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "Cấu hình Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "Cài đặt Toàn cầu của Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "Thứ tự tắt Driver"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "Driver đợi dữ liệu được tiêu thụ bởi upsd trước khi xuất bản thêm."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "Giảm quyền đến người dùng này"
 
@@ -114,7 +143,7 @@ msgstr "Giảm quyền đến người dùng này"
 msgid "Enable"
 msgstr "Bật lên"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
@@ -122,35 +151,35 @@ msgstr ""
 "Bật một kịch bản hotplug làm cho tất cả các thiết bị ttyUSB (ví dụ: USB nối "
 "tiếp) trong nhóm được đọc và ghi như người dùng 'nut'"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "Thực thi lệnh notify"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "Tắt nguồn ép buộc"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "Cài đặt chung"
 
@@ -159,7 +188,7 @@ msgstr "Cài đặt chung"
 msgid "Go to NUT CGI"
 msgstr "Chuyển đến NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -171,7 +200,7 @@ msgstr ""
 msgid "Host"
 msgstr "Host"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr ""
 
@@ -179,78 +208,82 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr "Tên máy chủ hoặc địa chỉ IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "Tên máy chủ hoặc địa chỉ của UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "Địa chỉ IP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "Bỏ qua"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "Bỏ qua Pin yếu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "Lệnh tức thì"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "Chỉ Ngắt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "Kích thước Ngắt"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "Nhà sản xuất (Hiển thị)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "Độ dài tối đa của USB HID được báo cáo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "Tuổi tối đa của Dữ liệu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "Số lần thử tối đa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "Độ trễ khởi động tối đa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "Số lượng kết nối tối đa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "Số lần tối đa để thử khởi động một driver."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "Thời gian tối đa tính bằng giây giữa các lần cập nhật trạng thái UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "Số lượng nguồn cung cấp tối thiểu được yêu cầu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "Mô hình (Hiển thị)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -265,17 +298,17 @@ msgstr ""
 msgid "NUT CGI - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "Công cụ UPS Mạng (Theo dõi)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "Công cụ UPS Mạng (Máy chủ)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "Người dùng NUT"
 
@@ -295,7 +328,7 @@ msgstr ""
 msgid "NUT server - main"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "Tên của UPS"
 
@@ -308,207 +341,249 @@ msgstr "Công cụ UPS Mạng"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Cấu hình CGI Công cụ UPS Mạng"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Cấu hình Giám sát Công cụ UPS Mạng"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Cấu hình Máy chủ Công cụ UPS Mạng"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "Không khóa"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "Không có OIDs chuyển đổi điện áp thấp/cao"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "Lệnh thông báo"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "Độ trễ tắt (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "Độ trễ bật (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "Đường dẫn chứa chứng chỉ ca để so khớp với chứng chỉ máy chủ"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "Đường dẫn đến tệp trạng thái"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "Thời gian sau đó dữ liệu được coi là cũ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "Khoảng thời gian khảo sát"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "Tần suất khảo sát"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "Thông báo tần suất khảo sát"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "Tần suất (các) khảo sát"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "Cổng"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "Giá trị công suất"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "Chủ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "Sản phẩm (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "Yêu cầu SSL và đảm bảo CN máy chủ khớp với tên máy chủ"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "Độ trễ thử lại"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "Vai trò"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "Chạy các trình điều khiển trong môi trường chroot(2)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "Chạy với tư cách người dùng"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "Cộng đồng SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "Số lần thử lại SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "Thời gian chờ SNMP (s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "Phiên bản SNMP"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "Số Serial"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "Đặt quyền cổng nối tiếp USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "Đặt biến"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "Lệnh tắt máy"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "Giao tiếp đồng bộ"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "Tên phần này sẽ được sử dụng làm tên UPS ở nơi khác"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr ""
 "Thời gian tính bằng giây giữa các lần thử lại khởi động trình điều khiển."
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 "Thời gian tính bằng giây mà upsdrvctl sẽ chờ trình điều khiển hoàn thành quá "
 "trình khởi động"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "Cài đặt toàn cầu của máy chủ UPS"
 
@@ -516,70 +591,91 @@ msgstr "Cài đặt toàn cầu của máy chủ UPS"
 msgid "UPS name"
 msgstr "Tên UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB Bus(es) (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "ID Sản phẩm USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "ID Nhà sản xuất USB"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr ""
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr ""
 "Sử dụng %s để xem danh sách đầy đủ các lệnh mà UPS của bạn hỗ trợ (yêu cầu "
 "gói %s)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "Tên người dùng"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "Nhà sản xuất (regex)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "Xác minh tất cả kết nối bằng SSL"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "Giải pháp tạm thời cho firmware lỗi"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "Ghi vào syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon từ bỏ đặc quyền của người dùng này"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "Đường dẫn Chứng chỉ CA"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "Tệp chứng chỉ (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "Đường dẫn chứa chứng chỉ ca để so khớp với chứng chỉ máy chủ"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "Yêu cầu SSL và đảm bảo CN máy chủ khớp với tên máy chủ"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "Xác minh tất cả kết nối bằng SSL"
 
 #~ msgid "Driver Path"
 #~ msgstr "Đường dẫn Driver"

--- a/applications/luci-app-nut/po/zh_Hans/nut.po
+++ b/applications/luci-app-nut/po/zh_Hans/nut.po
@@ -17,101 +17,130 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.8.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "额外关机时间（秒）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "要监听的地址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "允许的动作"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "由 NUT 配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "从设备"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr "辅助的（已废弃）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "从中断管道读取的字节数"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA 证书路径"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "证书文件（SSL）"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "通过 CGI 控制 UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr "自定义消息类型的通知消息"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "无反应时间"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "没有此字段的 UPS 的默认值。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "断电后执行命令的延时"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "如果断电后电源恢复，则延迟开启 UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "说明（显示）"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "显示名称"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "启动驱动程序时不要锁定端口"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "驱动"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "驱动程序配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "驱动程序全局设置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "驱动程序关闭顺序"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "在发布更多内容之前，驱动程序会等待 upsd 处理完数据。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "降低权限至此用户"
 
@@ -119,17 +148,17 @@ msgstr "降低权限至此用户"
 msgid "Enable"
 msgstr "启用"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr "启用热插拔脚本，使所有 ttyUSB 设备（例如串行 USB）组读写为用户“nut”"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "执行 notify 命令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -137,7 +166,7 @@ msgstr ""
 "对基于 USB HID 的 UPS，NUT 需要 USB 产品 ID 来设置权限，以便驱动程序可以访问 "
 "UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
@@ -145,7 +174,7 @@ msgstr ""
 "对基于 USB HID 的 UPS，NUT 需要 USB 供应商 ID 来设置权限，以便驱动程序可以访"
 "问 UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
@@ -154,12 +183,12 @@ msgstr ""
 "对基于 USB HID 的 UPS，允许使用多个同类的 USB 设备（USB 产品和 USB 供应商 ID "
 "相同）。其他 UPS 也可能使用此值。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "强制关机"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "全局设置"
 
@@ -168,7 +197,7 @@ msgstr "全局设置"
 msgid "Go to NUT CGI"
 msgstr "前往 NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr "授予 luci-app-nut 的 UCI 管理员权限"
 
@@ -180,7 +209,7 @@ msgstr "授予对 luci-app-nut 的有限 UCI 读取权限"
 msgid "Host"
 msgstr "主机"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "主机同步"
 
@@ -188,78 +217,82 @@ msgstr "主机同步"
 msgid "Hostname or IP address"
 msgstr "主机名或 IP 地址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS 的主机名或地址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP 地址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "如此列表为空，你需要 %s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "忽略"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "忽略低电量"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "即时命令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "仅中断"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "中断大小"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "制造商（展示）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "报告的最大 USB HID 长度"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "最大数据年龄"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "最大重试次数"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "最大启动延迟"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "最大连接数"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "尝试启动驱动程序的最大次数。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "刷新 UPS 状态的最长间隔时间（秒）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "所需的最低数量或电源"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "型号（显示）"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -274,17 +307,17 @@ msgstr "NUT CGI - 管理员"
 msgid "NUT CGI - main"
 msgstr "NUT CGI - 主要"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "网络 UPS 工具（监控）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "网络 UPS 工具（服务器）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT 用户"
 
@@ -304,7 +337,7 @@ msgstr "NUT 服务器 - 管理员"
 msgid "NUT server - main"
 msgstr "NUT 服务器 - 主要"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "UPS 的名称"
 
@@ -317,204 +350,246 @@ msgstr "网络 UPS 工具"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "网络 UPS 工具 CGI 配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "网络 UPS 工具监控配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "网络 UPS 工具服务器配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "没有锁"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "没有低压/高压传输 OID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "通知标记"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "通知设置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "通知命令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "关闭延迟（秒）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "开启延迟（秒）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "密码"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "匹配主机证书的 ca 证书路径"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "状态文件的路径"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "数据过期时间"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "轮询间隔"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "轮询频率"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "轮询频率警报"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "轮询频率（秒）"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "端口"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "功率值"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "主设备"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr "主要（已废弃）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "产品（正则表达式）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "需要 SSL 并确保服务器 CN 与主机名匹配"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "重试延迟"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "角色"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "在 chroot(2) 环境中运行驱动程序"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "RunAs 用户"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP 社区"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP 重试"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP 超时"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP 版本"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "序列号"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "设置 USB 串口权限"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "设置变量"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "关机命令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "同步通信"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "此部分的名称将在其他地方用作 UPS 名称"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr "这被传递到驱动程序，因此确保驱动程序支持此选项"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "驱动程序重试启动的时间间隔（秒）。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr "upsdrvctl 等待驱动程序完成启动的时间（秒）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr "辅助 UPS （已废弃）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr "UPS 监视器用户设置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr "主 UPS（已废弃）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS 服务器全局设置"
 
@@ -522,68 +597,92 @@ msgstr "UPS 服务器全局设置"
 msgid "UPS name"
 msgstr "UPS 名称"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB 总线（正则表达式）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB 产品 ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB 供应商 ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "无法运行 ldd：%s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr "使用 %s 查看 UPS 支持的命令的完整列表（需要 %s包）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr "用户类型（主要/辅助）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "用户名"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "供应商（正则表达式）"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "验证所有 SSL 连接"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "有缺陷的固件的解决方法"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "写入 syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "写入 syslog 并执行通知命令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "安装驱动"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon 删除此用户的权限"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA 证书路径"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "证书文件（SSL）"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "匹配主机证书的 ca 证书路径"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "需要 SSL 并确保服务器 CN 与主机名匹配"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "无法运行 ldd：%s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "验证所有 SSL 连接"
 
 #~ msgid "Driver Path"
 #~ msgstr "驱动程序路径"

--- a/applications/luci-app-nut/po/zh_Hant/nut.po
+++ b/applications/luci-app-nut/po/zh_Hant/nut.po
@@ -16,101 +16,130 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2026.9.dev0\n"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid ""
+"\"Certificate name\" and \"certificate password\" need to be entered in "
+"double-quotes (\") if the value has a space in it. An empty password must be "
+"entered as an empty pair of double-quotes (\"\")"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
 msgid "Additional Shutdown Time(s)"
 msgstr "額外關機時間 (秒)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
 msgid "Addresses on which to listen"
 msgstr "要監聽的位址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:51
 msgid "Allowed actions"
 msgstr "允許的動作"
 
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid ""
+"An empty database was created in /etc/nut/cert_db at package install. To use "
+"it, SSH in, fill it using certutil, and put /etc/nut/cert_db in this field."
+msgstr ""
+
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:21
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "As configured by NUT"
 msgstr "由 NUT 配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:61
 msgid "Auxiliary"
 msgstr "從裝置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:69
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
 msgid "Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Bytes to read from interrupt pipe"
 msgstr "從中斷管道讀取的位元組數"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "CA Certificate path"
-msgstr "CA 憑證路徑"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "CA certificate(s)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
-msgid "Certificate file (SSL)"
-msgstr "憑證檔案 (SSL)"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:67
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:65
+msgid "Certificate name and password"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid "Certificate request level"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "Client certificate chain and private key"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:17
 msgid "Control UPS via CGI"
 msgstr "透過 CGI 控制 UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:113
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
 msgid "Custom notification message for message type"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:93
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
 msgid "Deadtime"
 msgstr "無反應時間"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
 msgid "Default for UPSes without this field."
 msgstr "沒有此欄位的 UPS 的預設值。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Delay for kill power command"
 msgstr "斷電後執行指令的延遲"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "Delay to power on UPS if power returns after kill power"
 msgstr "若斷電後電源恢復，則延遲開啟 UPS"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
 msgid "Description (Display)"
 msgstr "說明 (顯示)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Disable weak SSL"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:33
 msgid "Display name"
 msgstr "顯示名稱"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "Do not lock port when starting driver"
 msgstr "啟動驅動程式時不要鎖定連接埠"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:143
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:132
 msgid "Driver"
 msgstr "驅動程式"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:138
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:127
 msgid "Driver Configuration"
 msgstr "驅動程式配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
 msgid "Driver Global Settings"
 msgstr "驅動程式全域設定"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:229
 msgid "Driver Shutdown Order"
 msgstr "驅動程式關閉順序"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Driver waits for data to be consumed by upsd before publishing more."
 msgstr "在釋出更多內容之前，驅動程式會等待 upsd 處理完資料。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "Drop privileges to this user"
 msgstr "降低權限至此使用者"
 
@@ -118,42 +147,42 @@ msgstr "降低權限至此使用者"
 msgid "Enable"
 msgstr "啟用"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:160
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:149
 msgid ""
 "Enables a hotplug script that makes all ttyUSB devices (e.g. serial USB) "
 "group read-write as user %s"
 msgstr ""
 "啟用熱插拔指令碼，使所有 ttyUSB 裝置 (例如序列 USB) 組讀寫為使用者「nut」"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:6
 msgid "Execute notify command"
 msgstr "執行 notify 指令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid ""
 "For USB HID based UPSes, USB Product Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid ""
 "For USB HID based UPSes, USB Vendor Id is required for NUT to set "
 "permissions so the driver can access the UPS"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid ""
 "For USB HID based UPSes, allows use of multiple USB devices of the same type "
 "(USB product and USB vendor are identical). Other UPSes may also use this "
 "value."
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:54
 msgid "Forced Shutdown"
 msgstr "強制關機"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:16
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:31
 msgid "Global Settings"
 msgstr "全域設定"
 
@@ -162,7 +191,7 @@ msgstr "全域設定"
 msgid "Go to NUT CGI"
 msgstr "前往 NUT CGI"
 
-#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:15
+#: applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json:13
 msgid "Grant admin UCI access for luci-app-nut"
 msgstr ""
 
@@ -174,7 +203,7 @@ msgstr ""
 msgid "Host"
 msgstr "主機"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:89
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:75
 msgid "Host Sync"
 msgstr "主機同步"
 
@@ -182,78 +211,82 @@ msgstr "主機同步"
 msgid "Hostname or IP address"
 msgstr "主機名稱或 IP 位址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:28
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
 msgid "Hostname or address of UPS"
 msgstr "UPS 的主機名稱或位址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:78
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:72
 msgid "IP Address"
 msgstr "IP 位址"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "If this list is empty you need to %s"
 msgstr "若此清單為空您需要%s"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:12
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:9
 msgid "Ignore"
 msgstr "忽略"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:175
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
 msgid "Ignore Low Battery"
 msgstr "忽略低電量"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid "Instant commands"
 msgstr "即時指令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:179
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
 msgid "Interrupt Only"
 msgstr "僅中斷"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:183
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
 msgid "Interrupt Size"
 msgstr "中斷大小"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
 msgid "Manufacturer (Display)"
 msgstr "製造商 (顯示)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Max USB HID Length Reported"
 msgstr "報告的最大 USB HID 長度"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Maximum Age of Data"
 msgstr "最大資料年齡"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum Retries"
 msgstr "最大重試次數"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:114
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:103
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Maximum Start Delay"
 msgstr "最大啟動延遲"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:97
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:91
 msgid "Maximum connections"
 msgstr "最大連線數"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:118
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:107
 msgid "Maximum number of times to try starting a driver."
 msgstr "嘗試啟動驅動程式的最大次數。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Maximum time in seconds between refresh of UPS status"
 msgstr "重新整理 UPS 狀態之間的最長時間 (秒)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:74
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:60
 msgid "Minimum required number or power supplies"
 msgstr "所需的最低數量或電源"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid "Model (Display)"
 msgstr "型號 (顯示)"
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:70
+msgid "NO (do not request or verify a client certificate)"
+msgstr ""
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:13
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi_admin.js:13
@@ -268,17 +301,17 @@ msgstr "NUT CGI - 管理"
 msgid "NUT CGI - main"
 msgstr "NUT CGI - 主要"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:67
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:28
 msgid "NUT Monitor"
 msgstr "NUT 監控"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:13
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:36
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:28
 msgid "NUT Server"
 msgstr "NUT 伺服器"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:46
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:40
 msgid "NUT Users"
 msgstr "NUT 使用者"
 
@@ -298,7 +331,7 @@ msgstr "NUT 伺服器 - 管理"
 msgid "NUT server - main"
 msgstr "NUT 伺服器 - 主要"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:25
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:22
 msgid "Name of UPS"
 msgstr "UPS 名稱"
 
@@ -311,204 +344,246 @@ msgstr "Network UPS Tools"
 msgid "Network UPS Tools CGI Configuration"
 msgstr "Network UPS Tools CGI 配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:68
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:54
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:29
 msgid "Network UPS Tools Monitoring Configuration"
 msgstr "Network UPS Tools 監控配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:43
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:14
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:29
 msgid "Network UPS Tools Server Configuration"
 msgstr "Network UPS Tools 伺服器配置"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:202
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
 msgid "No Lock"
 msgstr "沒有鎖"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:206
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:195
 msgid "No low/high voltage transfer OIDs"
 msgstr "沒有低壓/高壓傳輸 OID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:116
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:92
 msgid "Notification flags"
 msgstr "通知旗標"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:108
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
 msgid "Notifications settings"
 msgstr "通知設定"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:23
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:38
 msgid "Notify command"
 msgstr "通知指令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:210
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
 msgid "Off Delay(s)"
 msgstr "關閉延遲 (秒)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:219
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:208
 msgid "On Delay(s)"
 msgstr "開啟延遲 (秒)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:45
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:46
+msgid "PEM file containing client certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "PEM file containing server certificate chain and private key (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:53
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:51
+msgid "PEM file containing the CA certificate(s) (OpenSSL)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:47
 msgid "Password"
 msgstr "密碼"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:99
-msgid "Path containing ca certificates to match against host certificate"
-msgstr "匹配主機憑證的 ca 憑證路徑"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:62
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:60
+msgid "Path to NSS certificate and key databases"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:24
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:39
 msgid "Path to state file"
 msgstr "狀態檔案的路徑"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:92
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid "Per-host override for certident, certverify, and forcessl"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:86
 msgid "Period after which data is considered stale"
 msgstr "資料過期時間"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:117
 msgid "Poll Interval"
 msgstr "輪詢間隔"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:79
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:65
 msgid "Poll frequency"
 msgstr "輪詢頻率"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:84
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:70
 msgid "Poll frequency alert"
 msgstr "輪詢頻率警報"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:228
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:217
 msgid "Polling Frequency(s)"
 msgstr "輪詢頻率 (秒)"
 
 #: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_cgi.js:28
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:32
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:233
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:29
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:77
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:222
 msgid "Port"
 msgstr "連接埠"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:37
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:34
 msgid "Power value"
 msgstr "功率值"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:68
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:62
 msgid "Primary"
 msgstr "主要"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:70
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:64
 msgid "Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:237
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:226
 msgid "Product (regex)"
 msgstr "產品 (正規表示式)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Require SSL and make sure server CN matches hostname"
-msgstr "需要 SSL 並確保伺服器 CN 與主機名稱匹配"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:71
+msgid "REQUEST (any client certificate)"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:72
+msgid "REQUIRE (and verify)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Require SSL and verify host certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL even if not verifying host certificates"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:78
+msgid "Require SSL to connect"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:74
+msgid "Require at least TLSv1.2 for SSL communications"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Retry Delay"
 msgstr "重試延遲"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:66
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:60
 msgid "Role"
 msgstr "角色"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "Run drivers in a chroot(2) environment"
 msgstr "在 chroot(2) 環境中執行驅動程式"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:35
 msgid "RunAs User"
 msgstr "以指定使用者執行"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:168
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:157
 msgid "SNMP Community"
 msgstr "SNMP 社群"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:236
 msgid "SNMP retries"
 msgstr "SNMP 重試"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:251
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:240
 msgid "SNMP timeout(s)"
 msgstr "SNMP 逾時"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:244
 msgid "SNMP version"
 msgstr "SNMP 版本"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:257
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:246
 msgid "SNMPv1"
 msgstr "SNMPv1"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:258
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:247
 msgid "SNMPv2c"
 msgstr "SNMPv2c"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:259
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:248
 msgid "SNMPv3"
 msgstr "SNMPv3"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:156
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:145
 msgid "Serial Number"
 msgstr "序號"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:159
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:44
+msgid "Server certificate chain and private key"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:148
 msgid "Set USB serial port permissions"
 msgstr "設定 USB 串列埠權限"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:59
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:53
 msgid "Set variables"
 msgstr "設定變數"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:26
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:41
 msgid "Shutdown command"
 msgstr "關機指令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:266
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:255
 msgid "Synchronous Communication"
 msgstr "同步通訊"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:128
 msgid "The name of this section will be used as UPS name elsewhere"
 msgstr "此部分的名稱將在其他地方用作 UPS 名稱"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:172
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:196
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:199
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:161
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:185
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:188
 msgid ""
 "This is passed through to the driver, so make sure your driver supports this "
 "option"
 msgstr "這被傳遞給驅動程式，所以請確保其支援此選項"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:123
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:112
 msgid "Time in seconds between driver start retry attempts."
 msgstr "驅動程式重試之間的間隔 (秒)。"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:191
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:180
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr "upsdrvctl 等待驅動程式完成啟動的時間 (秒)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:131
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:107
 msgid "UPS Auxiliary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:119
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:95
 msgid "UPS Monitor User Settings"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:128
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:104
 msgid "UPS Primary (Deprecated)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:89
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:17
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:83
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:32
 msgid "UPS Server Global Settings"
 msgstr "UPS 伺服器全域性設定"
 
@@ -516,68 +591,92 @@ msgstr "UPS 伺服器全域性設定"
 msgid "UPS name"
 msgstr "UPS 名稱"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:164
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
 msgid "USB Bus(es) (regex)"
 msgstr "USB 匯流排 (正規表示式)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:150
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:139
 msgid "USB Product Id"
 msgstr "USB 產品 ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:153
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:142
 msgid "USB Vendor Id"
 msgstr "USB 供應商 ID"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:56
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:28
-msgid "Unable to run ldd: %s"
-msgstr "無法執行 ldd: %s"
-
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:63
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:57
 msgid ""
 "Use %s to see full list of commands your UPS supports (requires %s package)"
 msgstr "使用 %s 查看 UPS 支援的完整指令清單 (需要 %s 包)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:122
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:98
 msgid "User type (Primary/Auxiliary)"
 msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:42
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:50
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:39
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:44
 msgid "Username"
 msgstr "使用者名稱"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:263
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:252
 msgid "Vendor (regex)"
 msgstr "供應商 (正規表示式)"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:103
-msgid "Verify all connection with SSL"
-msgstr "驗證所有 SSL 連線"
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:73
+msgid "Verify all connections with SSL"
+msgstr ""
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:187
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server_admin.js:69
+msgid ""
+"Whether to request a client certificate and whether to validate a requested "
+"client certificate"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:176
 msgid "Workaround for buggy firmware"
 msgstr "有缺陷的韌體的解決方法"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:10
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:7
 msgid "Write to syslog"
 msgstr "寫入 syslog"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:11
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor.js:8
 msgid "Write to syslog and execute notify command"
 msgstr "寫入 syslog 並執行 notify 指令"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:111
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:100
 msgid "chroot"
 msgstr "chroot"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:144
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:85
+msgid ""
+"hostname \"certificate name\" certverify (as 0 or 1) forcessl (as 0 or 1)"
+msgstr ""
+
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_server.js:133
 msgid "install drivers"
 msgstr "安裝驅動程式"
 
-#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:20
+#: applications/luci-app-nut/htdocs/luci-static/resources/view/nut/nut_monitor_admin.js:35
 msgid "upsmon drops privileges to this user"
 msgstr "upsmon 刪除此使用者的權限"
+
+#~ msgid "CA Certificate path"
+#~ msgstr "CA 憑證路徑"
+
+#~ msgid "Certificate file (SSL)"
+#~ msgstr "憑證檔案 (SSL)"
+
+#~ msgid "Path containing ca certificates to match against host certificate"
+#~ msgstr "匹配主機憑證的 ca 憑證路徑"
+
+#~ msgid "Require SSL and make sure server CN matches hostname"
+#~ msgstr "需要 SSL 並確保伺服器 CN 與主機名匹配"
+
+#~ msgid "Unable to run ldd: %s"
+#~ msgstr "無法執行 ldd: %s"
+
+#~ msgid "Verify all connection with SSL"
+#~ msgstr "驗證所有 SSL 連線"
 
 #~ msgid "Driver Path"
 #~ msgstr "驅動程式路徑"

--- a/applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json
+++ b/applications/luci-app-nut/root/usr/share/rpcd/acl.d/luci-app-nut.json
@@ -4,15 +4,20 @@
 		"read": {
 			"file": {
 				"/lib/nut/": [ "list" ],
-				"/usr/libexec/nut/": [ "list" ],
-				"/usr/bin/ldd /usr/sbin/upsmon": ["exec"],
-				"/usr/bin/ldd /usr/sbin/upsd": ["exec"]
+				"/usr/libexec/nut/": [ "list" ]
 			},
 			"uci": [ "nut_cgi", "nut_monitor", "nut_server" ]
 		}
 	},
 	"luci-app-nut-admin": {
 		"description": "Grant admin UCI access for luci-app-nut",
+		"read": {
+			"file": {
+				"/usr/share/nut/ssl_backend": ["read"],
+				"/usr/bin/ldd /usr/sbin/upsmon": ["exec"],
+				"/usr/bin/ldd /usr/sbin/upsd": ["exec"]
+			}
+		},
 		"write": {
 			"uci": [ "nut_cgi", "nut_monitor", "nut_server" ]
 		}


### PR DESCRIPTION
## Pull request details

### Description

Both the configuration for NSS-based SSL and the configuration for
OpenSSL-based SSL were incomplete, so add missing options, and enhance
existing settings.

Additionally, the method of checking for being compiled with SSL changes
with https://github.com/openwrt/packages/pull/29893. We now have a file
/usr/share/nut/ssl_backend which contains either 'nss', 'openssl', or
'none'. We use this to show the applicable configuration options in the
UI when it is available. For compatibility with previous version of the
nut package, we keep the 'ldd' method of determining availability of
SSL, for now.

That same pull request adds server-side CERTPATH and so on handling in
https://github.com/danielfdickinson/packages/blob/c0ec3741ce64b8613b8324575f907342303563fc/net/nut/files/nut-server-config.sh.functions#L94-L107

Finally, SSL settings are security-sensitive so move them to the 'admin'
NUT screens to reduce visibility, and to prepare for a future commit to
the NUT package which will separate the UCI configs for admin and
non-privileged users.

### Maintainer
@danielfdickinson @systemcrash 

---

## Tested on

**OpenWrt version:** OpenWrt SNAPSHOT r35715-94a21b3fe9
**LuCI version:** LuCI Master 26.220.05649~98417a6
**Web browser(s):** Firefox 140.13.0esr (64-bit)

## Re-tested on

### Server and Self-client

**OpenWrt version:** OpenWrt SNAPSHOT r35906-3d1645ee2
**LuCI version:** LuCI Master 26.239.32285~01b60d0
**Web browser(s):** Firefox 140.14.0esr (64-bit)

### Client

**OpenWrt version:** OpenWrt SNAPSHOT r35921-f0204d78e1
**LuCI version:** LuCI Master 26.238.54490~7a6ff75
**Web browser(s):** Firefox 140.14.0esr (64-bit)

---

## Checklist
- [ ] Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [x] Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
  Prefers but does not depend on: https://github.com/openwrt/packages/pull/29893
