### PR TITLE
luci-app-sfp-info: add missing ucode-mod-math dependency

### DIFF
--- a/applications/luci-app-sfp-info/Makefile
+++ b/applications/luci-app-sfp-info/Makefile
@@ -4,11 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=SFP/QSFP Transceiver Diagnostics
-LUCI_DEPENDS:=+luci-base +ethtool-full  # requires ethtool >= 7.0 for --json support
+LUCI_DEPENDS:=+luci-base +ethtool-full +ucode-mod-math
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0
 PKG_VERSION:=1.0
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Meng Zhuo <mengzhuo@iscas.ac.cn>
 
 include ../../luci.mk

--- a/applications/luci-app-sfp-info/README.md
+++ b/applications/luci-app-sfp-info/README.md
@@ -14,6 +14,7 @@ Visual dashboard for SFP/QSFP optical transceiver diagnostics via `ethtool --jso
 
 - `luci-base`
 - `ethtool-full` (>= 7.0 for JSON output support)
+- `ucode-mod-math` (mW to dBm conversion in the rpcd backend)
 
 ## RPC API
 


### PR DESCRIPTION
## Pull request details

### Description

`luci-app-sfp-info` does not declare its dependency on `ucode-mod-math`. Its
rpcd backend does `import { log } from 'math';` and uses it in `mw_to_dbm()`,
but the Makefile only declares `+luci-base +ethtool-full`.

The module used to arrive transitively through `luci-base` until 3fb9db3869
("luci-base: move the ucode-mod-math dependency to luci-app-ddns") removed it
there and declared it in `luci-app-ddns`, the only consumer in the tree at that
point. This package was merged afterwards (#8652), so it was missed. Without
the module ucode cannot load the plugin, the `luci.sfp-info` ubus object is
never registered, and the status page only reports `RPC call to
luci.sfp-info/list failed with error -32000: Object not found`.

This adds `+ucode-mod-math` to `LUCI_DEPENDS`, lists it in `README.md`, and
bumps `PKG_RELEASE` so existing installations pick it up (this package pins
`PKG_VERSION`, so its version does not change on its own). The trailing comment
on the `LUCI_DEPENDS` line is dropped: it is the only inline comment on such a
line in the tree, and the ethtool version it noted is already in `README.md`.

`ethtool-full` 7.1 is installed on the test device and returns valid JSON, and
the plugin is already mode 100755, so neither is a factor here.

### Screenshot or video of changes _(if applicable)_

n/a -- packaging-only change.

### Maintainer _(preferred)_
@mengzhuo

---

## Tested on
**Device:** XikeStor SKS8310-8X (8x SFP+, Realtek RTL9303, target `realtek/rtl930x`)
**OpenWrt version:** OpenWrt SNAPSHOT r35859-ff0d8f4141, kernel 6.18.44
**LuCI version:** LuCI 26.228.64482~c26820a
**Web browser(s):** Chrome 151.0.7922.138

<details>
<summary>Before and after on the device</summary>

```
# ucode -R /usr/share/rpcd/ucode/sfp-info.uc
Syntax error: Unable to resolve path for module 'math'
In line 5, byte 27:

 `import { log } from 'math';`
  Near here ----------------^

# ubus list | grep sfp
(no output)

# apk add ucode-mod-math
(1/1) Installing ucode-mod-math (2026.07.09~b885dd0f-r1)
OK: 8594 KiB in 113 packages

# service rpcd restart
# rm -f /tmp/luci-indexcache.*; rm -rf /tmp/luci-modulecache/

# ubus list | grep sfp
luci.sfp-info

# ubus call luci.sfp-info list
{
	"result": [
		...
		{
			"iface": "lan6",
			"vendor_pn": "SFP-10G-SR",
			...
			"diagnostics": {
				"temperature_c": 47.8125,
				"voltage_v": 3.2530000000000001,
				"bias_current_ma": 6,
				"tx_power_mw": 0.5,
				"tx_power_dbm": -3.0102999566398116,
				"rx_power_mw": 0.40000000000000002,
				"rx_power_dbm": -3.9794000867203749
			},
			...
		},
		...
	]
}
```

All eight SFP+ ports are returned; one entry is shown, serial redacted.
</details>
