### PR TITLE
luci-proto-bfd: add BFD protocol handler

### DIFF
--- a/protocols/luci-proto-bfd/Makefile
+++ b/protocols/luci-proto-bfd/Makefile
@@ -1,0 +1,26 @@
+# Copyright 2026 Wolf480pl <wolf480@interia.pl>
+#
+# Modified by Wolf480pl <wolf480@interia.pl>,
+# based on luci-proto-gre, which was:
+#
+#   Based on luci-proto-ipip.
+#   Credited author of luci-proto-ipip is Roger Pueyo Centelles <roger.pueyo@guifi.net>
+#   Copyright 2016 Roger Pueyo Centelles <roger.pueyo@guifi.net>
+#
+#   Modified by Jan Betik <jan.betik@svine.su>
+#   Copyright 2020 Jan Betik <jan.betik@svine.su>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for BFD (RFC5880)
+LUCI_DEPENDS:=+bfdd
+
+PKG_MAINTAINER:=Wolf480pl <wolf480@interia.pl>
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-bfd/htdocs/luci-static/resources/protocol/bfd.js
+++ b/protocols/luci-proto-bfd/htdocs/luci-static/resources/protocol/bfd.js
@@ -1,0 +1,82 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+return network.registerProtocol('bfd', {
+	getI18n: function() {
+		return _('Bidirectional Forwarding Detection (BFD) Session');
+	},
+
+	getPackageName: function() {
+		return 'proto-bfd';
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+		var proto = this;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peer_address', _("Remote IP address"), _("The IP address of the remote BFD peer."));
+		o.rmempty = false;
+		o.datatype = 'or(ip4addr("nomask"),ip6addr("nomask"))';
+
+		o = s.taboption('general', form.Flag, 'multihop', _("Multihop"), _("Allow BFD packats to traverse multiple hops. Use when BFD peer is not a direct neighbour of this router."));
+
+		o = s.taboption('general', form.Value, 'local_address', _("Local IPv4 address"), _("The local IP address used to communicate with the BFD peer (mandatory on multihop)."));
+		o.rmempty = false;
+		o.datatype = 'or(ip4addr("nomask"),ip6addr("nomask"))';
+		o.depends('multihop', '1');
+		o.load = function(section_id) {
+			return network.getDevices().then(L.bind(function(devs) {
+				var addrs = devs.flatMap(d => {
+					var linkName = d.getName();
+					function addLinkName(addr) {
+						if (addr.startsWith("fe8")) {
+							addr = addr + "%" + linkName;
+						}
+						return addr;
+					}
+					var addrs4 = d.getIPAddrs().map(a => a.split('/')[0]);
+					var addrs6 = d.getIP6Addrs().map(a => a.split('/')[0]).map(addLinkName);
+					return addrs4.concat(addrs6)
+				}).sort()
+
+				for (var i = 0; i < addrs.length; i++) {
+					this.value(addrs[i]);
+				}
+				return form.Value.prototype.load.apply(this, [section_id]);
+			}, this));
+		};
+
+		o = s.taboption('general', form.Value, 'vrf_name', _("VRF Name"), _("Optional. The VRF used to communicate with the BFD peer."));
+		o.optional = true;
+		o.datatype = 'string';
+		o.depends('multihop', '1');
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', form.Value, 'detect_multiplier', _("Detect Multiplier"), _("Number of consecutive missed BFD packets after which the session is considered down."));
+		o.optional = true;
+		o.placeholder = 3;
+		o.datatype = 'uinteger';
+
+		o = s.taboption('advanced', form.Value, 'receive_interval', _("Receive Interval (ms)"), _("Minimum number of milliseconds between BFD packets we're willing to receive from the peer."));
+		o.optional = true;
+		o.placeholder = 300;
+		o.datatype = 'uinteger';
+
+		o = s.taboption('advanced', form.Value, 'transmit_interval', _("Transmit Interval (ms)"), _("Minimum number of milliseconds between BFD packet we transmit."));
+		o.optional = true;
+		o.placeholder = 300;
+		o.datatype = 'uinteger';
+
+		o = s.taboption('advanced', form.Flag, 'echo_mode', _("Echo Mode"), _("Echo mode sends packets with ourselves as destination, hoping the peer will reflect them without noticing."));
+
+		o = s.taboption('advanced', form.Value, 'echo_interval', _("Echo Interval (ms)"), _("Minimum number of milliseconds between BFD Echo packets, both for transmitting and receiving/reflecting. Set to zero to tell our peer we don't want incoming echos."));
+		o.optional = true;
+		o.placeholder = 50;
+		o.datatype = 'uinteger';
+	}
+});


### PR DESCRIPTION
<!-- 

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
Add luci-proto-bfd - a BFD protocol handler, so that users can configure bfdd peers through luci.
This depends on openwrt/packages#30364


### Screenshot or video of changes
<img width="600" height="632" alt="Screenshot 2026-08-23 at 16-38-47 integra - LuCI" src="https://github.com/user-attachments/assets/0ec183fe-0478-429e-a280-43ca6b5587cc" />
<img width="593" height="693" alt="Screenshot 2026-08-23 at 15-57-27 integra - LuCI" src="https://github.com/user-attachments/assets/292fefbb-933b-44f8-817f-c994e0aeaa0b" />

### Maintainer
Not sure... I'm adding myself (@wolf480pl) as the maintainer of the luci-protocol-bfd package, but @lucize maintains the bfdd package on openwrt/packages side

---

## Tested on
**OpenWrt version:** OpenWrt 24.10.2 r28739-d9340319c6
**LuCI version:** openwrt-24.10 branch (25.340.26705~d88390b)
**Web browser(s):** Firefox 145.0.2 (64-bit)

(Once I get a separate router for testing, I'll try testing on 25.12 and master as well)

---

## Checklist
- ~~_(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).~~
- [x] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
