### PR TITLE
luci-app-watchcat: add support for 'enabled' option

### DIFF
--- a/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
+++ b/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
@@ -18,6 +18,12 @@ return view.extend({
 
 		s.tab('general', _('General Settings'));
 
+		o = s.taboption('general', form.Flag, 'enabled',
+			_('Enabled'),
+			_('Enable or disable this Watchcat instance'));
+		o.default = '1';
+		o.rmempty = false;
+
 		o = s.taboption('general', form.ListValue, 'mode',
 			_('Mode'),
 			_("Ping Reboot: Reboot this device if a ping to a specified host fails for a specified duration of time. <br /> \

--- a/applications/luci-app-watchcat/po/templates/watchcat.pot
+++ b/applications/luci-app-watchcat/po/templates/watchcat.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:94
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:100
 msgid ""
 "<i>Applies to Ping Reboot and Periodic Reboot modes</i> <br /> When "
 "rebooting the router, the service will trigger a soft reboot. Entering a non-"
@@ -10,36 +10,44 @@ msgid ""
 "use 0 to disable the forced reboot delay."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:111
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:117
 msgid ""
 "<i>Applies to Ping Reboot and Restart Interface modes</i> <br /> If using "
 "ModemManager, you can have Watchcat restart your ModemManager interface by "
 "specifying its name."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:104
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:110
 msgid ""
 "<i>Applies to Ping Reboot, Restart Interface, and Run Script modes</i> <br /"
 "> Specify the interface to monitor and react if a ping over it fails."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:60
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:66
 msgid "Address family for pinging the host"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:65
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
 msgid "Any"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:84
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:90
 msgid "Big: 248 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:70
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:76
 msgid "Check Interval"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:93
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:23
+msgid "Enable or disable this Watchcat instance"
+msgstr ""
+
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:22
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:99
 msgid "Force Reboot Delay"
 msgstr ""
 
@@ -58,11 +66,11 @@ msgid ""
 "up more than one action."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:52
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:58
 msgid "Hosts To Check"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:77
 msgid ""
 "How often to ping the host specified above. <br /><br />The default unit is "
 "seconds, without a suffix, but you can use the suffix <b>m</b> for minutes, "
@@ -72,21 +80,21 @@ msgid ""
 "li><ul>"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:85
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:91
 msgid "Huge: 1492 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:52
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:58
 msgid "IP addresses or hostnames to ping."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:118
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:124
 msgid ""
 "If using ModemManager, then before restarting the interface, set the modem "
 "to be allowed to use any band."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:41
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:47
 msgid ""
 "In Periodic Reboot mode, it defines how often to reboot. <br /> In Ping "
 "Reboot mode, it defines the longest period of time without a reply from the "
@@ -100,43 +108,43 @@ msgid ""
 "li><li>1 week would be: <b>7d</b></li><ul>"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:102
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:108
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:103
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:109
 msgid "Interface to monitor and/or restart"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:86
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:92
 msgid "Jumbo: 9000 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:22
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:28
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:110
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:116
 msgid "Name of ModemManager Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:40
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:46
 msgid "Period"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:28
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:34
 msgid "Periodic Reboot"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:80
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:86
 msgid "Ping Packet Size"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:27
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:33
 msgid "Ping Reboot"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:23
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:29
 msgid ""
 "Ping Reboot: Reboot this device if a ping to a specified host fails for a "
 "specified duration of time. <br /> Periodic Reboot: Reboot this device after "
@@ -146,29 +154,29 @@ msgid ""
 "for a specified duration of time. <br />"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:29
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:35
 msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:30
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:36
 msgid "Run Script"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:33
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:39
 msgid "Script to run"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:34
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:40
 msgid ""
 "Script to run when the host has not responded for the specified duration of "
 "time. The script is passed the interface name as $1"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:81
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:87
 msgid "Small: 1 byte"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:83
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:89
 msgid "Standard: 56 bytes"
 msgstr ""
 
@@ -176,7 +184,7 @@ msgstr ""
 msgid "These rules will govern how this device reacts to network events."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:117
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:123
 msgid "Unlock Modem Bands"
 msgstr ""
 
@@ -186,6 +194,6 @@ msgstr ""
 msgid "Watchcat"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:82
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:88
 msgid "Windows: 32 bytes"
 msgstr ""


### PR DESCRIPTION
Adds a checkbox to enable/disable each watchcat instance.

## Pull request details

### Description

Adds a checkbox to enable/disable each watchcat instance.
Depends on: https://github.com/openwrt/packages/pull/30234

### Maintainer: @jow-
---

## Tested on
**OpenWrt Version:** 25.12.5
**OpenWrt Target/Subtarget:** mediatek/filogic
**OpenWrt Device:** Xiaomi Mi Router AX3000T

---

## Checklist
- [x] Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [x] Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
