### PR TITLE
luci-app-nes-emulator: add NES emulator interface

### DIFF
--- a/applications/luci-app-nes-emulator/Makefile
+++ b/applications/luci-app-nes-emulator/Makefile
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+include $(TOPDIR)/rules.mk
+
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Yaroslav Vereshchagin <yarik.vereshchagin1996@gmail.com>
+
+LUCI_TITLE:=LuCI support for NES Emulator
+LUCI_DESCRIPTION:=Web interface for the NES emulator service
+LUCI_DEPENDS:=+luci-base +rpcd +jshn +jsonfilter +cgi-io +nes-emulator
+LUCI_PKGARCH:=all
+LUCI_MAINTAINER:=$(PKG_MAINTAINER)
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nes-emulator/htdocs/luci-static/resources/nes-emulator.js
+++ b/applications/luci-app-nes-emulator/htdocs/luci-static/resources/nes-emulator.js
@@ -1,0 +1,39 @@
+'use strict';
+'require baseclass';
+'require rpc';
+
+const LONG_RUNNING_RPC_TIMEOUT = 120;
+const LONG_RUNNING_ACTION_GRACE = 5;
+
+function getRpcTimeout() {
+	return Math.max(
+		Number(L.env.rpctimeout) || 20,
+		LONG_RUNNING_RPC_TIMEOUT
+	);
+}
+
+function getActionTimeout() {
+	return (getRpcTimeout() + LONG_RUNNING_ACTION_GRACE) * 1000;
+}
+
+function declareLongRunningRpc(specification) {
+	const call = rpc.declare(Object.assign({}, specification, {
+		nobatch: true
+	}));
+
+	return (...args) => {
+		const savedTimeout = L.env.rpctimeout;
+		L.env.rpctimeout = getRpcTimeout();
+		try {
+			return call(...args);
+		}
+		finally {
+			L.env.rpctimeout = savedTimeout;
+		}
+	};
+}
+
+return baseclass.extend({
+	getActionTimeout,
+	declareLongRunningRpc
+});

--- a/applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js
+++ b/applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js
@@ -1,0 +1,519 @@
+'use strict';
+'require view';
+'require rpc';
+'require ui';
+'require nes-emulator as nesEmulator';
+
+const callCanControl = rpc.declare({
+	object: 'session',
+	method: 'access',
+	params: [ 'scope', 'object', 'function' ],
+	expect: { '': { access: false } }
+});
+
+const callStatus = rpc.declare({
+	object: 'nes-emulator',
+	method: 'status',
+	expect: { '': {} }
+});
+
+const callRoms = rpc.declare({
+	object: 'nes-emulator',
+	method: 'roms',
+	expect: { '': { roms: [] } }
+});
+
+const callLoad = nesEmulator.declareLongRunningRpc({
+	object: 'nes-emulator',
+	method: 'load',
+	params: [ 'path' ],
+	expect: { '': {} }
+});
+
+const callImport = nesEmulator.declareLongRunningRpc({
+	object: 'nes-emulator',
+	method: 'import',
+	params: [ 'staged', 'name' ],
+	expect: { '': {} }
+});
+
+const callReserveUpload = rpc.declare({
+	object: 'nes-emulator',
+	method: 'reserve_upload',
+	expect: { '': {} }
+});
+
+const callDiscardUpload = rpc.declare({
+	object: 'nes-emulator',
+	method: 'discard_upload',
+	params: [ 'staged' ],
+	expect: { '': {} }
+});
+
+const callStart = nesEmulator.declareLongRunningRpc({
+	object: 'nes-emulator',
+	method: 'start',
+	expect: { '': {} }
+});
+
+const callStop = rpc.declare({
+	object: 'nes-emulator',
+	method: 'stop',
+	expect: { '': {} }
+});
+
+const callPause = rpc.declare({
+	object: 'nes-emulator',
+	method: 'pause',
+	expect: { '': {} }
+});
+
+const callEmuReset = rpc.declare({
+	object: 'nes-emulator',
+	method: 'reset',
+	expect: { '': {} }
+});
+
+function withTimeout(promise, ms) {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(
+			() => reject(new Error(_('Request timed out'))),
+			ms
+		);
+		Promise.resolve(promise).then(
+			value => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			error => {
+				clearTimeout(timer);
+				reject(error);
+			}
+		);
+	});
+}
+
+function requireSuccess(reply) {
+	if (!reply)
+		throw new Error(_('Empty response'));
+	if (reply.error || reply.ok === false)
+		throw new Error(reply.error || _('Operation failed'));
+	return reply;
+}
+
+return view.extend({
+	load() {
+		return callCanControl('ubus', 'nes-emulator', 'access')
+			.catch(() => ({ access: false }));
+	},
+
+	render(data) {
+		this.canControl = Boolean(data && data.access);
+		this.actionBusy = false;
+		this.lastStatus = null;
+		// Invalidate requests owned by an older rendering of this view.
+		this.refreshGeneration = (this.refreshGeneration || 0) + 1;
+		const body = E('div', { class: 'cbi-map' }, [
+			E('h2', {}, _('NES Emulator')),
+			E('div', { class: 'cbi-map-descr' },
+				_('FCEUmm, picture rendering and optional JPEG encoding all run on the router CPU. The browser is only a display, audio sink and controller.')),
+			E('div', { class: 'cbi-section' }, [
+				E('h3', {}, _('Status')),
+				E('div', { id: 'nes-status', class: 'cbi-value' },
+					E('em', {}, _('Loading status…'))),
+				E('div', { class: 'cbi-page-actions' }, [
+					E('button', {
+						class: 'btn cbi-button cbi-button-apply',
+						'data-nes-action': '1',
+						'data-nes-kind': 'start',
+						disabled: true,
+						click: ui.createHandlerFn(this, 'onStart')
+					}, _('Start')),
+					' ',
+					E('button', {
+						class: 'btn cbi-button cbi-button-action',
+						'data-nes-action': '1',
+						'data-nes-kind': 'pause',
+						disabled: true,
+						click: ui.createHandlerFn(this, 'onPause')
+					}, _('Pause / Resume')),
+					' ',
+					E('button', {
+						class: 'btn cbi-button cbi-button-action',
+						'data-nes-action': '1',
+						'data-nes-kind': 'reset',
+						disabled: true,
+						click: ui.createHandlerFn(this, 'onEmuReset')
+					}, _('Reset console')),
+					' ',
+					E('button', {
+						class: 'btn cbi-button cbi-button-remove',
+						'data-nes-action': '1',
+						'data-nes-kind': 'stop',
+						disabled: true,
+						click: ui.createHandlerFn(this, 'onStop')
+					}, _('Stop emulation')),
+					' ',
+					E('button', {
+						class: 'btn cbi-button',
+						click: ui.createHandlerFn(this, 'onRefreshAll')
+					}, _('Refresh'))
+				])
+			]),
+			this.canControl ? E('div', { class: 'cbi-section' }, [
+				E('h3', {}, _('Upload ROM from this computer')),
+				E('p', {},
+					_('The authenticated LuCI uploader stages the file, then rpcd validates its size, extension and NES header before an atomic import. Maximum size: 16 MiB.')),
+				E('div', { class: 'cbi-page-actions' }, [
+					E('button', {
+						class: 'btn cbi-button cbi-button-apply',
+						'data-nes-action': '1',
+						'data-nes-kind': 'upload',
+						disabled: !this.canControl,
+						click: ui.createHandlerFn(this, 'onUpload')
+					}, _('Choose, upload & load ROM'))
+				])
+			]) : '',
+			E('div', { class: 'cbi-section' }, [
+				E('h3', {}, _('ROMs on router')),
+				E('div', { id: 'nes-rom-table' },
+					E('em', {}, _('Loading ROM list…')))
+			]),
+			E('div', { class: 'cbi-section' }, [
+				E('h3', {}, _('Play')),
+				this.canControl ? E('p', {}, [
+					E('a', {
+						href: L.url('admin/services/nes-emulator/play')
+					}, _('Open Play tab (control permission required)'))
+				]) : E('p', { class: 'alert-message warning' },
+					_('Read-only access: game controls, ROM loading and uploads are disabled.')),
+				this.canControl && window.location.protocol === 'https:'
+					? E('details', {}, [
+						E('summary', {}, _('Connection help')),
+						E('p', {},
+							_('LuCI is using HTTPS, while the local game client uses HTTP. If the browser blocks the new window or upgrades it to HTTPS, allow HTTP for this router address or use a trusted reverse proxy.'))
+					])
+					: ''
+			])
+		]);
+
+		requestAnimationFrame(() => this.onRefreshAll());
+		return body;
+	},
+
+	statusText(status) {
+		if (!status || status.error)
+			return E('em', {}, status && status.error
+				? status.error
+				: _('Daemon is not reachable'));
+
+		const parts = [
+			status.core || 'FCEUmm',
+			status.rom ? _('ROM: %s').format(status.rom) : _('no ROM'),
+			status.running ? _('running') : _('stopped'),
+			status.on_demand ? _('on demand') : '',
+			status.paused ? _('paused') : '',
+			status.stream_format || '',
+			status.stream_fps
+				? _('%s stream FPS').format(status.stream_fps)
+				: ''
+		].filter(Boolean);
+
+		return E('span', {}, parts.join(' · '));
+	},
+
+	romTable(list, error, notice, truncated) {
+		const rows = (list || []).map(item => {
+			const path = typeof item === 'string'
+				? item
+				: (item.path || item.name || '');
+			const label = typeof item === 'string'
+				? item
+				: (item.name || item.path || '');
+			const unreadable = typeof item === 'object' &&
+				item !== null && item.readable === false;
+			const reason = unreadable
+				? (item.error ||
+					_('Not readable by nesd; upload through LuCI or set group nesd and mode 0640.'))
+				: '';
+
+			return E('tr', { class: 'tr' }, [
+				E('td', { class: 'td' }, unreadable
+					? [
+						label,
+						E('br'),
+						E('small', { class: 'warning' }, reason)
+					]
+					: label),
+				E('td', { class: 'td' }, [
+					E('button', {
+						class: 'btn cbi-button cbi-button-apply',
+						'data-nes-action': '1',
+						'data-nes-kind': 'load',
+						'data-nes-unavailable': unreadable ? '1' : '0',
+						disabled: Boolean(
+							this.actionBusy ||
+							!path ||
+							!this.canControl ||
+							unreadable
+						),
+						title: reason,
+						click: ui.createHandlerFn(this, 'onLoad', path)
+					}, _('Load'))
+				])
+			]);
+		});
+
+		if (!rows.length) {
+			rows.push(E('tr', { class: 'tr' }, [
+				E('td', { class: 'td', colspan: 2 },
+					E('em', {}, error || (this.canControl
+						? _('No ROMs — upload one above')
+						: _('No ROMs found'))))
+			]));
+		}
+		if (truncated || notice) {
+			rows.push(E('tr', { class: 'tr' }, [
+				E('td', { class: 'td', colspan: 2 },
+					E('small', {}, [
+						truncated ? _('ROM list was truncated. ') : '',
+						notice || ''
+					]))
+			]));
+		}
+
+		return E('table', { class: 'table' }, [
+			E('tr', { class: 'tr table-titles' }, [
+				E('th', { class: 'th' }, _('File')),
+				E('th', { class: 'th' }, _('Action'))
+			]),
+			...rows
+		]);
+	},
+
+	notifyError(title, error) {
+		ui.addNotification(
+			null,
+			E('p', {}, _('%s: %s').format(title, error.message || error)),
+			'error'
+		);
+	},
+
+	statusHasGame(status) {
+		if (!status || status.error)
+			return false;
+		if (typeof status.game_loaded === 'boolean')
+			return status.game_loaded;
+		return Boolean(status.rom || status.rom_path);
+	},
+
+	stateAllowsAction(kind, status) {
+		if (kind === 'load' || kind === 'upload')
+			return true;
+		if (!status || status.error)
+			return false;
+
+		const loaded = this.statusHasGame(status);
+		switch (kind) {
+		case 'start':
+			return loaded && !status.running;
+		case 'pause':
+		case 'reset':
+		case 'stop':
+			return loaded && Boolean(status.running);
+		default:
+			return true;
+		}
+	},
+
+	syncActionButtons() {
+		document.querySelectorAll('[data-nes-action]').forEach(button => {
+			const kind = button.getAttribute('data-nes-kind') || '';
+			const unavailable =
+				button.getAttribute('data-nes-unavailable') === '1';
+			button.disabled = Boolean(
+				this.actionBusy ||
+				!this.canControl ||
+				unavailable ||
+				!this.stateAllowsAction(kind, this.lastStatus)
+			);
+			if (kind === 'pause') {
+				button.textContent = this.lastStatus &&
+					this.lastStatus.paused
+					? _('Resume')
+					: _('Pause');
+			}
+		});
+	},
+
+	setActionBusy(busy) {
+		this.actionBusy = busy;
+		this.syncActionButtons();
+	},
+
+	async runAction(action, successText, timeoutMs = 30000) {
+		if (this.actionBusy)
+			return;
+		this.setActionBusy(true);
+		try {
+			requireSuccess(await withTimeout(action(), timeoutMs));
+			if (successText) {
+				ui.addNotification(null, E('p', {}, successText), 'info');
+			}
+			await this.onRefreshAll();
+		}
+		catch (error) {
+			this.notifyError(_('Operation failed'), error);
+		}
+		finally {
+			this.setActionBusy(false);
+		}
+	},
+
+	async onLoad(path) {
+		if (!this.canControl || !path)
+			return;
+		await this.runAction(
+			() => callLoad(path),
+			_('Loaded %s').format(path),
+			nesEmulator.getActionTimeout()
+		);
+	},
+
+	async onUpload() {
+		let staged = '';
+
+		if (!this.canControl || this.actionBusy)
+			return;
+		this.setActionBusy(true);
+		try {
+			const reservation = requireSuccess(
+				await withTimeout(callReserveUpload(), 20000)
+			);
+			staged = reservation.staged || '';
+			if (!/^\/tmp\/nes-emulator-upload\/[0-9a-f]{32}\.rom$/.test(staged))
+				throw new Error(_('Invalid upload reservation'));
+			const reply = await ui.uploadFile(
+				staged,
+				null,
+				_('Supported: iNES/NES 2.0, UNIF and FDS; maximum 16 MiB')
+			);
+			// rpcd import is transactional but cannot be cancelled. Waiting for
+			// its real result avoids a false timeout followed by a racing discard.
+			const result = await callImport(
+				staged,
+				reply.name || 'upload.nes'
+			);
+			if (result && result.stored)
+				staged = '';
+			if (result && result.stored &&
+			    (result.error || result.ok === false)) {
+				ui.addNotification(
+					null,
+					E('p', {}, _('ROM was stored but could not be loaded: %s (%s)')
+						.format(
+							result.path || reply.name || _('uploaded ROM'),
+							result.error || _('Operation failed')
+						)),
+					'warning'
+				);
+				await this.onRefreshAll();
+				return;
+			}
+			requireSuccess(result);
+			staged = '';
+			ui.addNotification(
+				null,
+				E('p', {}, _('ROM uploaded and loaded: %s')
+					.format(result.path || reply.name)),
+				'info'
+			);
+			await this.onRefreshAll();
+		}
+		catch (error) {
+			if (staged)
+				await withTimeout(callDiscardUpload(staged), 20000)
+					.catch(() => {});
+			this.notifyError(_('Upload failed'), error);
+		}
+		finally {
+			this.setActionBusy(false);
+		}
+	},
+
+	onStart() {
+		if (!this.canControl ||
+		    !this.stateAllowsAction('start', this.lastStatus))
+			return Promise.resolve();
+		return this.runAction(
+			callStart,
+			_('Emulation started'),
+			nesEmulator.getActionTimeout()
+		);
+	},
+
+	onStop() {
+		if (!this.canControl ||
+		    !this.stateAllowsAction('stop', this.lastStatus))
+			return Promise.resolve();
+		return this.runAction(callStop, _('Emulation stopped'));
+	},
+
+	onPause() {
+		if (!this.canControl ||
+		    !this.stateAllowsAction('pause', this.lastStatus))
+			return Promise.resolve();
+		return this.runAction(callPause);
+	},
+
+	onEmuReset() {
+		if (!this.canControl ||
+		    !this.stateAllowsAction('reset', this.lastStatus))
+			return Promise.resolve();
+		return this.runAction(callEmuReset, _('Console reset'));
+	},
+
+	async onRefreshAll() {
+		const generation = (this.refreshGeneration || 0) + 1;
+		this.refreshGeneration = generation;
+		const statusRequest = withTimeout(callStatus(), 5000)
+			.catch(error => ({ error: error.message || String(error) }))
+			.then(status => {
+				if (generation !== this.refreshGeneration)
+					return;
+				this.lastStatus = status;
+				const statusNode = document.getElementById('nes-status');
+				if (statusNode)
+					statusNode.replaceChildren(this.statusText(status));
+				this.syncActionButtons();
+			});
+		const romRequest = withTimeout(callRoms(), 15000)
+			.catch(error => ({
+				roms: [],
+				error: error.message || String(error)
+			}))
+			.then(roms => {
+				if (generation !== this.refreshGeneration)
+					return;
+				const romNode = document.getElementById('nes-rom-table');
+				if (romNode) {
+					romNode.replaceChildren(
+						this.romTable(
+							roms.roms || [],
+							roms.error,
+							roms.notice,
+							roms.truncated
+						)
+					);
+				}
+				this.syncActionButtons();
+			});
+
+		await Promise.all([ statusRequest, romRequest ]);
+		return generation === this.refreshGeneration;
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js
+++ b/applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js
@@ -1,0 +1,134 @@
+'use strict';
+'require view';
+'require nes-emulator as nesEmulator';
+
+const callAccess = nesEmulator.declareLongRunningRpc({
+	object: 'nes-emulator',
+	method: 'access',
+	expect: { '': {} }
+});
+
+function urlHost(hostname) {
+	return hostname.includes(':') && hostname[0] !== '['
+		? '[' + hostname + ']'
+		: hostname;
+}
+
+return view.extend({
+	load() {
+		return callAccess().catch(error => ({
+			error: error.message || String(error)
+		}));
+	},
+
+	accessSection(access, busy) {
+		access = access || {};
+		const port = String(access.port || '29876');
+		const token = access.token || '';
+		const accessError = access.error || '';
+		const effectiveError = accessError ||
+			(access.ok === false ? _('Service unavailable') : '');
+		const unavailableMessage = busy
+			? _('Starting nesd…')
+			: effectiveError
+				? _('Cannot open the game client: %s').format(effectiveError)
+				: _('This page requires NES emulator control permission. The access token is never exposed to read-only LuCI sessions.');
+		const playUrl = 'http://' + urlHost(window.location.hostname) +
+			':' + port + '/play#token=' + encodeURIComponent(token);
+		const https = window.location.protocol === 'https:';
+		const launch = token
+			? E('a', {
+				class: 'btn cbi-button cbi-button-apply',
+				href: playUrl,
+				target: '_blank',
+				rel: 'noopener noreferrer'
+			}, _('Open game window'))
+			: E('span', {
+				class: 'btn cbi-button disabled',
+				'aria-disabled': 'true'
+			}, effectiveError
+				? _('Service unavailable')
+				: _('Control permission required'));
+		const connectionHelp = token && https
+			? E('details', {}, [
+				E('summary', {}, _('Connection help')),
+				E('p', {},
+					_('LuCI is using HTTPS, while the local game client uses HTTP. If the browser blocks the new window or upgrades it to HTTPS, allow HTTP for this router address or use a trusted reverse proxy.'))
+			])
+			: '';
+
+		return E('div', { class: 'cbi-section' }, [
+			!token
+				? E('p', { class: 'alert-message warning' },
+					unavailableMessage)
+				: '',
+			token
+				? E('p', {},
+					_('The game client opens in a separate local window. The router still runs FCEUmm and renders every frame.'))
+				: '',
+			connectionHelp,
+			E('p', { class: 'cbi-page-actions' }, [
+				launch,
+				effectiveError ? ' ' : '',
+				effectiveError
+					? E('button', {
+						class: 'btn cbi-button cbi-button-action',
+						'data-nes-retry': '1',
+						disabled: Boolean(busy),
+						click: this.onRetry.bind(this)
+					}, busy ? _('Starting…') : _('Retry'))
+					: ''
+			])
+		]);
+	},
+
+	updateAccessSection() {
+		const node = document.getElementById('nes-play-access');
+		if (node) {
+			node.replaceChildren(
+				this.accessSection(this.access, this.retryBusy)
+			);
+		}
+	},
+
+	async onRetry() {
+		if (this.retryBusy)
+			return;
+		this.retryBusy = true;
+		this.updateAccessSection();
+		try {
+			this.access = await callAccess();
+			if (!this.access) {
+				this.access = {
+					error: _('Empty response while starting nesd')
+				};
+			}
+		}
+		catch (error) {
+			this.access = {
+				error: error.message || String(error)
+			};
+		}
+		finally {
+			this.retryBusy = false;
+			this.updateAccessSection();
+		}
+	},
+
+	render(data) {
+		this.access = data || {};
+		this.retryBusy = false;
+
+		return E('div', { class: 'cbi-map' }, [
+			E('h2', {}, _('Play (thin client)')),
+			E('div', { class: 'cbi-map-descr' },
+				_('The router runs FCEUmm and renders every frame in software. This page only displays the stream, plays audio and sends controller input.')),
+			E('div', { id: 'nes-play-access' },
+				this.accessSection(this.access, false))
+		]);
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js
+++ b/applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js
@@ -1,0 +1,274 @@
+'use strict';
+'require view';
+'require form';
+'require ui';
+'require nes-emulator as nesEmulator';
+
+const callRotateToken = nesEmulator.declareLongRunningRpc({
+	object: 'nes-emulator',
+	method: 'rotate_token',
+	expect: { '': {} }
+});
+
+function validateDataDir(sectionId, value) {
+	if (!value || value[0] !== '/')
+		return _('An absolute directory path is required');
+	if (value.includes('\0') || value.includes('\n') ||
+	    value.includes(':') || value.includes(';') ||
+	    value.includes(',') || value.includes('//'))
+		return _('The directory contains unsupported characters');
+
+	const parts = value.split('/');
+	if (parts.includes('.') || parts.includes('..'))
+		return _('Relative path components are not allowed');
+
+	const forbidden = [
+		'/', '/bin', '/boot', '/dev', '/etc', '/home', '/lib',
+		'/lib64', '/mnt', '/opt', '/overlay', '/proc', '/root',
+		'/run', '/sbin', '/sys', '/tmp', '/usr', '/var'
+	];
+	if (forbidden.includes(value.replace(/\/+$/, '') || '/'))
+		return _('Choose a dedicated subdirectory, not a system root');
+	return true;
+}
+
+function validateOptionalDataDir(sectionId, value) {
+	if (!value)
+		return true;
+	return validateDataDir(sectionId, value);
+}
+
+function validateOrigin(sectionId, value) {
+	if (!value)
+		return true;
+	try {
+		const parsed = new URL(value);
+		if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+		    parsed.username || parsed.password || parsed.search ||
+		    parsed.hash || parsed.pathname !== '/' ||
+		    value !== parsed.origin)
+			throw new Error();
+		return true;
+	}
+	catch (error) {
+		return _('Enter an exact Origin such as https://192.168.1.1');
+	}
+}
+
+function validateRom(sectionId, value) {
+	if (!value)
+		return true;
+	const dirResult = validateDataDir(sectionId, value);
+	if (dirResult !== true)
+		return dirResult;
+	if (!/\.(nes|fds|unf|unif)$/i.test(value))
+		return _('Expected a .nes, .fds, .unf or .unif file');
+	return true;
+}
+
+return view.extend({
+	render() {
+		const map = new form.Map(
+			'nes-emulator',
+			_('NES Emulator settings'),
+			_('nesd contains a statically linked FCEUmm core. Emulation, PPU rendering and JPEG encoding stay on the router CPU.')
+		);
+
+		const section = map.section(
+			form.TypedSection,
+			'nes-emulator',
+			_('Service')
+		);
+		section.anonymous = true;
+		section.addremove = false;
+
+		let option;
+
+		option = section.option(
+			form.Flag,
+			'enabled',
+			_('Start at boot'),
+			_('Keep disabled unless the emulator should start on every boot. Loading a ROM starts it on demand for the current uptime.')
+		);
+		option.default = option.disabled;
+		option.rmempty = false;
+
+		option = section.option(
+			form.DummyValue,
+			'_core',
+			_('Emulator core')
+		);
+		option.cfgvalue = () => _('FCEUmm (statically linked into nesd)');
+
+		option = section.option(
+			form.Value,
+			'rom_dir',
+			_('Primary ROM directory'),
+			_('Validated LuCI uploads are stored here')
+		);
+		option.default = '/etc/nes-emulator/roms';
+		option.rmempty = false;
+		option.validate = validateDataDir;
+
+		option = section.option(
+			form.Flag,
+			'extra_rom_dirs_enabled',
+			_('Enable extra ROM directories'),
+			_('Hard-disable scanning and daemon access to every extra directory while keeping the saved paths ready for re-enabling.')
+		);
+		option.default = option.disabled;
+		option.rmempty = false;
+
+		option = section.option(
+			form.DynamicList,
+			'extra_rom_dir',
+			_('Extra ROM directories'),
+			_('Read-only USB or SD paths to scan, for example /mnt/sda1/roms')
+		);
+		option.placeholder = '/mnt/sda1/roms';
+		option.validate = validateOptionalDataDir;
+		option.retain = true;
+		option.depends('extra_rom_dirs_enabled', '1');
+
+		option = section.option(
+			form.Value,
+			'system_dir',
+			_('System directory')
+		);
+		option.default = '/etc/nes-emulator/system';
+		option.rmempty = false;
+		option.validate = validateDataDir;
+
+		option = section.option(
+			form.Value,
+			'save_dir',
+			_('Save directory'),
+			_('Battery-backed SRAM and full save states are written here using atomic replacement')
+		);
+		option.default = '/etc/nes-emulator/saves';
+		option.rmempty = false;
+		option.validate = validateDataDir;
+
+		option = section.option(
+			form.Value,
+			'bind',
+			_('Bind address'),
+			_('Use 0.0.0.0 for LAN access. Requests still require the generated token.')
+		);
+		option.datatype = 'ipaddr';
+		option.default = '0.0.0.0';
+		option.rmempty = false;
+
+		option = section.option(
+			form.Value,
+			'port',
+			_('HTTP / WebSocket port')
+		);
+		option.datatype = 'port';
+		option.default = '29876';
+		option.rmempty = false;
+
+		option = section.option(
+			form.Value,
+			'allowed_origin',
+			_('Restrict browser Origin'),
+			_('Optional exact Origin for a cross-origin custom client. The built-in game page is same-origin with nesd, so normally leave this empty.')
+		);
+		option.placeholder = 'https://client.example';
+		option.validate = validateOrigin;
+
+		option = section.option(
+			form.Button,
+			'_rotate_token',
+			_('Access token'),
+			_('The token is generated automatically and is required by every API and WebSocket client.')
+		);
+		option.inputtitle = _('Rotate token');
+		option.inputstyle = 'action';
+		option.onclick = async () => {
+			ui.showModal(
+				_('Rotating access token'),
+				E('p', {}, _('Restarting nesd…'))
+			);
+			try {
+				const reply = await callRotateToken();
+				if (!reply || reply.error || reply.ok === false)
+					throw new Error(reply && reply.error || _('Operation failed'));
+				ui.hideModal();
+				ui.addNotification(
+					null,
+					E('p', {}, _('Access token rotated; old game windows were disconnected.')),
+					'info'
+				);
+			}
+			catch (error) {
+				ui.hideModal();
+				ui.addNotification(
+					null,
+					E('p', {}, _('Token rotation failed: %s')
+						.format(error.message || error)),
+					'error'
+				);
+			}
+		};
+
+		option = section.option(
+			form.ListValue,
+			'stream_format',
+			_('Video stream format'),
+			_('Each raw RGB565 frame is 120 KiB: video uses about 2.0 Mbit/s at the default 2 FPS and 59.0 Mbit/s at 60 FPS. PCM 48 kHz stereo int16 adds about 1.54 Mbit/s, for roughly 3.5 or 60.5 Mbit/s total before WebSocket and Wi-Fi overhead. Raw is pixel-perfect but can consume substantial LAN airtime. JPEG reduces video bandwidth but is encoded in software on the router.')
+		);
+		option.value('raw', _('Raw RGB565 (pixel-perfect)'));
+		option.value('jpeg', _('Software JPEG (lower bandwidth)'));
+		option.default = 'raw';
+		option.rmempty = false;
+
+		option = section.option(
+			form.Value,
+			'jpeg_quality',
+			_('JPEG quality')
+		);
+		option.datatype = 'range(1,100)';
+		option.default = '92';
+		option.rmempty = false;
+		option.depends('stream_format', 'jpeg');
+
+		option = section.option(
+			form.Value,
+			'stream_fps',
+			_('Maximum streamed FPS'),
+			_('Allowed range: 1–60 FPS. This only limits frame delivery; FCEUmm keeps the ROM region’s native 50/60 FPS timing. Raw bandwidth scales directly with this value, so use 1–2 FPS on slow or shared Wi-Fi.')
+		);
+		option.datatype = 'range(1,60)';
+		option.default = '2';
+		option.rmempty = false;
+
+		option = section.option(
+			form.Flag,
+			'show_fps',
+			_('Show FPS counter'),
+			_('Draw only the browser-painted FPS number as a FCEUX-like pixel OSD directly over the NES canvas in its top-right corner, without a separate browser widget. The number reflects delivery, decode and paint slowdowns rather than the ROM’s native frame rate or the configured stream limit. The setting is applied after Save & Apply and the game window reconnects.')
+		);
+		option.default = option.enabled;
+		option.rmempty = false;
+
+		option = section.option(
+			form.Flag,
+			'show_touch_controls',
+			_('Show on-screen controls'),
+			_('Show the clickable and touch-friendly NES buttons in the game window. Disable this on a computer to free screen space; keyboard and gamepad controls remain available. Save & Apply, then reconnect the game window to apply the setting.')
+		);
+		option.default = option.enabled;
+		option.rmempty = false;
+
+		option = section.option(
+			form.Value,
+			'rom',
+			_('Autoload ROM path')
+		);
+		option.placeholder = '/etc/nes-emulator/roms/game.nes';
+		option.validate = validateRom;
+
+		return map.render();
+	}
+});

--- a/applications/luci-app-nes-emulator/po/templates/nes-emulator.pot
+++ b/applications/luci-app-nes-emulator/po/templates/nes-emulator.pot
@@ -1,0 +1,497 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:217
+msgid "%s stream FPS"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:296
+msgid "%s: %s"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:183
+msgid "Access token"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:200
+msgid "Access token rotated; old game windows were disconnected."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:287
+msgid "Action"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:240
+msgid ""
+"Allowed range: 1–60 FPS. This only limits frame delivery; FCEUmm keeps the "
+"ROM region’s native 50/60 FPS timing. Raw bandwidth scales directly with "
+"this value, so use 1–2 FPS on slow or shared Wi-Fi."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:15
+msgid "An absolute directory path is required"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:267
+msgid "Autoload ROM path"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:146
+msgid ""
+"Battery-backed SRAM and full save states are written here using atomic "
+"replacement"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:155
+msgid "Bind address"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:34
+msgid "Cannot open the game client: %s"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:31
+msgid "Choose a dedicated subdirectory, not a system root"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:173
+msgid "Choose, upload & load ROM"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:191
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:54
+msgid "Connection help"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:467
+msgid "Console reset"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:51
+msgid "Control permission required"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:207
+msgid "Daemon is not reachable"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:250
+msgid ""
+"Draw only the browser-painted FPS number as a FCEUX-like pixel OSD directly "
+"over the NES canvas in its top-right corner, without a separate browser "
+"widget. The number reflects delivery, decode and paint slowdowns rather than "
+"the ROM’s native frame rate or the configured stream limit. The setting is "
+"applied after Save & Apply and the game window reconnects."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:219
+msgid ""
+"Each raw RGB565 frame is 120 KiB: video uses about 2.0 Mbit/s at the default "
+"2 FPS and 59.0 Mbit/s at 60 FPS. PCM 48 kHz stereo int16 adds about 1.54 "
+"Mbit/s, for roughly 3.5 or 60.5 Mbit/s total before WebSocket and Wi-Fi "
+"overhead. Raw is pixel-perfect but can consume substantial LAN airtime. JPEG "
+"reduces video bandwidth but is encoded in software on the router."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:97
+msgid "Empty response"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:103
+msgid "Empty response while starting nesd"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:446
+msgid "Emulation started"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:453
+msgid "Emulation stopped"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:99
+msgid "Emulator core"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:116
+msgid "Enable extra ROM directories"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:54
+msgid "Enter an exact Origin such as https://192.168.1.1"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:65
+msgid "Expected a .nes, .fds, .unf or .unif file"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:125
+msgid "Extra ROM directories"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:101
+msgid "FCEUmm (statically linked into nesd)"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:118
+msgid ""
+"FCEUmm, picture rendering and optional JPEG encoding all run on the router "
+"CPU. The browser is only a display, audio sink and controller."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:286
+msgid "File"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/root/usr/share/rpcd/acl.d/luci-app-nes-emulator.json:3
+msgid "Grant access to the NES emulator"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:165
+msgid "HTTP / WebSocket port"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:117
+msgid ""
+"Hard-disable scanning and daemon access to every extra directory while "
+"keeping the saved paths ready for re-enabling."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:393
+msgid "Invalid upload reservation"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:229
+msgid "JPEG quality"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:91
+msgid ""
+"Keep disabled unless the emulator should start on every boot. Loading a ROM "
+"starts it on demand for the current uptime."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:261
+msgid "Load"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:377
+msgid "Loaded %s"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:179
+msgid "Loading ROM list…"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:122
+msgid "Loading status…"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:193
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:56
+msgid ""
+"LuCI is using HTTPS, while the local game client uses HTTP. If the browser "
+"blocks the new window or upgrades it to HTTPS, allow HTTP for this router "
+"address or use a trusted reverse proxy."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:239
+msgid "Maximum streamed FPS"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:116
+#: applications/luci-app-nes-emulator/root/usr/share/luci/menu.d/luci-app-nes-emulator.json:3
+msgid "NES Emulator"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:73
+msgid "NES Emulator settings"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:271
+msgid "No ROMs found"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:270
+msgid "No ROMs — upload one above"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:236
+msgid ""
+"Not readable by nesd; upload through LuCI or set group nesd and mode 0640."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:186
+msgid "Open Play tab (control permission required)"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:45
+msgid "Open game window"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:99
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:365
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:414
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:196
+msgid "Operation failed"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:175
+msgid ""
+"Optional exact Origin for a cross-origin custom client. The built-in game "
+"page is same-origin with nesd, so normally leave this empty."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/root/usr/share/luci/menu.d/luci-app-nes-emulator.json:13
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:343
+msgid "Pause"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:138
+msgid "Pause / Resume"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:182
+#: applications/luci-app-nes-emulator/root/usr/share/luci/menu.d/luci-app-nes-emulator.json:24
+msgid "Play"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:123
+msgid "Play (thin client)"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:106
+msgid "Primary ROM directory"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:278
+msgid "ROM list was truncated."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:425
+msgid "ROM uploaded and loaded: %s"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:411
+msgid "ROM was stored but could not be loaded: %s (%s)"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:211
+msgid "ROM: %s"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:177
+msgid "ROMs on router"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:221
+msgid "Raw RGB565 (pixel-perfect)"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:126
+msgid "Read-only USB or SD paths to scan, for example /mnt/sda1/roms"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:188
+msgid "Read-only access: game controls, ROM loading and uploads are disabled."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:159
+msgid "Refresh"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:23
+msgid "Relative path components are not allowed"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:79
+msgid "Request timed out"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:146
+msgid "Reset console"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:191
+msgid "Restarting nesd…"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:174
+msgid "Restrict browser Origin"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:342
+msgid "Resume"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:79
+msgid "Retry"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:186
+msgid "Rotate token"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:190
+msgid "Rotating access token"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:145
+msgid "Save directory"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:80
+msgid "Service"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:30
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:50
+msgid "Service unavailable"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/root/usr/share/luci/menu.d/luci-app-nes-emulator.json:35
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:249
+msgid "Show FPS counter"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:258
+msgid "Show on-screen controls"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:259
+msgid ""
+"Show the clickable and touch-friendly NES buttons in the game window. "
+"Disable this on a computer to free screen space; keyboard and gamepad "
+"controls remain available. Save & Apply, then reconnect the game window to "
+"apply the setting."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:222
+msgid "Software JPEG (lower bandwidth)"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:130
+msgid "Start"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:90
+msgid "Start at boot"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:32
+msgid "Starting nesd…"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:79
+msgid "Starting…"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:120
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:154
+msgid "Stop emulation"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:397
+msgid "Supported: iNES/NES 2.0, UNIF and FDS; maximum 16 MiB"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:136
+msgid "System directory"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:165
+msgid ""
+"The authenticated LuCI uploader stages the file, then rpcd validates its "
+"size, extension and NES header before an atomic import. Maximum size: 16 MiB."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:19
+msgid "The directory contains unsupported characters"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:67
+msgid ""
+"The game client opens in a separate local window. The router still runs "
+"FCEUmm and renders every frame."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:125
+msgid ""
+"The router runs FCEUmm and renders every frame in software. This page only "
+"displays the stream, plays audio and sends controller input."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:184
+msgid ""
+"The token is generated automatically and is required by every API and "
+"WebSocket client."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/play.js:35
+msgid ""
+"This page requires NES emulator control permission. The access token is "
+"never exposed to read-only LuCI sessions."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:208
+msgid "Token rotation failed: %s"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:163
+msgid "Upload ROM from this computer"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:435
+msgid "Upload failed"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:156
+msgid "Use 0.0.0.0 for LAN access. Requests still require the generated token."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:107
+msgid "Validated LuCI uploads are stored here"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:218
+msgid "Video stream format"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/settings.js:74
+msgid ""
+"nesd contains a statically linked FCEUmm core. Emulation, PPU rendering and "
+"JPEG encoding stay on the router CPU."
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:211
+msgid "no ROM"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:213
+msgid "on demand"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:214
+msgid "paused"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:212
+msgid "running"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:212
+msgid "stopped"
+msgstr ""
+
+#: applications/luci-app-nes-emulator/htdocs/luci-static/resources/view/nes-emulator/overview.js:413
+msgid "uploaded ROM"
+msgstr ""

--- a/applications/luci-app-nes-emulator/root/usr/libexec/rpcd/nes-emulator
+++ b/applications/luci-app-nes-emulator/root/usr/libexec/rpcd/nes-emulator
@@ -1,0 +1,1601 @@
+#!/bin/sh
+# Authenticated rpcd bridge. LuCI talks only to rpcd; rpcd talks to nesd on
+# the router and never exposes init-script execution through the ACL.
+
+. /lib/functions.sh 2>/dev/null
+. /usr/share/libubox/jshn.sh 2>/dev/null
+
+CONFIG_FILE=/etc/config/nes-emulator
+TOKEN_FILE=/etc/nes-emulator/auth.token
+UPLOAD_DIR=/tmp/nes-emulator-upload
+LOCK_DIR=/var/run/nes-emulator
+TOKEN_LOCK_FILE="$LOCK_DIR/auth.token.lock"
+UPLOAD_LOCK_FILE="$LOCK_DIR/upload.lock"
+START_LOCK_FILE="$LOCK_DIR/start.lock"
+TOKEN_LOCK_MAX_ATTEMPTS=10
+UPLOAD_LOCK_MAX_ATTEMPTS=3
+START_LOCK_MAX_ATTEMPTS=20
+ROTATE_TOKEN_LOCK_MAX_ATTEMPTS=3
+ROTATE_START_LOCK_MAX_ATTEMPTS=4
+NESD_BIN=/usr/bin/nesd
+MAX_ROM_SIZE=16777216
+ROM_QUOTA_SIZE=134217728
+MIN_FREE_KIB=8192
+MAX_ROM_ENTRIES=8192
+MAX_ROM_FIND_DEPTH=7
+AUTH_TOKEN=''
+TOKEN_LOCK_HELD=0
+UPLOAD_LOCK_HELD=0
+START_LOCK_HELD=0
+HTTP_CLIENT=''
+START_ERROR=''
+RPC_HOST=''
+SERVICE_INSTANCE_RUNNING=''
+SERVICE_INSTANCE_EXIT_CODE=''
+SERVICE_NESD_GID=''
+META_MODE=''
+META_NLINK=''
+META_UID=''
+META_GID=''
+
+# fd 9 owns the upload flock, fd 8 the token flock and fd 7 the startup flock.
+# Keep all three in this rpcd shell only: no command-substitution shell, service
+# process or external jshn process may keep a lock alive after this request exits.
+json_load_without_upload_fd() {
+	local statements
+
+	statements="$(
+		exec 7>&- 8>&- 9>&-
+		jshn -r "$1"
+	)" || return 1
+	eval "$statements"
+}
+
+json_dump_without_upload_fd() {
+	jshn ${JSON_PREFIX:+-p "$JSON_PREFIX"} \
+		${JSON_NONEWLINE:+-n} ${JSON_INDENT:+-i} -w 7>&- 8>&- 9>&-
+}
+
+read_metadata() {
+	local path="$1" metadata
+
+	metadata="$(
+		exec 7>&- 8>&- 9>&-
+		LC_ALL=C ls -ldn "$path" 2>/dev/null
+	)" || return 1
+	case "$metadata" in
+		*'
+'*) return 1 ;;
+	esac
+	# Intentional field splitting of the fixed-format numeric ls output.
+	# shellcheck disable=SC2086
+	set -- $metadata
+	[ "$#" -ge 4 ] || return 1
+	case "$2:$3:$4" in *[!0-9:]*) return 1 ;; esac
+	META_MODE="$1"
+	META_NLINK="$2"
+	META_UID="$3"
+	META_GID="$4"
+	return 0
+}
+
+validate_regular_metadata() {
+	local path="$1" expected_mode="$2" expected_uid="$3" expected_gid="$4"
+
+	[ -f "$path" ] && [ ! -L "$path" ] || return 1
+	read_metadata "$path" &&
+		[ "$META_MODE" = "$expected_mode" ] &&
+		[ "$META_NLINK" = 1 ] &&
+		[ "$META_UID" = "$expected_uid" ] &&
+		[ "$META_GID" = "$expected_gid" ]
+}
+
+validate_directory_metadata() {
+	local path="$1" expected_mode="$2" expected_uid="$3" expected_gid="$4"
+
+	[ -d "$path" ] && [ ! -L "$path" ] || return 1
+	read_metadata "$path" &&
+		[ "$META_MODE" = "$expected_mode" ] &&
+		[ "$META_UID" = "$expected_uid" ] &&
+		[ "$META_GID" = "$expected_gid" ]
+}
+
+prepare_lock_directory() {
+	if [ -e "$LOCK_DIR" ] || [ -L "$LOCK_DIR" ]; then
+		validate_directory_metadata "$LOCK_DIR" drwx------ 0 0
+		return
+	fi
+	(
+		exec 7>&- 8>&- 9>&-
+		umask 077
+		mkdir "$LOCK_DIR"
+	) 2>/dev/null ||
+		validate_directory_metadata "$LOCK_DIR" drwx------ 0 0 ||
+		return 1
+	validate_directory_metadata "$LOCK_DIR" drwx------ 0 0
+}
+
+prepare_lock_file() {
+	local path="$1"
+
+	prepare_lock_directory || return 1
+	if [ -e "$path" ] || [ -L "$path" ]; then
+		validate_regular_metadata "$path" -rw------- 0 0
+		return
+	fi
+	(
+		exec 7>&- 8>&- 9>&-
+		set -C
+		umask 077
+		: >"$path"
+	) 2>/dev/null ||
+		validate_regular_metadata "$path" -rw------- 0 0 ||
+		return 1
+	validate_regular_metadata "$path" -rw------- 0 0
+}
+
+load_service_nesd_gid() {
+	[ -n "$SERVICE_NESD_GID" ] && return 0
+	SERVICE_NESD_GID="$(
+		exec 7>&- 8>&- 9>&-
+		id -g nesd 2>/dev/null
+	)" || SERVICE_NESD_GID=
+	case "$SERVICE_NESD_GID" in
+		''|*[!0-9]*) return 1 ;;
+	esac
+	return 0
+}
+
+validate_config_file() {
+	validate_regular_metadata "$CONFIG_FILE" -rw------- 0 0
+}
+
+json_error() {
+	json_init
+	json_add_boolean ok 0
+	json_add_string error "$1"
+	json_dump_without_upload_fd
+}
+
+token_is_valid() {
+	local token="$1"
+
+	[ "${#token}" -ge 32 ] 2>/dev/null &&
+		[ "${#token}" -le 127 ] 2>/dev/null || return 1
+	case "$token" in *[!A-Za-z0-9._~-]*) return 1 ;; esac
+	return 0
+}
+
+new_token() {
+	local token
+
+	token="$(
+		exec 7>&- 8>&- 9>&-
+		hexdump -v -n 32 -e '1/1 "%02x"' /dev/urandom 2>/dev/null
+	)" || return 1
+	[ "${#token}" -eq 64 ] || return 1
+	printf '%s' "$token"
+}
+
+validate_token_parent() {
+	local directory="${TOKEN_FILE%/*}" resolved
+
+	load_service_nesd_gid || return 1
+	[ -d "$directory" ] && [ ! -L "$directory" ] || return 1
+	resolved="$(
+		exec 7>&- 8>&- 9>&-
+		readlink -f "$directory" 2>/dev/null
+	)" || return 1
+	[ "$resolved" = "$directory" ] || return 1
+	validate_directory_metadata "$directory" drwxr-x--- 0 \
+		"$SERVICE_NESD_GID"
+}
+
+read_auth_token() {
+	local token bytes lines
+
+	load_service_nesd_gid || return 1
+	validate_regular_metadata "$TOKEN_FILE" -rw-r----- 0 \
+		"$SERVICE_NESD_GID" || return 1
+	token="$(
+		exec 7>&- 8>&- 9>&-
+		cat "$TOKEN_FILE" 2>/dev/null
+	)" || return 1
+	token_is_valid "$token" || return 1
+	bytes="$(
+		exec 7>&- 8>&- 9>&-
+		wc -c <"$TOKEN_FILE" 2>/dev/null | tr -d ' '
+	)"
+	lines="$(
+		exec 7>&- 8>&- 9>&-
+		wc -l <"$TOKEN_FILE" 2>/dev/null | tr -d ' '
+	)"
+	[ "$lines" = 1 ] &&
+		[ "$bytes" -eq $((${#token} + 1)) ] 2>/dev/null || return 1
+	AUTH_TOKEN="$token"
+	return 0
+}
+
+write_auth_token() {
+	local token="$1" temporary
+
+	token_is_valid "$token" || return 1
+	validate_token_parent || return 1
+	if [ -e "$TOKEN_FILE" ] || [ -L "$TOKEN_FILE" ]; then
+		validate_regular_metadata "$TOKEN_FILE" -rw-r----- 0 \
+			"$SERVICE_NESD_GID" || return 1
+	fi
+	temporary="$(
+		exec 7>&- 8>&- 9>&-
+		mktemp "${TOKEN_FILE}.tmp.XXXXXX" 2>/dev/null
+	)" ||
+		return 1
+	if ! printf '%s\n' "$token" >"$temporary" ||
+	   ! chown root:nesd "$temporary" 2>/dev/null 7>&- 8>&- 9>&- ||
+	   ! chmod 0640 "$temporary" 2>/dev/null 7>&- 8>&- 9>&- ||
+	   ! mv -f "$temporary" "$TOKEN_FILE" 7>&- 8>&- 9>&-; then
+		rm -f "$temporary" 7>&- 8>&- 9>&-
+		return 1
+	fi
+	return 0
+}
+
+release_token_lock() {
+	[ "$TOKEN_LOCK_HELD" -eq 1 ] || return 0
+	exec 8>&-
+	TOKEN_LOCK_HELD=0
+	[ "$UPLOAD_LOCK_HELD" -eq 1 ] ||
+		[ "$START_LOCK_HELD" -eq 1 ] ||
+		trap - 0 1 2 15
+}
+
+acquire_token_lock() {
+	local attempts=0
+
+	[ "$TOKEN_LOCK_HELD" -eq 0 ] || return 0
+	prepare_lock_file "$TOKEN_LOCK_FILE" || return 1
+	command exec 8<>"$TOKEN_LOCK_FILE" || return 1
+	validate_regular_metadata "$TOKEN_LOCK_FILE" -rw------- 0 0 || {
+		exec 8>&-
+		return 1
+	}
+	while ! flock -n 8 2>/dev/null; do
+		attempts=$((attempts + 1))
+		if [ "$attempts" -ge "$TOKEN_LOCK_MAX_ATTEMPTS" ]; then
+			exec 8>&-
+			return 1
+		fi
+		sleep 1 9>&- 8>&- 7>&-
+	done
+	TOKEN_LOCK_HELD=1
+	trap 'release_all_locks' 0
+	trap 'release_all_locks; exit 1' 1 2 15
+	return 0
+}
+
+release_upload_lock() {
+	[ "$UPLOAD_LOCK_HELD" -eq 1 ] || return 0
+	exec 9>&-
+	UPLOAD_LOCK_HELD=0
+	[ "$TOKEN_LOCK_HELD" -eq 1 ] ||
+		[ "$START_LOCK_HELD" -eq 1 ] ||
+		trap - 0 1 2 15
+}
+
+release_start_lock() {
+	[ "$START_LOCK_HELD" -eq 1 ] || return 0
+	exec 7>&-
+	START_LOCK_HELD=0
+	[ "$TOKEN_LOCK_HELD" -eq 1 ] ||
+		[ "$UPLOAD_LOCK_HELD" -eq 1 ] ||
+		trap - 0 1 2 15
+}
+
+release_all_locks() {
+	trap - 0 1 2 15
+	if [ "$TOKEN_LOCK_HELD" -eq 1 ]; then
+		exec 8>&-
+		TOKEN_LOCK_HELD=0
+	fi
+	if [ "$UPLOAD_LOCK_HELD" -eq 1 ]; then
+		exec 9>&-
+		UPLOAD_LOCK_HELD=0
+	fi
+	if [ "$START_LOCK_HELD" -eq 1 ]; then
+		exec 7>&-
+		START_LOCK_HELD=0
+	fi
+}
+
+acquire_upload_lock() {
+	local attempts=0
+
+	[ "$UPLOAD_LOCK_HELD" -eq 0 ] || return 0
+	prepare_lock_file "$UPLOAD_LOCK_FILE" || return 1
+	command exec 9<>"$UPLOAD_LOCK_FILE" || return 1
+	validate_regular_metadata "$UPLOAD_LOCK_FILE" -rw------- 0 0 || {
+		exec 9>&-
+		return 1
+	}
+	while ! flock -n 9 2>/dev/null; do
+		attempts=$((attempts + 1))
+		if [ "$attempts" -ge "$UPLOAD_LOCK_MAX_ATTEMPTS" ]; then
+			exec 9>&-
+			return 1
+		fi
+		sleep 1 9>&-
+	done
+	UPLOAD_LOCK_HELD=1
+	trap 'release_all_locks' 0
+	trap 'release_all_locks; exit 1' 1 2 15
+	return 0
+}
+
+acquire_start_lock() {
+	local attempts=0 max_attempts="${1:-$START_LOCK_MAX_ATTEMPTS}"
+
+	[ "$START_LOCK_HELD" -eq 0 ] || return 0
+	case "$max_attempts" in ''|*[!0-9]*|0) return 1 ;; esac
+	prepare_lock_file "$START_LOCK_FILE" || return 1
+	command exec 7<>"$START_LOCK_FILE" || return 1
+	validate_regular_metadata "$START_LOCK_FILE" -rw------- 0 0 || {
+		exec 7>&-
+		return 1
+	}
+	while ! flock -n 7 2>/dev/null; do
+		attempts=$((attempts + 1))
+		if [ "$attempts" -ge "$max_attempts" ]; then
+			exec 7>&-
+			return 1
+		fi
+		sleep 1 9>&- 7>&-
+	done
+	START_LOCK_HELD=1
+	trap 'release_all_locks' 0
+	trap 'release_all_locks; exit 1' 1 2 15
+	return 0
+}
+
+remove_legacy_token() {
+	uci -q get nes-emulator.main.auth_token \
+		>/dev/null 2>&1 7>&- 8>&- 9>&- ||
+		return 0
+	uci -q delete nes-emulator.main.auth_token 7>&- 8>&- 9>&- &&
+		uci -q commit nes-emulator 7>&- 8>&- 9>&- &&
+		validate_config_file
+}
+
+ensure_auth_token() {
+	local token
+
+	validate_token_parent || return 1
+	acquire_token_lock || return 1
+	if read_auth_token; then
+		token="$AUTH_TOKEN"
+	elif [ ! -e "$TOKEN_FILE" ] && [ ! -L "$TOKEN_FILE" ]; then
+		token="$(
+			exec 7>&- 8>&- 9>&-
+			new_token
+		)"
+		if [ "${#token}" -ne 64 ] ||
+		   ! write_auth_token "$token" ||
+		   ! remove_legacy_token; then
+			release_token_lock
+			return 1
+		fi
+	else
+		release_token_lock
+		return 1
+	fi
+	release_token_lock
+	AUTH_TOKEN="$token"
+	return 0
+}
+
+prepare_upload_dir() {
+	if [ -e "$UPLOAD_DIR" ] || [ -L "$UPLOAD_DIR" ]; then
+		validate_directory_metadata "$UPLOAD_DIR" drwx------ 0 0
+		return
+	fi
+	(
+		exec 9>&-
+		umask 077
+		mkdir "$UPLOAD_DIR"
+	) 2>/dev/null || return 1
+	validate_directory_metadata "$UPLOAD_DIR" drwx------ 0 0
+}
+
+rotate_token() {
+	local token was_running=0 enabled
+
+	validate_token_parent || {
+		json_error "authentication token directory metadata is unsafe"
+		return
+	}
+	# Including the pre-dispatch token check, the RPCD lock phase allows at
+	# most seven one-second sleeps. A native restart has its own bounded token
+	# lock, so LuCI gives the complete non-cancellable operation a longer budget.
+	acquire_start_lock "$ROTATE_START_LOCK_MAX_ATTEMPTS" || {
+		json_error "another NES Emulator startup operation is still in progress; retry shortly"
+		return
+	}
+	/etc/init.d/nes-emulator running >/dev/null 2>&1 9>&- 7>&- &&
+		was_running=1
+	acquire_token_lock || {
+		release_start_lock
+		json_error "authentication token is busy"
+		return
+	}
+	token="$(
+		exec 7>&- 8>&- 9>&-
+		new_token
+	)"
+	if [ "${#token}" -ne 64 ] ||
+	   ! write_auth_token "$token" ||
+	   ! remove_legacy_token; then
+		release_token_lock
+		release_start_lock
+		json_error "cannot rotate authentication token"
+		return
+	fi
+	release_token_lock
+	AUTH_TOKEN="$token"
+	# A direct init/procd start does not use the RPC startup lock. If it passed
+	# token validation while rotation waited for the token lock, detect the
+	# newly running daemon here and restart it with the new token.
+	if [ "$was_running" -eq 0 ] &&
+	   /etc/init.d/nes-emulator running >/dev/null 2>&1 9>&- 7>&-; then
+		was_running=1
+	fi
+	if [ "$was_running" -eq 1 ]; then
+		enabled="$(
+			exec 7>&- 8>&- 9>&-
+			uci -q get nes-emulator.main.enabled 2>/dev/null
+		)"
+		case "$enabled" in
+		1|on|true|yes|enabled)
+			/etc/init.d/nes-emulator restart >/dev/null 2>&1 9>&- 7>&-
+			;;
+		*)
+			NESD_ON_DEMAND=1 NESD_SKIP_AUTOLOAD=1 \
+				/etc/init.d/nes-emulator restart \
+				>/dev/null 2>&1 9>&- 7>&-
+			;;
+		esac || {
+			release_start_lock
+			json_error "token changed, but nesd could not be restarted"
+			return
+		}
+	fi
+	release_start_lock
+	json_init
+	json_add_boolean ok 1
+	json_add_string token "$token"
+	json_dump_without_upload_fd
+}
+
+load_config() {
+	local bind host
+
+	PORT="$(uci -q get nes-emulator.main.port 2>/dev/null)"
+	case "$PORT" in ''|*[!0-9]*) PORT=29876 ;; esac
+	[ "$PORT" -ge 1 ] 2>/dev/null &&
+		[ "$PORT" -le 65535 ] 2>/dev/null || PORT=29876
+
+	ROM_DIR="$(uci -q get nes-emulator.main.rom_dir 2>/dev/null)"
+	ROM_DIR="${ROM_DIR:-/etc/nes-emulator/roms}"
+
+	bind="$(uci -q get nes-emulator.main.bind 2>/dev/null)"
+	case "$bind" in
+		''|0.0.0.0) host=127.0.0.1 ;;
+		::|\[::\]) host=::1 ;;
+		*[!0-9A-Fa-f:.]*) host=127.0.0.1 ;;
+		\[*\]) host="${bind#\[}"; host="${host%\]}" ;;
+		*) host="$bind" ;;
+	esac
+	RPC_HOST="$host"
+	case "$host" in
+		*:*) BASE="http://[${host}]:${PORT}" ;;
+		*) BASE="http://${host}:${PORT}" ;;
+	esac
+}
+
+select_http_client() {
+	[ -x "$NESD_BIN" ] || {
+		HTTP_CLIENT=''
+		return 1
+	}
+	HTTP_CLIENT=nesd
+	return 0
+}
+
+api_get() {
+	[ "$HTTP_CLIENT" = nesd ] || return 127
+	"$NESD_BIN" --rpc-client \
+		--rpc-host "$RPC_HOST" \
+		--rpc-port "$PORT" \
+		--rpc-path "$1" \
+		--rpc-method GET \
+		--rpc-token-file "$TOKEN_FILE" \
+		--rpc-timeout-ms 2000 \
+		2>/dev/null 9>&- 7>&-
+}
+
+api_post() {
+	local path="$1" body="$2"
+
+	[ "$HTTP_CLIENT" = nesd ] || return 127
+	# nesd validates and buffers the complete reply before writing stdout.
+	# Non-2xx replies keep a nonzero status while preserving their JSON body.
+	"$NESD_BIN" --rpc-client \
+		--rpc-host "$RPC_HOST" \
+		--rpc-port "$PORT" \
+		--rpc-path "$path" \
+		--rpc-method POST \
+		--rpc-body "$body" \
+		--rpc-token-file "$TOKEN_FILE" \
+		--rpc-timeout-ms 3000 \
+		2>/dev/null 9>&- 7>&-
+}
+
+daemon_is_ready() {
+	local resp message_type architecture running paused core_loaded game_loaded
+
+	resp="$(
+		exec 7>&- 9>&-
+		api_get /api/status
+	)" || return 1
+	[ -n "$resp" ] || return 1
+	json_load_without_upload_fd "$resp" 2>/dev/null || return 1
+	json_get_var message_type t
+	json_get_var architecture architecture
+	json_get_var running running
+	json_get_var paused paused
+	json_get_var core_loaded core_loaded
+	json_get_var game_loaded game_loaded
+	case "$message_type:$architecture:$running:$paused:$core_loaded:$game_loaded" in
+		status:router-cpu-thin-client:[01]:[01]:[01]:[01]) return 0 ;;
+	esac
+	return 1
+}
+
+service_instance_state() {
+	local response running exit_code
+
+	SERVICE_INSTANCE_RUNNING=''
+	SERVICE_INSTANCE_EXIT_CODE=''
+	response="$(
+		exec 7>&- 9>&-
+		ubus -S call service list \
+			'{"name":"nes-emulator"}' 2>/dev/null
+	)" || return 1
+	[ -n "$response" ] || return 1
+	running="$(
+		exec 7>&- 9>&-
+		jsonfilter -s "$response" \
+			-e '@["nes-emulator"].instances.nesd.running' \
+			2>/dev/null
+	)" || return 1
+	case "$running" in
+		true|1) SERVICE_INSTANCE_RUNNING=1 ;;
+		false|0) SERVICE_INSTANCE_RUNNING=0 ;;
+		*) return 1 ;;
+	esac
+	exit_code="$(
+		exec 7>&- 9>&-
+		jsonfilter -s "$response" \
+			-e '@["nes-emulator"].instances.nesd.exit_code' \
+			2>/dev/null
+	)" || exit_code=
+	case "$exit_code" in
+		'') [ "$SERVICE_INSTANCE_RUNNING" -eq 1 ] || return 1 ;;
+		*[!0-9]*) return 1 ;;
+		*)
+			[ "$exit_code" -le 255 ] 2>/dev/null || return 1
+			SERVICE_INSTANCE_EXIT_CODE="$exit_code"
+			;;
+	esac
+	return 0
+}
+
+set_preflight_start_error() {
+	case "$1" in
+		10)
+			START_ERROR="the nesd service account is missing or invalid; reinstall nes-emulator"
+			;;
+		11)
+			START_ERROR="the nes-emulator configuration file is missing or has unsafe ownership or permissions"
+			;;
+		12)
+			START_ERROR="the configured bind address, port or browser origin is invalid; review NES Emulator settings"
+			;;
+		13)
+			START_ERROR="a configured emulator data directory is unsafe, unavailable or inaccessible to nesd"
+			;;
+		14)
+			START_ERROR="the nesd authentication token is missing or has unsafe ownership or permissions"
+			;;
+		*)
+			START_ERROR="nesd startup checks failed; verify the emulator configuration and package installation"
+			;;
+	esac
+}
+
+set_native_start_error() {
+	case "$1" in
+		64)
+			START_ERROR="nesd rejected the authentication token file; rotate the token or reinstall both emulator packages"
+			;;
+		65)
+			START_ERROR="nesd cannot access one or more configured emulator data directories"
+			;;
+		66)
+			START_ERROR="nesd could not allocate the resources required by the emulator; free router memory and retry"
+			;;
+		67)
+			START_ERROR="the configured NES Emulator port $PORT is already in use; choose another port in Settings"
+			;;
+		68)
+			START_ERROR="nesd is not permitted to bind the configured address and port"
+			;;
+		69)
+			START_ERROR="nesd could not initialize its local HTTP service; review the bind address, port and data directories"
+			;;
+		70)
+			START_ERROR="nesd could not apply its required privilege and security restrictions; reinstall nes-emulator"
+			;;
+		71)
+			START_ERROR="nesd could not initialize process signal handling; restart the router and retry"
+			;;
+		127)
+			START_ERROR="OpenWrt could not execute /usr/bin/nesd; reinstall nes-emulator for this router architecture"
+			;;
+		137)
+			START_ERROR="nesd was killed during startup, usually because the router ran out of memory"
+			;;
+		139)
+			START_ERROR="nesd crashed during startup; reinstall matching nes-emulator packages for this router architecture"
+			;;
+		143)
+			START_ERROR="nesd was terminated during startup; wait for other service operations to finish and retry"
+			;;
+		0)
+			START_ERROR="nesd stopped before its local API became ready"
+			;;
+		*)
+			START_ERROR="nesd stopped unexpectedly during startup"
+			;;
+	esac
+}
+
+daemon_request() {
+	local endpoint="$1" resp
+
+	resp="$(
+		exec 9>&-
+		api_post "$endpoint" '{}'
+	)"
+	if [ -n "$resp" ]; then
+		printf '%s\n' "$resp"
+	else
+		json_error "nesd is not responding"
+	fi
+}
+
+start_daemon() {
+	local i=0 preflight_status start_status
+
+	START_ERROR=''
+	if [ -z "$HTTP_CLIENT" ]; then
+		START_ERROR="the matching /usr/bin/nesd loopback RPC client is missing; reinstall nes-emulator and luci-app-nes-emulator together"
+		return 1
+	fi
+
+	if daemon_is_ready; then
+		return 0
+	fi
+	if ! acquire_start_lock; then
+		START_ERROR="another NES Emulator startup operation is still in progress; retry shortly"
+		return 1
+	fi
+	if daemon_is_ready; then
+		release_start_lock
+		return 0
+	fi
+
+	NESD_ON_DEMAND=1 NESD_SKIP_AUTOLOAD=1 \
+		/etc/init.d/nes-emulator preflight \
+		>/dev/null 2>&1 9>&- 7>&-
+	preflight_status=$?
+	if [ "$preflight_status" -ne 0 ]; then
+		set_preflight_start_error "$preflight_status"
+		release_start_lock
+		return 1
+	fi
+
+	NESD_ON_DEMAND=1 NESD_SKIP_AUTOLOAD=1 \
+		/etc/init.d/nes-emulator start >/dev/null 2>&1 9>&- 7>&-
+	start_status=$?
+	if [ "$start_status" -ne 0 ]; then
+		START_ERROR="the OpenWrt service manager rejected the nesd start request"
+		release_start_lock
+		return 1
+	fi
+	while :; do
+		if daemon_is_ready; then
+			release_start_lock
+			return 0
+		fi
+		[ "$i" -ge 15 ] && break
+		i=$((i + 1))
+		sleep 1 9>&- 7>&-
+	done
+
+	if service_instance_state; then
+		if [ "$SERVICE_INSTANCE_RUNNING" -eq 1 ]; then
+			START_ERROR="nesd is running, but its local API is unreachable at $BASE; check the configured bind address, port and authentication token"
+		else
+			set_native_start_error "$SERVICE_INSTANCE_EXIT_CODE"
+		fi
+	elif /etc/init.d/nes-emulator running >/dev/null 2>&1 9>&- 7>&-; then
+		START_ERROR="nesd is running, but its local API is unreachable at $BASE; check the configured bind address, port and authentication token"
+	else
+		START_ERROR="nesd stopped during startup, but OpenWrt did not provide a valid service exit status"
+	fi
+	release_start_lock
+	return 1
+}
+
+mode_allows_nesd() {
+	local mode="$1" owner="$2" group="$3" required="$4"
+
+	if [ "$owner" = "$NESD_UID" ]; then
+		case "$required:$mode" in
+			read:?r*|search:???[xs]*) return 0 ;;
+		esac
+	elif case " $NESD_GROUPS " in *" $group "*) true ;; *) false ;; esac; then
+		case "$required:$mode" in
+			read:????r*|search:??????[xs]*) return 0 ;;
+		esac
+	else
+		case "$required:$mode" in
+			read:???????r*|search:?????????[xt]*) return 0 ;;
+		esac
+	fi
+	return 1
+}
+
+path_is_readable_by_nesd() {
+	local current="$1" required=read metadata mode nlink owner group rest
+
+	[ -n "$NESD_UID" ] && [ -n "$NESD_GROUPS" ] || return 1
+	while :; do
+		metadata="$(
+			exec 9>&-
+			LC_ALL=C ls -ldn "$current" 2>/dev/null
+		)" || return 1
+		case "$metadata" in
+			*'
+'*) return 1 ;;
+		esac
+		IFS=' ' read -r mode nlink owner group rest <<EOF
+$metadata
+EOF
+		case "$owner:$group" in
+			:*|*:|*[!0-9:]*) return 1 ;;
+		esac
+		mode_allows_nesd "$mode" "$owner" "$group" "$required" ||
+			return 1
+		[ "$current" != "/" ] || return 0
+		current="${current%/*}"
+		[ -n "$current" ] || current=/
+		required=search
+	done
+}
+
+file_size_bytes() {
+	local size
+
+	[ -f "$1" ] && [ ! -L "$1" ] || return 1
+	size="$(
+		exec 7>&- 9>&-
+		wc -c <"$1" 2>/dev/null | tr -d ' \t'
+	)" || return 1
+	case "$size" in ''|*[!0-9]*) return 1 ;; esac
+	printf '%s\n' "$size"
+}
+
+scan_rom_root() {
+	local root="$1" resolved scan_dir fifo find_pid find_status=0
+	local full name ext size readable
+
+	[ "$SCAN_TRUNCATED" -eq 0 ] || return 0
+	valid_data_dir "$root" || return 0
+	resolved="$(
+		exec 9>&-
+		readlink -f "$root" 2>/dev/null
+	)" || return 0
+	valid_data_dir "$resolved" || return 0
+	[ -d "$resolved" ] || return 0
+	scan_dir="$(
+		exec 9>&-
+		mktemp -d /tmp/nes-rom-scan.XXXXXX 2>/dev/null
+	)" || {
+		SCAN_TRUNCATED=1
+		return 0
+	}
+	fifo="$scan_dir/results"
+	if ! mkfifo "$fifo" 2>/dev/null 9>&-; then
+		rmdir "$scan_dir" 9>&-
+		SCAN_TRUNCATED=1
+		return 0
+	fi
+	find "$resolved" -mindepth 1 -maxdepth "$MAX_ROM_FIND_DEPTH" \
+		-type f -print0 >"$fifo" 2>/dev/null 9>&- &
+	find_pid=$!
+	# OpenWrt uses BusyBox ash, whose read supports NUL delimiters.
+	# shellcheck disable=SC3045
+	while IFS= read -r -d '' full; do
+		SCAN_ENTRIES=$((SCAN_ENTRIES + 1))
+		if [ "$SCAN_ENTRIES" -gt "$MAX_ROM_ENTRIES" ]; then
+			SCAN_TRUNCATED=1
+			break
+		fi
+		name="${full##*/}"
+		case "$name" in ''|.*) continue ;; esac
+		ext="$(
+			exec 9>&-
+			printf '%s' "${name##*.}" |
+				tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz'
+		)"
+		case "$ext" in nes|fds|unf|unif) ;; *) continue ;; esac
+		size="$(file_size_bytes "$full")" || continue
+		case "$size" in ''|*[!0-9]*) continue ;; esac
+		[ "$size" -le "$MAX_ROM_SIZE" ] 2>/dev/null || continue
+		rom_is_valid "$full" "$ext" "$size" || continue
+		readable=0
+		path_is_readable_by_nesd "$full" && readable=1
+		json_add_object ""
+		json_add_string name "$name"
+		json_add_string path "$full"
+		json_add_string source "$resolved"
+		json_add_int size "$size"
+		json_add_boolean readable "$readable"
+		if [ "$readable" -ne 1 ]; then
+			json_add_string error \
+				"ROM is not readable by nesd; set traversable directory permissions and group nesd with mode 0640"
+		fi
+		json_close_object
+	done <"$fifo"
+	wait "$find_pid" || find_status=$?
+	rm -f "$fifo" 9>&-
+	rmdir "$scan_dir" 2>/dev/null 9>&- || :
+	if [ "$SCAN_TRUNCATED" -eq 0 ] && [ "$find_status" -ne 0 ]; then
+		SCAN_TRUNCATED=1
+	fi
+}
+
+offline_roms() {
+	SCAN_ENTRIES=0
+	SCAN_TRUNCATED=0
+	NESD_UID="$(
+		exec 9>&-
+		id -u nesd 2>/dev/null
+	)" || NESD_UID=
+	NESD_GROUPS="$(
+		exec 9>&-
+		id -G nesd 2>/dev/null
+	)" || NESD_GROUPS=
+	case "$NESD_UID" in ''|*[!0-9]*) NESD_UID= ;; esac
+	case "$NESD_GROUPS" in
+		''|*[!0-9\ ]*) NESD_GROUPS= ;;
+	esac
+	json_init
+	json_add_array roms
+	scan_rom_root "$ROM_DIR"
+	if config_load nes-emulator; then
+		scan_configured_extra_rom_roots
+	fi
+	json_close_array
+	json_add_string dir "$ROM_DIR"
+	json_add_boolean truncated "$SCAN_TRUNCATED"
+	json_add_string notice "nesd is stopped; ROMs were scanned without starting it"
+	json_dump_without_upload_fd
+}
+
+scan_configured_extra_rom_roots() {
+	local extra_rom_dirs_enabled
+
+	config_get_bool extra_rom_dirs_enabled main extra_rom_dirs_enabled 0
+	[ "$extra_rom_dirs_enabled" -eq 1 ] || return 0
+	config_list_foreach main extra_rom_dir scan_rom_root
+}
+
+valid_data_dir() {
+	local d="$1"
+
+	[ -n "$d" ] && [ "${d#/}" != "$d" ] || return 1
+	while [ "$d" != "/" ] && [ "${d%/}" != "$d" ]; do
+		d="${d%/}"
+	done
+	[ "$(
+		exec 9>&-
+		printf '%s' "$d" | wc -l
+	)" -eq 0 ] || return 1
+	case "$d" in
+		/|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/mnt|/opt|/overlay|/proc|/root|/run|/sbin|/sys|/tmp|/usr|/var)
+			return 1
+			;;
+		*/../*|*/..|*/./*|*/.|*//*|*:*|*';'*|*,*)
+			return 1
+			;;
+	esac
+	return 0
+}
+
+rom_is_valid() {
+	local path="$1" ext="$2" size="$3" magic
+
+	magic="$(
+		exec 9>&-
+		hexdump -v -n 4 -e '1/1 "%02x"' "$path" 2>/dev/null
+	)" || return 1
+	case "$ext" in
+		nes) [ "$magic" = 4e45531a ] ;;
+		unf|unif)
+			[ "$size" -ge 32 ] && [ "$magic" = 554e4946 ]
+			;;
+		fds)
+			if [ "$magic" = 4644531a ]; then
+				[ "$size" -ge 65516 ] &&
+					[ $(((size - 16) % 65500)) -eq 0 ]
+			else
+				[ "$size" -ge 65500 ] &&
+					[ $((size % 65500)) -eq 0 ]
+			fi
+			;;
+		*) return 1 ;;
+	esac
+}
+
+tree_entry_count_is_bounded() {
+	local root="$1" scan_dir fifo find_pid find_status=0 entry count=0
+
+	scan_dir="$(
+		exec 9>&-
+		mktemp -d /tmp/nes-rom-count.XXXXXX 2>/dev/null
+	)" ||
+		return 1
+	fifo="$scan_dir/results"
+	if ! mkfifo "$fifo" 2>/dev/null 9>&-; then
+		rmdir "$scan_dir" 9>&-
+		return 1
+	fi
+	find "$root" -mindepth 1 -maxdepth "$MAX_ROM_FIND_DEPTH" \
+		-print0 >"$fifo" 2>/dev/null 9>&- &
+	find_pid=$!
+	# OpenWrt uses BusyBox ash, whose read supports NUL delimiters.
+	# shellcheck disable=SC3045
+	while IFS= read -r -d '' entry; do
+		count=$((count + 1))
+		[ "$count" -le "$MAX_ROM_ENTRIES" ] || break
+	done <"$fifo"
+	wait "$find_pid" || find_status=$?
+	rm -f "$fifo" 9>&-
+	rmdir "$scan_dir" 2>/dev/null 9>&- || :
+	[ "$count" -le "$MAX_ROM_ENTRIES" ] && [ "$find_status" -eq 0 ]
+}
+
+tree_has_boundary_directory() {
+	local root="$1" scan_dir fifo find_pid find_status=0 entry found=0
+
+	scan_dir="$(
+		exec 9>&-
+		mktemp -d /tmp/nes-rom-depth.XXXXXX 2>/dev/null
+	)" ||
+		return 2
+	fifo="$scan_dir/results"
+	if ! mkfifo "$fifo" 2>/dev/null 9>&-; then
+		rmdir "$scan_dir" 9>&-
+		return 2
+	fi
+	find "$root" -mindepth "$MAX_ROM_FIND_DEPTH" \
+		-maxdepth "$MAX_ROM_FIND_DEPTH" -type d -print0 \
+		>"$fifo" 2>/dev/null 9>&- &
+	find_pid=$!
+	# OpenWrt uses BusyBox ash, whose read supports NUL delimiters. The value
+	# itself is irrelevant; successful input proves a boundary directory exists.
+	# shellcheck disable=SC2034,SC3045
+	if IFS= read -r -d '' entry <"$fifo"; then
+		found=1
+	fi
+	wait "$find_pid" || find_status=$?
+	rm -f "$fifo" 9>&-
+	rmdir "$scan_dir" 2>/dev/null 9>&- || :
+	[ "$find_status" -eq 0 ] || [ "$found" -eq 1 ] || return 2
+	[ "$found" -eq 1 ]
+}
+
+storage_is_available() {
+	local destination="$1" incoming="$2"
+	local used old_size=0 effective available_kib required_kib
+	local scan depth_result
+
+	scan="$(
+		exec 9>&-
+		mktemp /tmp/nes-rom-quota.XXXXXX 2>/dev/null
+	)" || return 1
+	if ! tree_entry_count_is_bounded "$ROM_DIR"; then
+		rm -f "$scan" 9>&-
+		return 1
+	fi
+	tree_has_boundary_directory "$ROM_DIR"
+	depth_result=$?
+	if [ "$depth_result" -ne 1 ]; then
+		rm -f "$scan" 9>&-
+		return 1
+	fi
+	if ! find "$ROM_DIR" -maxdepth "$MAX_ROM_FIND_DEPTH" -type f \
+		-exec wc -c '{}' ';' >"$scan" 2>/dev/null 9>&-; then
+		rm -f "$scan" 9>&-
+		return 1
+	fi
+	used="$(
+		exec 9>&-
+		awk '
+			$1 !~ /^[0-9]+$/ { exit 2 }
+			{ total += $1 }
+			END { if (total < 0) exit 2; print total + 0 }
+		' "$scan"
+	)" || {
+		rm -f "$scan" 9>&-
+		return 1
+	}
+	rm -f "$scan" 9>&-
+	case "$used" in ''|*[!0-9]*) return 1 ;; esac
+	if [ -f "$destination" ] && [ ! -L "$destination" ]; then
+		old_size="$(file_size_bytes "$destination")"
+		case "$old_size" in ''|*[!0-9]*) return 1 ;; esac
+	fi
+	effective=$((used - old_size + incoming))
+	[ "$effective" -ge 0 ] &&
+		[ "$effective" -le "$ROM_QUOTA_SIZE" ] || return 1
+
+	available_kib="$(
+		exec 9>&-
+		df -Pk "$ROM_DIR" 2>/dev/null |
+			awk 'NR > 1 { value = $4 } END { print value }'
+	)"
+	case "$available_kib" in ''|*[!0-9]*) return 1 ;; esac
+	required_kib=$(((incoming + 1023) / 1024 + MIN_FREE_KIB))
+	[ "$available_kib" -ge "$required_kib" ]
+}
+
+staged_path_is_valid() {
+	local staged="$1" leaf nonce
+
+	case "$staged" in "$UPLOAD_DIR/"*) ;; *) return 1 ;; esac
+	leaf="${staged##*/}"
+	[ "$staged" = "$UPLOAD_DIR/$leaf" ] || return 1
+	[ "${#leaf}" -eq 36 ] 2>/dev/null || return 1
+	case "$leaf" in *.rom) ;; *) return 1 ;; esac
+	nonce="${leaf%.rom}"
+	[ "${#nonce}" -eq 32 ] 2>/dev/null || return 1
+	case "$nonce" in *[!0-9a-f]*) return 1 ;; esac
+	return 0
+}
+
+cleanup_staged_uploads() {
+	local staged marker now future
+
+	for staged in "$UPLOAD_DIR"/*.rom; do
+		[ -e "$staged" ] || [ -L "$staged" ] || continue
+		if [ ! -f "$staged" ] || [ -L "$staged" ]; then
+			rm -f "$staged" 9>&- || return 1
+		fi
+	done
+	# A five-minute future tolerance keeps an in-flight cgi-io write from
+	# looking stale while still recovering reservations after a clock rollback.
+	marker="$UPLOAD_DIR/.cleanup-future"
+	rm -f "$marker" 9>&- || return 1
+	if ! (
+		exec 9>&-
+		set -C
+		umask 077
+		: >"$marker"
+	) 2>/dev/null; then
+		return 1
+	fi
+	now="$(
+		exec 9>&-
+		date +%s 2>/dev/null
+	)"
+	case "$now" in ''|*[!0-9]*)
+		rm -f "$marker" 9>&-
+		return 1
+		;;
+	esac
+	future=$((now + 300))
+	if ! touch -d "@$future" "$marker" 2>/dev/null 9>&- ||
+	   ! find "$UPLOAD_DIR" -maxdepth 1 -type f -name '*.rom' \
+		\( -mmin +30 -o -newer "$marker" \) \
+		-exec rm -f '{}' ';' >/dev/null 2>&1 9>&-; then
+		rm -f "$marker" 9>&-
+		return 1
+	fi
+	rm -f "$marker" 9>&- || return 1
+	# Remove the fixed staging name used by legacy versions.
+	[ ! -e "$UPLOAD_DIR/rom" ] && [ ! -L "$UPLOAD_DIR/rom" ] ||
+		rm -f "$UPLOAD_DIR/rom" 9>&- || return 1
+	return 0
+}
+
+cleanup_import_temps() {
+	local configured="$ROM_DIR" resolved tmp suffix metadata
+	local mode nlink owner nesd_uid
+
+	nesd_uid="$(
+		exec 9>&-
+		id -u nesd 2>/dev/null
+	)" || return 1
+	case "$nesd_uid" in ''|*[!0-9]*) return 1 ;; esac
+
+	while [ "$configured" != "/" ] &&
+	      [ "${configured%/}" != "$configured" ]; do
+		configured="${configured%/}"
+	done
+	valid_data_dir "$configured" &&
+		[ -d "$configured" ] && [ ! -L "$configured" ] || return 1
+	resolved="$(
+		exec 9>&-
+		readlink -f "$configured" 2>/dev/null
+	)" || return 1
+	[ "$resolved" = "$configured" ] && valid_data_dir "$resolved" || return 1
+
+	for tmp in "$resolved"/.nes-import.*; do
+		[ -e "$tmp" ] || [ -L "$tmp" ] || continue
+		[ -f "$tmp" ] && [ ! -L "$tmp" ] || continue
+		suffix="${tmp##*/.nes-import.}"
+		[ "${#suffix}" -eq 6 ] 2>/dev/null || continue
+		case "$suffix" in *[!A-Za-z0-9]*) continue ;; esac
+		metadata="$(
+			exec 9>&-
+			LC_ALL=C ls -ldn "$tmp" 2>/dev/null
+		)" || continue
+		IFS=' ' read -r mode nlink owner metadata <<EOF
+$metadata
+EOF
+		[ "$nlink" = 1 ] || continue
+		case "$mode" in
+			-rw-------|-rw-r-----) ;;
+			*) continue ;;
+		esac
+		case "$owner" in
+			0|"$nesd_uid") ;;
+			*) continue ;;
+		esac
+		rm -f "$tmp" 9>&- || return 1
+	done
+	return 0
+}
+
+reserve_upload_locked() {
+	local count=0 nonce staged attempt=0
+
+	cleanup_import_temps || {
+		json_error "cannot clean interrupted ROM imports"
+		return
+	}
+	cleanup_staged_uploads || {
+		json_error "cannot clean the upload staging directory"
+		return
+	}
+	for staged in "$UPLOAD_DIR"/*.rom; do
+		[ -f "$staged" ] && [ ! -L "$staged" ] || continue
+		count=$((count + 1))
+	done
+	[ "$count" -lt 1 ] || {
+		json_error "another upload is already pending; try again later"
+		return
+	}
+	while [ "$attempt" -lt 16 ]; do
+		nonce="$(
+			exec 9>&-
+			hexdump -v -n 16 -e '1/1 "%02x"' \
+				/dev/urandom 2>/dev/null
+		)" || nonce=
+		staged="$UPLOAD_DIR/$nonce.rom"
+		if [ "${#nonce}" -eq 32 ] &&
+		   (
+			exec 9>&-
+			set -C
+			umask 077
+			: >"$staged"
+		   ) 2>/dev/null; then
+			if ! chown root:root "$staged" 2>/dev/null 9>&- ||
+			   ! chmod 0600 "$staged" 2>/dev/null 9>&-; then
+				rm -f "$staged" 9>&-
+				json_error "cannot secure upload reservation"
+				return
+			fi
+			json_init
+			json_add_string staged "$staged"
+			json_dump_without_upload_fd
+			return
+		fi
+		attempt=$((attempt + 1))
+	done
+	json_error "cannot reserve a unique upload path"
+}
+
+reserve_upload() {
+	acquire_upload_lock || {
+		json_error "upload storage is busy"
+		return
+	}
+	reserve_upload_locked
+	release_upload_lock
+}
+
+discard_upload_locked() {
+	local input staged
+
+	read -r input
+	json_load_without_upload_fd "$input" 2>/dev/null || {
+		json_error "invalid request"
+		return
+	}
+	json_get_var staged staged
+	staged_path_is_valid "$staged" || {
+		json_error "invalid upload reservation"
+		return
+	}
+	rm -f "$staged" 9>&-
+	json_init
+	json_add_boolean ok 1
+	json_dump_without_upload_fd
+}
+
+discard_upload() {
+	acquire_upload_lock || {
+		json_error "upload storage is busy"
+		return
+	}
+	discard_upload_locked
+	release_upload_lock
+}
+
+import_rom_locked() {
+	local input staged name safe ext base size actual_size tmp dest body resp
+	local configured resolved daemon_error daemon_ok startup_error
+
+	read -r input
+	json_load_without_upload_fd "$input" 2>/dev/null || {
+		json_error "invalid request"
+		return
+	}
+	json_get_var staged staged
+	json_get_var name name
+	staged_path_is_valid "$staged" && [ -f "$staged" ] &&
+		[ ! -L "$staged" ] || {
+			json_error "staged upload is missing"
+			return
+		}
+
+	size="$(file_size_bytes "$staged")"
+	case "$size" in ''|*[!0-9]*) size=0 ;; esac
+	[ "$size" -ge 16 ] && [ "$size" -le "$MAX_ROM_SIZE" ] || {
+		rm -f "$staged" 9>&-
+		json_error "ROM size must be between 16 bytes and 16 MiB"
+		return
+	}
+
+	safe="$(
+		exec 9>&-
+		printf '%s' "${name##*/}" |
+			sed 's/[^A-Za-z0-9._-]/_/g; s/^\.*//'
+	)"
+	[ -n "$safe" ] || safe=upload.nes
+	ext="$(
+		exec 9>&-
+		printf '%s' "${safe##*.}" |
+			tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz'
+	)"
+	case "$ext" in nes|fds|unf|unif) ;; *)
+		rm -f "$staged" 9>&-
+		json_error "unsupported ROM extension"
+		return
+		;;
+	esac
+	rom_is_valid "$staged" "$ext" "$size" || {
+		rm -f "$staged" 9>&-
+		json_error "file header does not match a supported NES ROM"
+		return
+	}
+
+	configured="$ROM_DIR"
+	while [ "$configured" != "/" ] &&
+	      [ "${configured%/}" != "$configured" ]; do
+		configured="${configured%/}"
+	done
+	resolved="$(
+		exec 9>&-
+		readlink -f "$configured" 2>/dev/null
+	)" || resolved=
+	if ! valid_data_dir "$configured" ||
+	   [ ! -d "$configured" ] ||
+	   [ -L "$configured" ] ||
+	   [ "$resolved" != "$configured" ] ||
+	   ! valid_data_dir "$resolved"; then
+		rm -f "$staged" 9>&-
+		json_error "configured ROM directory is unsafe or unavailable"
+		return
+	fi
+	ROM_DIR="$resolved"
+	cleanup_import_temps || {
+		rm -f "$staged" 9>&-
+		json_error "cannot clean interrupted ROM imports"
+		return
+	}
+
+	base="${safe%.*}"
+	base="$(
+		exec 9>&-
+		printf '%s' "$base" | cut -c1-100
+	)"
+	[ -n "$base" ] || base=upload
+	safe="${base}.${ext}"
+	dest="$ROM_DIR/$safe"
+	if [ -e "$dest" ] || [ -L "$dest" ]; then
+		[ -f "$dest" ] && [ ! -L "$dest" ] || {
+			rm -f "$staged" 9>&-
+			json_error "ROM destination is not a regular file"
+			return
+		}
+	fi
+	storage_is_available "$dest" "$size" || {
+		rm -f "$staged" 9>&-
+		json_error "ROM quota exceeded or less than 8 MiB would remain free"
+		return
+	}
+	tmp="$(
+		exec 9>&-
+		mktemp "$ROM_DIR/.nes-import.XXXXXX" 2>/dev/null
+	)" || {
+		rm -f "$staged" 9>&-
+		json_error "cannot create a temporary ROM file"
+		return
+	}
+	# Bound the copy itself: a concurrently replaced or growing cgi-io target
+	# must not be able to consume the filesystem before post-copy validation.
+	if ! dd if="$staged" of="$tmp" bs=4096 count=4097 2>/dev/null 9>&- ||
+	   ! chown nesd:nesd "$tmp" 2>/dev/null 9>&- ||
+	   ! chmod 0640 "$tmp" 9>&-; then
+		rm -f "$tmp" "$staged" 9>&-
+		json_error "cannot store ROM in the configured directory"
+		return
+	fi
+	actual_size="$(file_size_bytes "$tmp")"
+	case "$actual_size" in ''|*[!0-9]*) actual_size=0 ;; esac
+	if [ "$actual_size" -ne "$size" ] 2>/dev/null ||
+	   [ "$actual_size" -lt 16 ] 2>/dev/null ||
+	   [ "$actual_size" -gt "$MAX_ROM_SIZE" ] 2>/dev/null ||
+	   ! rom_is_valid "$tmp" "$ext" "$actual_size"; then
+		rm -f "$tmp" "$staged" 9>&-
+		json_error "staged ROM changed during import"
+		return
+	fi
+	# Revalidate at commit time. The completed temp file is now included in
+	# the directory scan, so concurrent direct /api/upload traffic cannot
+	# make this import exceed the quota or free-space reserve.
+	if ! storage_is_available "$dest" 0; then
+		rm -f "$tmp" "$staged" 9>&-
+		json_error "ROM quota exceeded or less than 8 MiB would remain free"
+		return
+	fi
+	if ! mv -f "$tmp" "$dest" 9>&-; then
+		rm -f "$tmp" "$staged" 9>&-
+		json_error "cannot store ROM in the configured directory"
+		return
+	fi
+	if ! rm -f "$staged" 9>&-; then
+		json_init
+		json_add_boolean ok 0
+		json_add_boolean stored 1
+		json_add_string path "$dest"
+		json_add_string error \
+			"ROM was stored, but the upload reservation could not be removed"
+		json_dump_without_upload_fd
+		return
+	fi
+	if ! sync 9>&-; then
+		json_init
+		json_add_boolean ok 0
+		json_add_boolean stored 1
+		json_add_string path "$dest"
+		json_add_string error \
+			"ROM was stored, but filesystem durability could not be confirmed"
+		json_dump_without_upload_fd
+		return
+	fi
+
+	if start_daemon; then
+		json_init
+		json_add_string path "$dest"
+		body="$(
+			exec 9>&-
+			json_dump_without_upload_fd
+		)"
+		resp="$(
+			exec 9>&-
+			api_post /api/load "$body"
+		)"
+	else
+		startup_error="$START_ERROR"
+	fi
+	if [ -z "$resp" ]; then
+		json_init
+		json_add_boolean ok 0
+		json_add_boolean stored 1
+		json_add_string path "$dest"
+		json_add_string error \
+			"ROM was stored, but ${startup_error:-nesd did not return a load result}"
+		json_dump_without_upload_fd
+		return
+	fi
+	if json_load_without_upload_fd "$resp" 2>/dev/null; then
+		json_get_var daemon_error error
+		json_get_var daemon_ok ok
+		if [ -n "$daemon_error" ] || [ "$daemon_ok" = 0 ]; then
+			json_init
+			json_add_boolean ok 0
+			json_add_boolean stored 1
+			json_add_string path "$dest"
+			json_add_string error \
+				"${daemon_error:-nesd rejected the imported ROM}"
+			json_dump_without_upload_fd
+			return
+		fi
+	fi
+	printf '%s\n' "$resp"
+}
+
+import_rom() {
+	acquire_upload_lock || {
+		json_error "upload storage is busy"
+		return
+	}
+	import_rom_locked
+	release_upload_lock
+}
+
+validate_config_file || {
+	case "$1" in call) json_error "configuration file is missing or unsafe" ;; esac
+	exit 1
+}
+load_config
+select_http_client || :
+# Token rotation takes the same lock once here and once while replacing the
+# token. Use its shorter per-request budget without penalizing ordinary calls.
+case "$1:$2" in
+	call:rotate_token) TOKEN_LOCK_MAX_ATTEMPTS="$ROTATE_TOKEN_LOCK_MAX_ATTEMPTS" ;;
+esac
+ensure_auth_token || {
+	case "$1" in call) json_error "cannot initialize authentication token" ;; esac
+	exit 1
+}
+if ! prepare_upload_dir; then
+	case "$1" in call) json_error "cannot prepare the secure upload directory" ;; esac
+	exit 1
+fi
+umask 077
+
+case "$1" in
+list)
+	printf '%s\n' '{"status":{},"access":{},"roms":{},"reserve_upload":{},"discard_upload":{"staged":"str"},"load":{"path":"str"},"import":{"staged":"str","name":"str"},"start":{},"stop":{},"pause":{},"reset":{},"rotate_token":{}}'
+	;;
+call)
+	case "$2" in
+	status)
+		resp="$(api_get /api/status)"
+		if [ -n "$resp" ]; then
+			printf '%s\n' "$resp"
+		else
+			json_init
+			json_add_boolean running 0
+			json_add_boolean paused 0
+			json_add_boolean core_loaded 0
+			json_add_boolean game_loaded 0
+			json_add_int viewers 0
+			json_add_int port "$PORT"
+			if [ -z "$HTTP_CLIENT" ]; then
+				json_add_string error \
+					"the matching nesd loopback RPC client is missing; reinstall both emulator packages"
+			elif /etc/init.d/nes-emulator running \
+				>/dev/null 2>&1 9>&-; then
+				json_add_string error \
+					"nesd is running, but its local API is not responding"
+			else
+				case "$(uci -q get nes-emulator.main.enabled 2>/dev/null)" in
+				1|on|true|yes|enabled)
+					json_add_string error \
+						"nesd exited or could not be started; inspect logread"
+					;;
+				*)
+					json_add_boolean on_demand 1
+					;;
+				esac
+			fi
+			json_dump_without_upload_fd
+		fi
+		;;
+	access)
+		start_daemon || {
+			json_error "${START_ERROR:-nesd could not be started}"
+			exit 0
+		}
+		json_init
+		json_add_string token "$AUTH_TOKEN"
+		json_add_int port "$PORT"
+		json_dump_without_upload_fd
+		;;
+	roms)
+		resp="$(api_get /api/roms)"
+		if [ -n "$resp" ]; then
+			printf '%s\n' "$resp"
+		else
+			offline_roms
+		fi
+		;;
+	reserve_upload) reserve_upload ;;
+	discard_upload) discard_upload ;;
+	load)
+		read -r input
+		json_load_without_upload_fd "$input" 2>/dev/null || {
+			json_error "invalid request"
+			exit 0
+		}
+		json_get_var path path
+		[ -n "$path" ] || {
+			json_error "path is required"
+			exit 0
+		}
+		# nesd is the final path-security boundary for this forwarded request.
+		# Its resolve_rom_path() canonicalizes with realpath(), confines the
+		# result to the configured primary or opt-in extra ROM roots, reopens it
+		# with O_NOFOLLOW, and validates the extension, size, and ROM header.
+		start_daemon || {
+			json_error "${START_ERROR:-nesd could not be started}"
+			exit 0
+		}
+		json_init
+		json_add_string path "$path"
+		body="$(json_dump_without_upload_fd)"
+		resp="$(api_post /api/load "$body")"
+		if [ -n "$resp" ]; then
+			printf '%s\n' "$resp"
+		else
+			json_error "nesd rejected the ROM"
+		fi
+		;;
+	import)
+		import_rom
+		;;
+	start)
+		start_daemon || {
+			json_error "${START_ERROR:-nesd could not be started}"
+			exit 0
+		}
+		daemon_request /api/start
+		;;
+	stop) daemon_request /api/stop ;;
+	pause) daemon_request /api/pause ;;
+	reset) daemon_request /api/reset ;;
+	rotate_token) rotate_token ;;
+	*) json_error "unknown method" ;;
+	esac
+	;;
+*)
+	exit 1
+	;;
+esac

--- a/applications/luci-app-nes-emulator/root/usr/share/luci/menu.d/luci-app-nes-emulator.json
+++ b/applications/luci-app-nes-emulator/root/usr/share/luci/menu.d/luci-app-nes-emulator.json
@@ -1,0 +1,45 @@
+{
+	"admin/services/nes-emulator": {
+		"title": "NES Emulator",
+		"order": 90,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-nes-emulator" ]
+		}
+	},
+	"admin/services/nes-emulator/overview": {
+		"title": "Overview",
+		"order": 1,
+		"action": {
+			"type": "view",
+			"path": "nes-emulator/overview"
+		},
+		"depends": {
+			"acl": [ "luci-app-nes-emulator" ]
+		}
+	},
+	"admin/services/nes-emulator/play": {
+		"title": "Play",
+		"order": 2,
+		"action": {
+			"type": "view",
+			"path": "nes-emulator/play"
+		},
+		"depends": {
+			"acl": [ "luci-app-nes-emulator" ]
+		}
+	},
+	"admin/services/nes-emulator/settings": {
+		"title": "Settings",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "nes-emulator/settings"
+		},
+		"depends": {
+			"acl": [ "luci-app-nes-emulator" ]
+		}
+	}
+}

--- a/applications/luci-app-nes-emulator/root/usr/share/rpcd/acl.d/luci-app-nes-emulator.json
+++ b/applications/luci-app-nes-emulator/root/usr/share/rpcd/acl.d/luci-app-nes-emulator.json
@@ -1,0 +1,25 @@
+{
+	"luci-app-nes-emulator": {
+		"description": "Grant access to the NES emulator",
+		"read": {
+			"ubus": {
+				"nes-emulator": [ "status", "roms" ]
+			},
+			"uci": [ "nes-emulator" ]
+		},
+		"write": {
+			"cgi-io": [ "upload" ],
+			"ubus": {
+				"nes-emulator": [
+					"access", "reserve_upload", "discard_upload", "load",
+					"import", "start", "stop", "pause", "reset",
+					"rotate_token"
+				]
+			},
+			"uci": [ "nes-emulator" ],
+			"file": {
+				"/tmp/nes-emulator-upload/*": [ "write" ]
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Pull request details

### Description

Add a JavaScript LuCI interface for the NES emulator service.

The application provides service status and controls, authenticated ROM upload
and loading, emulator settings, and access to the thin browser game client.
Emulation, rendering, JPEG encoding, and audio generation remain in the native
`nesd` service on the router. No ROM or BIOS files are included.

A shared application resource centralizes the long-running RPC policy used by
all three views. The package directly depends on its external runtime helpers;
installing it also selects and installs the native `nes-emulator` package.

The RPCD bridge uses BusyBox-compatible file operations. Client-supplied load
paths are passed to `nesd`, whose final validation canonicalizes the path,
confines it to configured ROM roots, opens it with `O_NOFOLLOW`, and validates
the extension, size, and ROM header before loading.

Token creation and rotation share a lock with the native init script. Token,
upload, and startup locks live in the root-owned mode-`0700`
`/var/run/nes-emulator` tmpfs directory. Each mode-`0600`, root-owned,
single-link lock file is safely prepared with no-clobber creation and
`umask 077`, opened without truncation through catchable `command exec`
redirection, and revalidated after opening. Descriptor 9 owns the upload lock,
8 the token lock, and 7 the startup lock. Every external child in the token
critical sections, including the outer command-substitution shells, closes all
three descriptors; startup/upload children close the held request locks too.

Rotation is serialized with startup and rechecks a daemon that may have started
concurrently. Its RPCD-side lock phase has an exact maximum of seven one-second
sleeps: two for each of the two token-lock encounters plus three for the startup
lock. A contended native restart can add at most nine native token-lock sleeps,
for a coordinated lock-wait maximum of 16.

A shared application resource declares the start-capable `access`, `start`,
`load`, and `import` calls, plus `rotate_token`, with `nobatch: true` and an RPC
timeout of at least 120 seconds. Each request therefore captures its own timeout
instead of inheriting the first request in an animation-frame batch. The helper
restores the previous global value immediately after the synchronous RPC
invocation, so unrelated calls retain their configured timeout. The local
Start/Load guard is computed from the effective RPC timeout plus five seconds;
transactional Import/Rotate operations await their real result instead of
racing a false client-side timeout.

Depends on [openwrt/packages#30350](https://github.com/openwrt/packages/pull/30350).
This pull request remains a draft until that native package is available to the
LuCI build, as required by the LuCI pull request template for dependent
submissions.

The English POT template was generated with LuCI's `i18n-scan.pl`; translation
`.po` files remain managed through Weblate.

### Screenshot or video of changes _(if applicable)_

![OpenWrt NES browser client](https://raw.githubusercontent.com/communism420/openwrt-nes-emulator/main/docs/assets/openwrt-nes-emulator.png)

The screenshot uses the project's freely distributable demo ROM; no commercial
game assets are included.

### Maintainer _(preferred)_

@communism420

---

## Tested on

**OpenWrt version:** OpenWrt 25.12.5  
**LuCI version:** hardware-tested PR head `5028c07a` on the OpenWrt 25.12.5 LuCI stack  
**Current review heads:** LuCI `038ad57ad8`; native `62ec2dff9`  
**Device:** ASUS RT-AX52 Pro (`mediatek/filogic`, `aarch64_cortex-a53`)  
**Web browser(s):** Chromium desktop checks; end-to-end desktop browser smoke test passed

The on-device smoke test used LuCI head `5028c07a` and native head `b4424df4`,
both built with the official OpenWrt 25.12.5 `mediatek/filogic` SDK. LuCI pages,
service status/controls, settings, ROM upload/loading, streamed gameplay, video,
audio, controller input, save/load state, and the FCEUX-style FPS overlay all
worked on the router.

The hardware-tested emulator and FCEUmm sources remain unchanged. Current heads
add the review-driven protected lock lifecycle, external-storage diagnostics,
bounded wait accounting, isolated/unbatched long-operation RPC handling, and
complete fd 7/8/9 child-process hygiene.

The source revision exporting these heads is covered by the successful
[project CI run](https://github.com/communism420/openwrt-nes-emulator/actions/runs/32956033619).
It includes ShellCheck, BusyBox resource-operation contracts, dynamic unbatched
long-RPC timeout/restoration tests, shared-resource packaging/export checks,
lock-fd inheritance checks, browser-client contracts, native path-confinement
integration tests, exact export validation, a clean
native build, and the complete black-box regression suite.

The unchanged package recipes and native binary also passed a clean current
Snapshot x86/64 SDK package check/build. The application passes the current LuCI
ESLint configuration, package check, and compilation. Generated APK metadata
was inspected for direct `cgi-io`, `jshn`, `jsonfilter`, `luci-base`,
`nes-emulator`, and `rpcd` dependencies. The RPCD bridge is mode `0755`.

---

## Checklist

- [x] Depends on openwrt/packages#30350.
