### PR TITLE
luci-proto-modemmanager: fix iptype default value

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -140,10 +140,10 @@ return network.registerProtocol('modemmanager', {
 		o.password = true;
 
 		o = s.taboption('general', form.ListValue, 'iptype', _('IP Type'));
-		o.value('ipv4v6', _('IPv4/IPv6 (both - defaults to IPv4)'))
 		o.value('ipv4', _('IPv4 only'));
 		o.value('ipv6', _('IPv6 only'));
-		o.default = 'ipv4v6';
+		o.value('ipv4v6', _('IPv4/IPv6 (both)'));
+		o.default = 'ipv4';
 
 		o = s.taboption('advanced', form.Value, 'mtu', _('Override MTU'));
 		o.placeholder = dev ? (dev.getMTU() || '1500') : '1500';
@@ -197,9 +197,9 @@ return network.registerProtocol('modemmanager', {
 
 		o = s.taboption('general', form.ListValue, 'init_iptype', _('Initial EPS Bearer IP Type'));
 		o.depends('init_epsbearer', 'custom');
-		o.value('ipv4v6', _('IPv4/IPv6 (both - defaults to IPv4)'))
 		o.value('ipv4', _('IPv4 only'));
 		o.value('ipv6', _('IPv6 only'));
-		o.default = 'ipv4v6';
+		o.value('ipv4v6', _('IPv4/IPv6 (both)'));
+		o.default = 'ipv4';
 	}
 });


### PR DESCRIPTION
### Description

The `iptype` and `init_iptype` `ListValue` options in `modemmanager.js` declared `ipv4v6` as the default, while the `modemmanager` package itself defaults to `ipv4` (see [net/modemmanager README.md](https://github.com/openwrt/packages/blob/master/net/modemmanager/README.md?plain=1#L40-L41)).

Since LuCI's form widgets skip writing a UCI option to `/etc/config/network` when the selected value equals the field's declared default, selecting **IPv4/IPv6 (both)** in the UI never actually persisted `option iptype 'ipv4v6'`. On save/apply, modemmanager then fell back to its own default (`ipv4`), silently downgrading the connection to IPv4-only — making the `ipv4v6` option effectively impossible to use through LuCI.

This PR aligns both `iptype` and `init_iptype` defaults with the modemmanager package default (`ipv4`), and drops the now-inaccurate `- defaults to IPv4` hint from the `ipv4v6` label.

### Issue reported by

Originally reported and diagnosed by @moawut on the forum:
https://forum.openwrt.org/t/luci-proto-modemmanager-support-thread/23696/120