### PR TITLE
luci-app-rustdesk-server: fixes firmware update causes configuration loss.

### DIFF
--- a/applications/luci-app-rustdesk-server/root/etc/uci-defaults/50-luci-rustdesk-server
+++ b/applications/luci-app-rustdesk-server/root/etc/uci-defaults/50-luci-rustdesk-server
@@ -3,11 +3,13 @@
 # luci-app-rustdesk-server UCI defaults
 # This script runs on first install to set up sensible defaults
 
-uci -q batch <<-EOF >/dev/null
-	set rustdesk-server.@rustdesk-server[0]=rustdesk-server
-	set rustdesk-server.@rustdesk-server[0].enabled='0'
-	set rustdesk-server.@rustdesk-server[0].enabled_relay='0'
-	commit rustdesk-server
+if ! uci -q get rustdesk-server.@rustdesk-server[0] >/dev/null; then
+	uci -q batch <<-EOF >/dev/null
+		set rustdesk-server.@rustdesk-server[0]=rustdesk-server
+		set rustdesk-server.@rustdesk-server[0].enabled='0'
+		set rustdesk-server.@rustdesk-server[0].enabled_relay='0'
+		commit rustdesk-server
 EOF
+fi
 
 exit 0


### PR DESCRIPTION

Fixes #8935
This fixes the issue where configuration settings were lost during a firmware upgrade.
Signed-off-by: David Mandy <smallprogramzhusir@gmail.com>

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
fixes firmware update causes configuration loss.

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.2
**LuCI version:** LuCI openwrt-25.12 branch
**Web browser(s):** Chrome

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [x] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
