### PR TITLE
luci-app-pbr: preserve resolver_set selection

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-pbr
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=20
+PKG_RELEASE:=21
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_URL:=https://github.com/mossdef-org/luci-app-pbr/

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
@@ -113,6 +113,8 @@ return view.extend({
 			text
 		);
 		o.value("none", _("Disabled"));
+		o.default = "none";
+		o.rmempty = false;
 		if (reply.platform.adguardhome_ipset_support) {
 			o.value("adguardhome.ipset", _("AdGuardHome ipset"));
 			o.default = "adguardhome.ipset";


### PR DESCRIPTION
Since commit 974b5864e05e ("luci-base: fix uci write bug when input value equals default"), form values matching their default are removed when rmempty is enabled.

luci-app-pbr selects the resolver_set default dynamically according to the resolver support available on the device. Unlike the other PBR options with defaults, pbr treats a missing resolver_set as disabled.

Saving the page can therefore silently disable dnsmasq nft set handling and make domain policies fall back to one-time resolveip lookups.

Use "none" as the base default and disable rmempty so LuCI always stores the selected resolver.

### Maintainer

@stangri @egc112 

---

## Tested on

**OpenWrt version:** Snapshot
**LuCI version:** Latest

---

