### PR TITLE
luci-mod-system, luci-mod-status: permit sysupgrade --create-backup and legacy iptables-save

### DIFF
--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -94,7 +94,9 @@
 				"/usr/sbin/ip6tables --line-numbers -w -nvxL -t *": [ "exec" ],
 				"/usr/sbin/ip6tables": [ "list" ],
 				"/usr/sbin/iptables-save": [ "exec" ],
-				"/usr/sbin/ip6tables-save": [ "exec" ]
+				"/usr/sbin/ip6tables-save": [ "exec" ],
+				"/usr/sbin/iptables-legacy-save": [ "exec" ],
+				"/usr/sbin/ip6tables-legacy-save": [ "exec" ]
 			},
 			"ubus": {
 				"file": [ "stat" ]

--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -176,7 +176,8 @@
 				"/proc/mtd": [ "read" ],
 				"/proc/partitions": [ "read" ],
 				"/proc/sys/kernel/hostname": [ "read" ],
-				"/sbin/sysupgrade --list-backup": [ "exec" ]
+				"/sbin/sysupgrade --list-backup": [ "exec" ],
+				"/sbin/sysupgrade --create-backup -": [ "exec" ]
 			},
 			"ubus": {
 				"file": [ "exec", "read", "stat" ]


### PR DESCRIPTION
The firewall status page runs the legacy iptables-save pair whenever those binaries
exist, and only the non-legacy pair is in the session ACL. The `.catch()` covers a
failed `stat()`, so a device that carries the legacy binaries never falls back to the
non-legacy command.

    modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js, load():

            fs.stat('/usr/sbin/iptables-legacy-save').then(function() {
                    return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-legacy-save'), '');
            }).catch(function() {
                    return L.resolveDefault(fs.exec_direct('/usr/sbin/iptables-save'), '');
            }),

cgi-io matches the requested command against the caller's session ACL and refuses the
exec. `handleCgiIoReply()` in `luci-base/htdocs/luci-static/resources/fs.js` turns the
403 into a `PermissionError` and `L.resolveDefault(..., '')` turns that into an empty
string, so the legacy tables come back empty. The luci-mod-status half is a fix against
current master on its own.

    main.c, main_exec() (cgi-io master):

            /* If there was no ACL match, check for a match on the executable */
            if (!allowed && !session_access(fields[1], "file", exe, "exec")) {
                    free(args);
                    return failure(403, 0, "Access to command denied by ACL");

The luci-mod-system half only takes effect once openwrt/cgi-io#6 lands. On cgi-io
master the archive is created by cgi-io itself, gated on the `cgi-io backup` scope and
not on a file exec grant, so the new entry is unused today.

    main.c, main_backup() (cgi-io master):

            if (!fields[1] || !session_access(fields[1], "cgi-io", "backup", "read"))
                    return failure(403, 0, "Backup permission denied");
            ...
            execl("/sbin/sysupgrade", "/sbin/sysupgrade",
                  "--create-backup", "-", NULL);

openwrt/cgi-io#6 moves that exec to rpcd's file method so it keeps working when uhttpd
runs as a non-root user (openwrt/openwrt#24740), and openwrt/rpcd#40 returns the
child's stdout as a file descriptor so the archive is streamed. rpcd matches on the
command line, so the grant names the exact string, the same form as the
`/sbin/sysupgrade --list-backup` entry already in that ACL. Both PRs are still open.

Depends on openwrt/cgi-io#6 and openwrt/rpcd#40.

I used AI to help me write the change. The empty-table behaviour is read from the
code chain above; I have not reproduced it on a device. Should the luci-mod-status
commit go in on its own now, since it fixes current master, and the
luci-mod-system one wait for cgi-io#6?
