### PR TITLE
radicale3: fix versioned dependency

### DIFF
--- a/applications/luci-app-radicale3/Makefile
+++ b/applications/luci-app-radicale3/Makefile
@@ -10,7 +10,7 @@ PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_PROVIDES:=luci-app-radicale2
 
-EXTRA_DEPENDS:=radicale3 (>= 3.7.1-1)
+LUCI_EXTRA_DEPENDS:=radicale3 (>=3.7.1-r1)
 
 include ../../luci.mk
 


### PR DESCRIPTION
## Pull request details

### Description

The Makefile incorrectly used EXTRA_DEPENDS when it needs LUCI_EXTRA_DEPENDS. Fix that.
Also, the version format was wrong (never noticed because LuCI wasn't actually using the versioned dependency).



### Maintainer
@danielfdickinson @BKPepe 

---

## Tested on

Not available: Python host is currently not compiling under the SDK, for me.

---

## Checklist
- [x] Includes what Issue it closes (e.g. openwrt/luci#issue-number).
      * No open issue
- [x] Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
      * No new dependency
