### PR TITLE
luci-mod-system: improve Dropbear interface binding selection

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js
@@ -17,16 +17,39 @@ return view.extend({
 		o = s.option(form.Flag, 'enable', _('Enable Instance'), _('Enable <abbr title="Secure Shell">SSH</abbr> service instance'));
 		o.default  = o.enabled;
 
-		o = s.option(form.Flag, '_direct', _('Bind to Interface'));
-		o.default = o.disabled;
+		// Virtual option: derives UI mode from Interface/DirectInterface,
+		// is not stored in UCI; inactive real options are removed on save
+		o = s.option(form.ListValue, '_bind_to', _('Bind to'), _('Select how the SSH service should be bound to network interfaces or IP addresses'));
+		o.widget = 'radio';
+		o.value('all', _('All interfaces (unspecified)'));
+		o.value('interface', _('IP addresses of interface'));
+		o.value('direct', _('Network interface'));
+		o.default = 'all';
+		o.cfgvalue = function(section) {
+			if (this.section.cfgvalue(section, 'DirectInterface'))
+				return 'direct';
+			if (this.section.cfgvalue(section, 'Interface'))
+				return 'interface';
+			return 'all';
+		};
+		o.forcewrite = true;
+		o.write = function(section) {
+			this.remove(section);
+		};
 
-		o = s.option(widgets.NetworkSelect, 'DirectInterface', _('Interface'), _('Listen only on the given interface or, if unspecified, on all'));
+		o = s.option(widgets.NetworkSelect, 'DirectInterface', _('Interface'), _('Listen only on the given interface'));
 		o.nocreate = true;
-		o.depends('_direct', '1');
+		o.depends('_bind_to', 'direct');
+		o.validate = function(section, value) {
+			return value ? true : _('Please select an interface');
+		};
 
-		o = s.option(widgets.NetworkSelect, 'Interface', _('Interface'), _('Listen on up to 10 IPs on the given interface or, if unspecified, on all interfaces'));
+		o = s.option(widgets.NetworkSelect, 'Interface', _('Interface'), _('Listen on up to 10 IPs on the given interface'));
 		o.nocreate = true;
-		o.depends('_direct', '0');
+		o.depends('_bind_to', 'interface');
+		o.validate = function(section, value) {
+			return value ? true : _('Please select an interface');
+		};
 
 		o = s.option(form.Value, 'Port', _('Port'));
 		o.datatype    = 'port';

--- a/modules/luci-mod-system/root/etc/uci-defaults/90_luci-mod-system-dropbear
+++ b/modules/luci-mod-system/root/etc/uci-defaults/90_luci-mod-system-dropbear
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+# remove the "_direct" UI state from existing Dropbear configs
+
+is_commit=0
+
+dropbear_update() {
+	local _direct
+
+	config_get _direct "$1" _direct
+	[ -n "$_direct" ] || return 0
+
+	if uci -q delete dropbear."$1"._direct; then
+		is_commit=1
+	fi
+}
+
+config_load "dropbear"
+config_foreach dropbear_update dropbear
+[ $is_commit -eq 0 ] || uci commit dropbear
+
+exit 0


### PR DESCRIPTION
### Motivation

The current Dropbear LuCI configuration exposes interface binding through a boolean
"Bind to Interface" option and two different Interface fields:

- when disabled, Interface means: listen on IP addresses assigned to the selected
  network interface;
- when enabled, DirectInterface means: bind directly to the selected network interface.

This works correctly internally, but the UI is confusing because the same-looking Interface selector represents different Dropbear configuration options depending on the state of the flag.

The current UI can therefore be ambiguous:

    Bind to Interface: [x]
    Interface: [lan]

versus:

    Bind to Interface: [ ]
    Interface: [lan]

Although both configurations display an Interface selector, they result in different Dropbear behaviour.

Additionally, the UI flag was persisted as “option _direct” in UCI, although the dropbear service never uses it.

### Description
**New UI**

Replace the boolean "Bind to Interface" option with a three-way "Bind to" selection:

    Bind to
        ( ) All interfaces (unspecified)
        ( ) IP addresses of interface
            Interface: [ lan ]
        ( ) Network interface
            Interface: [ lan ]

The three modes map to the existing Dropbear configuration:

1. All interfaces
   Neither Interface nor DirectInterface is configured.

2. IP addresses of interface
   The existing Interface option is used.

3. Network interface
   The existing DirectInterface option is used.

**Implementation**

The change is limited to the LuCI dropbear configuration.

A virtual "_bind_to" ListValue controls the UI. Its value is derived from the existing Interface/DirectInterface options and is not persisted.

Added a one-time "uci-defaults" migration to remove the legacy "_direct" UI state from existing Dropbear configs.

### Screenshot or video of changes
<img width="1536" height="1440" alt="IMG_0156" src="https://github.com/user-attachments/assets/eecd5067-1462-472b-95fc-e3e8132a4126" />
<img width="1536" height="1594" alt="IMG_0157" src="https://github.com/user-attachments/assets/0ba028ee-f9ae-449f-b5db-c3e406859cfb" />
<img width="1536" height="1593" alt="IMG_0158" src="https://github.com/user-attachments/assets/f921bd4c-c43a-4353-ac7a-207a309ee0ab" />


### Maintainer _(preferred)_
-

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4)
**LuCI version:** LuCI openwrt-25.12 branch (26.209.73834~b61f907)
**Web browser(s):** Firefox 153.0.4

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
