### PR TITLE
luci-app-ppe-qos: add a page for the PPE hardware QoS classifiers

### DIFF
--- a/applications/luci-app-ppe-qos/Makefile
+++ b/applications/luci-app-ppe-qos/Makefile
@@ -1,0 +1,15 @@
+# Copyright 2026 Julius Bairaktaris <julius@bairaktaris.de>
+# Licensed to the public under the Apache License 2.0.
+
+include $(TOPDIR)/rules.mk
+
+PKG_MAINTAINER:=Julius Bairaktaris <julius@bairaktaris.de>
+PKG_LICENSE:=Apache-2.0
+
+LUCI_TITLE:=LuCI support for the Qualcomm PPE hardware QoS classifiers
+LUCI_DEPENDS:=+ppe-qos
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ppe-qos/htdocs/luci-static/resources/view/network/ppe-qos.js
+++ b/applications/luci-app-ppe-qos/htdocs/luci-static/resources/view/network/ppe-qos.js
@@ -1,0 +1,137 @@
+'use strict';
+'require view';
+'require form';
+
+var CLASSES = [
+	[ 'cs0',  _('CS0 - best effort') ],
+	[ 'cs1',  _('CS1 - scavenger / bulk') ],
+	[ 'cs3',  _('CS3 - broadcast video') ],
+	[ 'af31', _('AF31 - multimedia streaming') ],
+	[ 'cs4',  _('CS4 - real-time interactive (games)') ],
+	[ 'af41', _('AF41 - multimedia conferencing (calls)') ],
+	[ 'cs5',  _('CS5 - signalling, DNS') ],
+	[ 'ef',   _('EF - voice bearer') ],
+	[ 'cs6',  _('CS6 - network control') ]
+];
+
+function prio_options(o) {
+	for (var i = 0; i <= 7; i++)
+		o.value(i, i >= 4 ? _('Priority %d (served past the bulk queue)').format(i)
+				  : _('Priority %d (bulk queue)').format(i));
+}
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('ppe-qos', _('PPE Hardware QoS'),
+			_('Which egress queue of the switch a flow rides. A marking rule puts a DSCP on the flow, ' +
+			  'a map turns that DSCP into an internal priority, and the priority picks the queue: ' +
+			  'priorities 4 and up are served past the bulk queue of a shaped port, so marked traffic ' +
+			  'keeps idle latency while the bulk queue stays deep enough for full throughput. ' +
+			  'Marking is done by the switch itself, so it reaches flows the PPE has offloaded. ' +
+			  'Shaper rates and the bulk queue depth belong to SQM (hw_ppe.qos).'));
+
+		s = m.section(form.NamedSection, 'global', 'global', _('Global'));
+
+		o = s.option(form.Flag, 'enabled', _('Enable marking rules'),
+			_('Turns the rules below off without deleting them. The DSCP maps and the small-packet ' +
+			  'priority stay in effect either way.'));
+		o.default = '1';
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'small_packet_len', _('Small packet: maximum L3 length'),
+			_('Frames up to this IP length take the priority below whatever their marking: ' +
+			  'ACKs, handshakes, DNS, VoIP and game traffic jump the bulk queue. 0 disables. ' +
+			  'A value just under the MTU means "everything that is not a full-size bulk frame".'));
+		o.datatype = 'and(uinteger,range(0,1500))';
+		o.placeholder = '128';
+
+		o = s.option(form.ListValue, 'small_packet_prio', _('Small packet: priority'));
+		prio_options(o);
+		o.default = '5';
+
+		o = s.option(form.Value, 'wan_port', _('Uplink switch port'),
+			_('Left empty this is taken from the WAN interface, with any VLAN id stripped, ' +
+			  'since the switch knows only the port. Set it if that guess is wrong.'));
+		o.datatype = 'netdevname';
+		o.placeholder = _('auto');
+		o.optional = true;
+
+		/* Marking rules. */
+		s = m.section(form.GridSection, 'rule', _('Marking rules'),
+			_('Each rule is applied in both directions: as written on the ports your clients sit ' +
+			  'behind, and mirrored on the uplink port so the returning half of the same connection ' +
+			  'is marked too. Ports may be single or a range (5000-5500), and several may be listed. ' +
+			  'The switch matches addresses and ports only - there is no matching by domain name.'));
+		s.addremove = true;
+		s.anonymous = true;
+		s.sortable = true;
+		s.nodescriptions = true;
+
+		o = s.option(form.Flag, 'enabled', _('Enable'));
+		o.editable = true;
+		o.default = '1';
+
+		o = s.option(form.Value, 'name', _('Name'));
+		o.rmempty = false;
+
+		o = s.option(form.ListValue, 'proto', _('Protocol'));
+		o.value('tcpudp', _('TCP and UDP'));
+		o.value('tcp', 'TCP');
+		o.value('udp', 'UDP');
+		o.default = 'tcpudp';
+
+		o = s.option(form.Value, 'src_ip', _('Source address'),
+			_('Optional. Addresses or CIDRs, space separated; IPv4 and IPv6 may be mixed.'));
+		o.datatype = 'list(ipmask)';
+		o.optional = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'dest_ip', _('Destination address'),
+			_('Optional, same syntax as the source address.'));
+		o.datatype = 'list(ipmask)';
+		o.optional = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'src_port', _('Source port'),
+			_('Optional. A port, a range, or several separated by spaces.'));
+		o.datatype = 'list(portrange)';
+		o.optional = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'dest_port', _('Destination port'),
+			_('Optional, same syntax as the source port. This is the usual way to name a service.'));
+		o.datatype = 'list(portrange)';
+		o.optional = true;
+
+		o = s.option(form.ListValue, 'class', _('Class'),
+			_('A class only changes the queue if the map below turns it into a priority of 4 or more. ' +
+			  'It also reaches Wi-Fi, which reads the DSCP for its own access categories.'));
+		CLASSES.forEach(function(c) { o.value(c[0], c[1]); });
+		o.rmempty = false;
+
+		/* DSCP to priority. */
+		s = m.section(form.GridSection, 'dscp', _('DSCP to priority'),
+			_('What a mark is worth once the switch reads it. Applied with dcb app on every switch ' +
+			  'port, so it classifies traffic marked by these rules and traffic that arrives already ' +
+			  'marked alike. Anything unlisted stays at priority 0 and rides the bulk queue.'));
+		s.addremove = true;
+		s.anonymous = true;
+
+		o = s.option(form.Value, 'dscp', _('DSCP'));
+		o.datatype = 'and(uinteger,range(0,63))';
+		o.rmempty = false;
+		o.value('32', _('32 (CS4 - games)'));
+		o.value('34', _('34 (AF41 - calls)'));
+		o.value('40', _('40 (CS5 - signalling, DNS)'));
+		o.value('46', _('46 (EF - voice)'));
+		o.value('48', _('48 (CS6 - control)'));
+
+		o = s.option(form.ListValue, 'prio', _('Priority'));
+		prio_options(o);
+		o.rmempty = false;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-ppe-qos/htdocs/luci-static/resources/view/network/ppe-qos.js
+++ b/applications/luci-app-ppe-qos/htdocs/luci-static/resources/view/network/ppe-qos.js
@@ -1,0 +1,141 @@
+'use strict';
+'require view';
+'require form';
+
+var CLASSES = [
+	[ 'cs0',  _('CS0 - best effort') ],
+	[ 'cs1',  _('CS1 - scavenger / bulk') ],
+	[ 'cs3',  _('CS3 - broadcast video') ],
+	[ 'af31', _('AF31 - multimedia streaming') ],
+	[ 'cs4',  _('CS4 - real-time interactive (games)') ],
+	[ 'af41', _('AF41 - multimedia conferencing (calls)') ],
+	[ 'cs5',  _('CS5 - signalling, DNS') ],
+	[ 'ef',   _('EF - voice bearer') ],
+	[ 'cs6',  _('CS6 - network control') ]
+];
+
+function prio_options(o) {
+	for (var i = 0; i <= 7; i++)
+		o.value(i, i >= 4 ? _('Priority %d (served past the bulk queue)').format(i)
+				  : _('Priority %d (bulk queue)').format(i));
+}
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('ppe-qos', _('PPE Hardware QoS'),
+			_('Which egress queue of the switch a flow rides. A marking rule puts a DSCP on the flow, ' +
+			  'a map turns that DSCP into an internal priority, and the priority picks the queue: ' +
+			  'priorities 4 and up are served past the bulk queue of a shaped port, so marked traffic ' +
+			  'keeps idle latency while the bulk queue stays deep enough for full throughput. ' +
+			  'Marking is done by the switch itself, so it reaches flows the PPE has offloaded. ' +
+			  'Shaper rates and the bulk queue depth belong to SQM (hw_ppe.qos).'));
+
+		s = m.section(form.NamedSection, 'global', 'global', _('Global'));
+
+		o = s.option(form.Flag, 'enabled', _('Enable'),
+			_('Turns the whole configuration off without deleting it. The marking rules, the DSCP ' +
+			  'maps and the small-packet priority are all removed while this is off.'));
+		o.default = '1';
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'small_pkt_len', _('Small packet: maximum L3 length'),
+			_('Frames up to this IP length take the priority below whatever their marking: ' +
+			  'ACKs, handshakes, DNS, VoIP and game traffic jump the bulk queue. 0 disables. ' +
+			  'The value has to stay under a full-size segment: a bulk segment that qualified ' +
+			  'would ride the priority band.'));
+		o.datatype = 'and(uinteger,range(0,1500))';
+		o.placeholder = '1000';
+
+		o = s.option(form.ListValue, 'small_pkt_prio', _('Small packet: priority'));
+		prio_options(o);
+		o.default = '5';
+
+		o = s.option(form.Value, 'wan_port', _('Uplink switch port'),
+			_('Left empty this is taken from the WAN interface, with any VLAN id stripped, ' +
+			  'since the switch knows only the port. Set it if that guess is wrong.'));
+		o.datatype = 'netdevname';
+		o.placeholder = _('auto');
+		o.optional = true;
+
+		/* Marking rules. */
+		s = m.section(form.GridSection, 'rule', _('Marking rules'),
+			_('Each rule is installed on the uplink port, matched as the returning half of the ' +
+			  'connection with source and destination swapped, so the download direction is marked. ' +
+			  'The upload half is installed on the ports your clients sit behind only when the ' +
+			  'mark_upload option of the ppe-qos config is set, which it is not by default. ' +
+			  'Ports may be single or a range (5000-5500), and several may be listed. ' +
+			  'The switch matches addresses and ports only - there is no matching by domain name.'));
+		s.addremove = true;
+		s.anonymous = true;
+		s.sortable = true;
+		s.nodescriptions = true;
+
+		o = s.option(form.Flag, 'enabled', _('Enable'));
+		o.editable = true;
+		o.default = '1';
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'name', _('Name'));
+		o.rmempty = false;
+
+		o = s.option(form.ListValue, 'proto', _('Protocol'));
+		o.value('tcpudp', _('TCP and UDP'));
+		o.value('tcp', 'TCP');
+		o.value('udp', 'UDP');
+		o.default = 'tcpudp';
+
+		o = s.option(form.Value, 'src_ip', _('Source address'),
+			_('Optional. Addresses or CIDRs, space separated; IPv4 and IPv6 may be mixed.'));
+		o.datatype = 'list(ipmask)';
+		o.optional = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'dest_ip', _('Destination address'),
+			_('Optional, same syntax as the source address.'));
+		o.datatype = 'list(ipmask)';
+		o.optional = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'src_port', _('Source port'),
+			_('Optional. A port, a range, or several separated by spaces.'));
+		o.datatype = 'list(portrange)';
+		o.optional = true;
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'dest_port', _('Destination port'),
+			_('Optional, same syntax as the source port. This is the usual way to name a service.'));
+		o.datatype = 'list(portrange)';
+		o.optional = true;
+
+		o = s.option(form.ListValue, 'class', _('Class'),
+			_('A class only changes the queue if the map below turns it into a priority of 4 or more. ' +
+			  'It also reaches Wi-Fi, which reads the DSCP for its own access categories.'));
+		CLASSES.forEach(function(c) { o.value(c[0], c[1]); });
+		o.rmempty = false;
+
+		/* DSCP to priority. */
+		s = m.section(form.GridSection, 'dscp', _('DSCP to priority'),
+			_('What a mark is worth once the switch reads it. Applied with dcb app on every switch ' +
+			  'port, so it classifies traffic marked by these rules and traffic that arrives already ' +
+			  'marked alike. Anything unlisted stays at priority 0 and rides the bulk queue.'));
+		s.addremove = true;
+		s.anonymous = true;
+
+		o = s.option(form.Value, 'dscp', _('DSCP'));
+		o.datatype = 'and(uinteger,range(0,63))';
+		o.rmempty = false;
+		o.value('32', _('32 (CS4 - games)'));
+		o.value('34', _('34 (AF41 - calls)'));
+		o.value('40', _('40 (CS5 - signalling, DNS)'));
+		o.value('46', _('46 (EF - voice)'));
+		o.value('48', _('48 (CS6 - control)'));
+
+		o = s.option(form.ListValue, 'prio', _('Priority'));
+		prio_options(o);
+		o.rmempty = false;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-ppe-qos/root/usr/share/luci/menu.d/luci-app-ppe-qos.json
+++ b/applications/luci-app-ppe-qos/root/usr/share/luci/menu.d/luci-app-ppe-qos.json
@@ -1,0 +1,14 @@
+{
+	"admin/network/ppe-qos": {
+		"title": "PPE QoS",
+		"order": 61,
+		"action": {
+			"type": "view",
+			"path": "network/ppe-qos"
+		},
+		"depends": {
+			"acl": [ "luci-app-ppe-qos" ],
+			"uci": { "ppe-qos": true }
+		}
+	}
+}

--- a/applications/luci-app-ppe-qos/root/usr/share/rpcd/acl.d/luci-app-ppe-qos.json
+++ b/applications/luci-app-ppe-qos/root/usr/share/rpcd/acl.d/luci-app-ppe-qos.json
@@ -1,0 +1,11 @@
+{
+	"luci-app-ppe-qos": {
+		"description": "Grant access to the PPE hardware QoS configuration",
+		"read": {
+			"uci": [ "ppe-qos" ]
+		},
+		"write": {
+			"uci": [ "ppe-qos" ]
+		}
+	}
+}


### PR DESCRIPTION
A LuCI page for `ppe-qos`, which configures the Qualcomm PPE's hardware QoS
classifiers: marking rules that put a DSCP on a flow with the switch's own ACL
engine, a DSCP-to-priority map applied per switch port with `dcb app`, and the
driver's small-packet priority. The page edits all three from one place under
Network.

It depends on `ppe-qos` (`applications/luci-app-ppe-qos/Makefile`,
`LUCI_DEPENDS:=+ppe-qos`), which is openwrt/openwrt#24806 and is not in
openwrt/openwrt yet, so this cannot build or merge before that lands.

The page's class description says a mark only changes the switch queue if the
map turns it into a priority of 4 or more, and that it reaches Wi-Fi either
way because Wi-Fi reads the DSCP for its own access categories. It also says
that shaper rates and the bulk queue depth are not here; they belong to SQM
(`hw_ppe.qos`).

I cross-checked the UCI option names against that backend. The page writes
`small_pkt_len`, `small_pkt_prio` and `wan_port`:

    applications/luci-app-ppe-qos/htdocs/luci-static/resources/view/network/ppe-qos.js:
        o = s.option(form.Value, 'small_pkt_len', _('Small packet: maximum L3 length'),
        ...
        o = s.option(form.ListValue, 'small_pkt_prio', _('Small packet: priority'));
        ...
        o = s.option(form.Value, 'wan_port', _('Uplink switch port'),

which is what the init reads (openwrt/openwrt#24806):

    package/network/config/ppe-qos/files/ppe-qos.init, apply():
        config_get len global small_pkt_len 1000
        config_get prio global small_pkt_prio 5

    package/network/config/ppe-qos/files/ppe-qos.init, wan_port():
        config_get dev global wan_port

I installed the page on an AX3600; the JS is served over HTTPS and emits the
option names the init reads. I have not driven the interactive save round
trip; there is no browser on the bench, so the form-to-UCI write path is
unexercised.
