### PR TITLE
luci-app-usteer: support device names from multi-radio devices

### DIFF
--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -371,7 +371,7 @@ function getCipherAKM() {
 	for (const wlan in Localinfo) {		
 		fs.stat('/usr/sbin/hostapd_cli').then(stat => {
 			if (!stat || stat.type !== 'file') { return; }
-			fs.exec_direct('/usr/sbin/hostapd_cli', ['-i', wlan.split('.')[1], 'all_sta'])
+			fs.exec_direct('/usr/sbin/hostapd_cli', ['-i', wlan.split('.').slice(1).join('.'), 'all_sta'])
 				.then(res => { parseAllSta(res); })
 				.catch(err => {});
 		}).catch (function (){return null;});


### PR DESCRIPTION
## Pull request details

### Description

Devices such as the Banana-pi BE14 expose their network interface as `phy0.0-ap1`. This means that the interface name splitting algorithm would request for `phy0` to be queried, returning an erroneous no-data result.

### Screenshot or video of changes _(if applicable)_

(no behavioural change, fix only)

### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@<github-user>

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->

**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4)
**LuCI version:** LuCI (HEAD detached at 128a7812) branch (26.180.75667~128a781)
**Web browser(s):** Firefox 154.0

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
