### PR TITLE
luci-base: form.js: fix stripTags NotFoundError and modify source node

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -309,7 +309,7 @@ const CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement
 		const x = dom.elem(s) ? s : dom.parse(`<div>${s}</div>`);
 
 		x.querySelectorAll('br').forEach((br) => {
-			x.replaceChild(document.createTextNode('\n'), br);
+			br.parentNode.replaceChild(document.createTextNode('\n'), br);
 		});
 
 		return (x.textContent ?? x.innerText ?? '').replace(/([ \t]*\n)+/g, '\n');

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -306,7 +306,7 @@ const CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement
 		if (typeof(s) == 'string' && !s.match(/[<>&]/))
 			return s;
 
-		const x = dom.elem(s) ? s : dom.parse(`<div>${s}</div>`);
+		const x = dom.elem(s) ? s.cloneNode(true) : dom.parse(`<div>${s}</div>`);
 
 		x.querySelectorAll('br').forEach((br) => {
 			br.parentNode.replaceChild(document.createTextNode('\n'), br);


### PR DESCRIPTION

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
This PR addresses two issues:

1. NotFoundError:
 For example `s='<a><br></a>'`, then `x=dom.parse('<div><a><br></a></div>')`, this `br` is not a direct child node of `x`, the subsequent call `x.replaceChild(document.createTextNode('\n'), br)` will result in an error:

  ```
Uncaught (in promise) NotFoundError: Failed to execute 'replaceChild' on 'Node': The node to be replaced is not a child of this node.
    at eval (form.js:312:6)
    at NodeList.forEach (<anonymous>)
    at ClassConstructor.stripTags (form.js:311:28)
    at ClassConstructor.renderFrame (form.js:4434:30)
  ```

2. modify source node
 `stripTags` modifies the source node, causing switch port status missing `<br>` on first render.
 Clone source node as AI suggests: https://github.com/openwrt/luci/pull/8937#discussion_r3768291647

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** iStoreOS 25.12.5 2026081215
**LuCI version:** LuCI istoreos-25.12 branch 26.195.42598~4a1ef8c
**Web browser(s):** Chrome (151.0.7922.76)

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
