### PR TITLE
luci-base: fix auth plugin asset loading

### DIFF
--- a/modules/luci-base/ucode/authplugins.uc
+++ b/modules/luci-base/ucode/authplugins.uc
@@ -157,7 +157,7 @@ function normalize_assets(uuid, assets) {
 		if (type(src) != 'string')
 			continue;
 
-		if (!match(src, sprintf("^/luci-static/plugins/%s/", uuid)))
+		if (index(src, sprintf("/luci-static/plugins/%s/", uuid)) != 0)
 			continue;
 
 		if (match(src, /\.\.|[\r\n\t ]/))

--- a/modules/luci-base/ucode/authplugins.uc
+++ b/modules/luci-base/ucode/authplugins.uc
@@ -160,7 +160,7 @@ function normalize_assets(uuid, assets) {
 		if (index(src, sprintf("/luci-static/plugins/%s/", uuid)) != 0)
 			continue;
 
-		if (match(src, /\.\.|[\r\n\t ]/))
+		if (match(src, /\.\.|[\r\n\t "'<>`]/))
 			continue;
 
 		push(rv, { type: 'script', src: src });


### PR DESCRIPTION
`normalize_assets()` builds its path pattern with `sprintf()` and hands the resulting string to `match()`. ucode's `match()` only accepts a regexp:

```c
if (ucv_type(pattern) != UC_REGEXP || !subject)
	return NULL;
```

It returns null whatever the subject is, `!match(...)` is therefore always true, and every asset is dropped by the `continue` under it. As far as I can tell no auth plugin has ever had its scripts rendered on the login page since the mechanism was added in 4a308bab.

It fails silently, which makes it unpleasant to track down. The `html` from the same `check()` result is unaffected, so the plugin's login UI renders normally but without the script that drives it, and nothing is logged. `plugins/luci-plugin-auth-example` declares `assets` too, so the shipped example is affected as well.

Reproducer:

```
$ ucode -e 'print(match("/a/b", "^/a/") ? "MATCH" : "NULL", "\n")'
NULL
$ ucode -e 'print(match("/a/b", /^\/a\//) ? "MATCH" : "NULL", "\n")'
MATCH
```

The check is a plain prefix test, so the first commit uses `index()` rather than compiling a regexp inside the loop. It returns the offset of the first occurrence or `-1`, which makes `!= 0` the equivalent of the anchored `^`, and it matches the existing idiom at `http.uc:397`.

The second commit is a follow-up from review. Because this series is what makes `normalize_assets()` return a non-empty result for the first time, the surviving `src` now reaches `<script src="{{ asset.src }}"></script>` unescaped in all three in-tree sysauth templates (`luci-base`, `bootstrap`, `footstrap`). The existing filter rejects `..` and whitespace but not quotes or angle brackets, so a `src` ending `x.js"></script><script>...` would close the attribute — no whitespace required. `normalize_assets()` is the single point every theme passes through, so the rejected character class is widened there rather than escaping in each template, which also covers out-of-tree themes carrying the same markup.

Found while getting a third-party WebAuthn auth plugin working. Verified on qualcommax/ipq807x with luci-base 26.234.21935: `auth_assets` arrives empty at the login template and no `<script>` tag is emitted, and correcting the path check makes the tag render and the passkey login complete.
