### PR TITLE
luci-proto-wireguard: download current peer configuration

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -816,7 +816,8 @@ return network.registerProtocol('wireguard', {
 							'click'(ev) {
 								ev.preventDefault();
 
-								const blob = new Blob([peer_config], { type: 'text/plain' });
+								const current_config = node.querySelector('.client-config').textContent;
+								const blob = new Blob([current_config], { type: 'text/plain' });
 								const url = URL.createObjectURL(blob);
 								const a = document.createElement('a');
 


### PR DESCRIPTION
## Pull request details

### Description

The WireGuard export preview is regenerated whenever its fields change, but the download button keeps using the configuration created when the dialog was opened. This can leave changes such as added DNS servers out of the downloaded file.

Read the current preview when the download is requested so the file matches what LuCI displays.

Fixes openwrt/packages#30358

### Screenshot or video of changes _(if applicable)_

Not applicable. This changes the downloaded configuration rather than the visible layout.

### Maintainer _(preferred)_

@danrl

---

## Tested on

**OpenWrt version:** OpenWrt 25.12.2 (`r32802-f505120278`)  
**LuCI version:** LuCI openwrt-25.12 branch (`26.082.75780~067535e`)  
**Web browser(s):** Firefox 151.0.2

Tested on an x86/64 OpenWrt VM. After adding `9.9.9.9` as a DNS server, the downloaded `wireguard-peer.conf` exactly matched the updated preview and contained:

```ini
DNS = 192.168.1.1, 9.9.9.9
```

`node --check` and `git diff --check` also pass.

---

## Checklist

- [x] Includes the issue it closes: openwrt/packages#30358.
