### PR TITLE
luci-app-package-manager: make the per-row action button compact

### DIFF
--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -51,6 +51,11 @@ const css = '								\
 		white-space: nowrap;			\
 	}									\
 										\
+	/* bootstrap sets 15%; shrink */	\
+	#packages .td.cbi-section-actions {	\
+		width: auto;					\
+	}									\
+										\
 	ul.deps, ul.deps ul, ul.errors {	\
 		margin-left: 1em;				\
 	}									\


### PR DESCRIPTION
Maintainer: @jow-

# Description:

The package table reserves 15% of its width for the action cell, causing the single action button to stretch unnecessarily.

Let the cell size to its content instead, giving the description more space while keeping the action buttons aligned. The change is scoped to the package table and does not affect the narrow-screen layout.
Screenshot or video of changes: 

# Before:
<img width="2392" height="720" alt="01-desktop-before" src="https://github.com/user-attachments/assets/f4cf6cb0-9340-4eaf-bd3c-bfc6443cbc06" />

# After:
<img width="2392" height="720" alt="02-desktop-after" src="https://github.com/user-attachments/assets/b93d35be-ca43-438a-82d9-04badb498d91" />
<img width="2392" height="394" alt="03-desktop-after-mixed-buttons" src="https://github.com/user-attachments/assets/69d591ec-8526-44a1-8427-2891b200f885" />


Tested on:
OpenWrt version: OpenWrt SNAPSHOT r0+35801-c0ffca4c63
LuCI version: luci-base 26.228.64482~c26820a
Web browser(s): Chrome 151.0.7922.138