### PR TITLE
luci-base,luci-mod-status: make log text search case-insensitive

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/views.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/views.js
@@ -116,10 +116,13 @@ var CBILogreadBox = function(logtag, name) {
 					return line.toLowerCase().includes(this.logTagFilter?.toLowerCase());
 				});
 
-				loglines = loglines.filter(line => {
-					const match = line.includes(this.logTextFilter);
-					return this.invertLogTextSearch ? !match : match;
-				});
+				if (this.logTextFilter) {
+					const filter = this.logTextFilter.toLowerCase();
+					loglines = loglines.filter(line => {
+						const match = line.toLowerCase().includes(filter);
+						return this.invertLogTextSearch ? !match : match;
+					});
+				}
 
 				return {
 					value: loglines?.join('\n'),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -95,8 +95,9 @@ return view.extend({
 
 			// Filter by text
 			if (this.logTextFilter) {
+				const filter = this.logTextFilter.toLowerCase();
 				loglines = loglines.filter(({ text }) => {
-					const match = text.includes(this.logTextFilter);
+					const match = text.toLowerCase().includes(filter);
 					return this.invertLogTextSearch ? !match : match;
 				});
 			}


### PR DESCRIPTION
### Description

Enable case-insensitive text search in the System Log and Kernel Log views.
Closes: https://github.com/openwrt/luci/issues/8952

### Maintainer
@systemcrash, @jow-

---

## Tested on
**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4)
**LuCI version:** LuCI openwrt-25.12 branch (26.209.73834~b61f907)
**Web browser(s):** Firefox 153.0.4

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
