### PR TITLE
luci-app-lldpd: remove broken CSS version suffix

### DIFF
--- a/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/config.js
+++ b/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/config.js
@@ -61,9 +61,7 @@ return L.view.extend({
 
 		// Inject CSS
 		const head = document.getElementsByTagName('head')[0];
-		const css = E('link', { 'href':
-			L.resource('lldpd/lldpd.css')
-				+ '?v=#PKG_VERSION', 'rel': 'stylesheet' });
+		const css = E('link', { 'href': L.resource('lldpd/lldpd.css'), 'rel': 'stylesheet' });
 
 		head.appendChild(css);
 	},

--- a/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/status.js
+++ b/applications/luci-app-lldpd/htdocs/luci-static/resources/view/lldpd/status.js
@@ -68,9 +68,7 @@ return L.view.extend({
 
 		// Inject CSS
 		const head = document.getElementsByTagName('head')[0];
-		const css = E('link', { 'href':
-			L.resource('lldpd/lldpd.css')
-				+ '?v=#PKG_VERSION', 'rel': 'stylesheet' });
+		const css = E('link', { 'href': L.resource('lldpd/lldpd.css'), 'rel': 'stylesheet' });
 
 		head.appendChild(css);
 	},


### PR DESCRIPTION
The stylesheet link ends with `?v=#PKG_VERSION`, a placeholder from the original Tano Systems build system that nothing in this repository replaces. Remove it and link the stylesheet directly, like other applications do.