### PR TITLE
luci-app-shunt: add LuCI support for shunt

### DIFF
--- a/applications/luci-app-shunt/Makefile
+++ b/applications/luci-app-shunt/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2026 Dirk Brenken (dev@brenken.org)
+# This is free software, licensed under the Apache License, Version 2.0
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for shunt
+LUCI_DEPENDS:=+luci-base +shunt
+
+PKG_VERSION:=0.1.5
+PKG_RELEASE:=1
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/logread.js
+++ b/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/logread.js
@@ -1,0 +1,4 @@
+'use strict';
+'require view.shunt.logtemplate as LogTemplate';
+
+return LogTemplate.Logview(/\bshunt(\[\d+\])?:/, 'shunt');

--- a/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/logtemplate.js
+++ b/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/logtemplate.js
@@ -1,0 +1,68 @@
+'use strict';
+'require rpc';
+
+const callLogRead = rpc.declare({
+	object: 'log',
+	method: 'read',
+	params: ['lines', 'stream', 'oneshot'],
+	expect: {}
+});
+
+function Logview(logtag, name) {
+	return L.view.extend({
+		load: () => Promise.resolve(),
+
+		render: function () {
+			const pollFn = () => {
+				return callLogRead(1000, false, true).then(res => {
+					const logEl = document.getElementById('logfile');
+					if (!logEl) return;
+					const filtered = (res?.log ?? [])
+						.filter(entry => !logtag || (logtag instanceof RegExp
+							? logtag.test(entry.msg)
+							: entry.msg.includes(logtag)))
+						.map(entry => {
+							const d = new Date(entry.time);
+							const pad = n => String(n).padStart(2, '0');
+							const date = `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`;
+							const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+							return `[${date}-${time}] ${entry.msg}`;
+						});
+					logEl.value = filtered.length > 0
+						? filtered.join('\n')
+						: _('No %s related logs yet!').format(name);
+					logEl.scrollTop = logEl.scrollHeight;
+				});
+			};
+
+			this._pollFn = pollFn;
+			L.Poll.add(pollFn);
+
+			return E('div', { class: 'cbi-map' }, [
+				E('div', { class: 'cbi-section' }, [
+					E('div', { class: 'cbi-section-descr' },
+						_('The syslog output, pre-filtered for messages related to: %s').format(name)),
+					E('textarea', {
+						id: 'logfile',
+						style: 'min-height: 500px; max-height: 90vh; width: 100%; padding: 5px; font-family: monospace; resize: vertical;',
+						readonly: 'readonly',
+						wrap: 'off'
+					})
+				])
+			]);
+		},
+
+		unload: function () {
+			if (this._pollFn) {
+				L.Poll.remove(this._pollFn);
+				this._pollFn = null;
+			}
+		},
+
+		handleSaveApply: null,
+		handleSave: null,
+		handleReset: null
+	});
+}
+
+return L.Class.extend({ Logview });

--- a/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js
+++ b/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js
@@ -1,0 +1,441 @@
+'use strict';
+'require dom';
+'require view';
+'require poll';
+'require fs';
+'require ui';
+'require uci';
+'require rpc';
+'require form';
+'require tools.widgets as widgets';
+
+const getStatus = rpc.declare({
+	object: 'luci.shunt',
+	method: 'status'
+});
+
+const getPackages = rpc.declare({
+	object: 'rpc-sys',
+	method: 'packagelist',
+	params: ['all'],
+	expect: { packages: {} }
+});
+
+function handleAction(ev) {
+	if (ev === 'restart') {
+		const map = document.querySelector('.cbi-map');
+		return dom.callClassMethod(map, 'save')
+			.then(L.bind(ui.changes.apply, ui.changes))
+			.then(function () {
+				return fs.exec_direct('/etc/init.d/shunt', [ev]);
+			});
+	}
+	return fs.exec_direct('/etc/init.d/shunt', [ev]);
+}
+
+function fmtMark(mark) {
+	if (mark == null) {
+		return '-';
+	}
+	return '0x%08x'.format(mark);
+}
+
+function fmtCount(n) {
+	if (n == null) {
+		return '?';
+	}
+	return '%d'.format(n);
+}
+
+function card(label, value, sub, cls) {
+	return E('div', { 'class': 'shunt-card' }, [
+		E('div', { 'class': 'shunt-label' }, label),
+		E('div', { 'class': 'shunt-value ' + (cls || '') }, value),
+		sub ? E('div', { 'class': 'shunt-sub' }, sub) : ''
+	]);
+}
+
+function dot(state) {
+	return E('span', { 'class': 'shunt-dot shunt-dot-' + state });
+}
+
+function renderState(st) {
+	if (!st || st.running == null) {
+		return E('div', { 'class': 'shunt-state' }, [
+			dot('off'), E('span', {}, _('no answer from the backend'))
+		]);
+	}
+
+	if (st.running && st.applied) {
+		return E('div', { 'class': 'shunt-state' }, [
+			dot('ok'), E('span', {}, _('running, policy applied'))
+		]);
+	}
+
+	if (st.running && !st.applied) {
+		return E('div', { 'class': 'shunt-state' }, [
+			dot('warn'), E('span', {}, _('running, but no ruleset in the kernel'))
+		]);
+	}
+
+	if (!st.running && st.applied) {
+		return E('div', { 'class': 'shunt-state' }, [
+			dot('warn'), E('span', {}, _('ruleset present, service not running'))
+		]);
+	}
+
+	return E('div', { 'class': 'shunt-state' }, [
+		dot('off'), E('span', {}, _('stopped'))
+	]);
+}
+
+// The observer's verdict identifiers are module contract - translated for
+// display only, with the raw key kept beside each label.
+const DROP_LABEL = {
+	'nomatch': _('Domain is in no policy'),
+	'qtype': _('Not an address query'),
+	'noaddr': _('Answer carried no usable address'),
+
+	'dns:E_RCODE': _('Error reply, e.g. NXDOMAIN'),
+	'dns:E_NOTRESP': _('Not a response'),
+	'dns:E_TRUNC': _('Truncated response'),
+	'dns:E_QDCOUNT': _('Not exactly one question'),
+	'dns:E_SHORT': _('Message ends mid-structure'),
+	'dns:E_MSGLEN': _('Message too long'),
+	'dns:E_QPTR': _('Compression pointer in the question'),
+	'dns:E_LABEL': _('Reserved label type'),
+	'dns:E_NAMELEN': _('Name too long'),
+	'dns:E_CHARSET': _('Name has a byte outside a-z 0-9 - _'),
+	'dns:E_RDLEN': _('Record length does not fit the type'),
+	'dns:E_ANSMAX': _('Too many answers'),
+
+	'frame:E_SHORT': _('Frame ends mid-structure'),
+	'frame:E_ETHER': _('Neither IPv4 nor IPv6'),
+	'frame:E_VLAN': _('Too many stacked VLAN tags'),
+	'frame:E_IPLEN': _('Inconsistent IP header length'),
+	'frame:E_FRAG': _('IP fragment'),
+	'frame:E_EXTHDR': _('Extension header chain too long'),
+	'frame:E_PROTO': _('Not UDP'),
+	'frame:E_UDPLEN': _('Inconsistent UDP length')
+};
+
+function dropLabel(key) {
+	return DROP_LABEL[key] || key;
+}
+
+function renderSnoop(svc) {
+	if (!svc || !svc.snoop) {
+		return '';
+	}
+
+	const drops = svc.snoop.drops || {};
+	const matched = svc.snoop.matched || 0;
+	const keys = Object.keys(drops).sort(function (a, b) {
+		return drops[b] - drops[a] || a.localeCompare(b);
+	});
+
+	let total = 0;
+
+	keys.forEach(function (k) {
+		total += drops[k];
+	});
+
+	const rows = keys.map(function (k) {
+		return E('tr', { 'class': 'tr' }, [
+			E('td', { 'class': 'td left' }, [
+				dropLabel(k),
+				E('span', { 'class': 'shunt-key' }, k)
+			]),
+			E('td', { 'class': 'td right' }, ['%d'.format(drops[k])])
+		]);
+	});
+
+	return E('div', { 'class': 'shunt-block' }, [
+		E('div', { 'class': 'shunt-label' },
+			[_('DNS responses observed on %s since the service started')
+				.format((svc.snoop.devices || []).join(', ') || '-')]),
+		E('table', { 'class': 'table' }, [
+			E('tr', { 'class': 'tr' }, [
+				E('td', { 'class': 'td left' },
+					E('strong', {}, _('Answers used for a policy'))),
+				E('td', { 'class': 'td right' },
+					E('strong', { 'class': 'shunt-hit' }, '%d'.format(matched)))
+			])
+		].concat(rows)),
+		E('div', { 'class': 'shunt-sub' }, _('%d of %d observed responses were not used. That is normal: the observer sees every answer on the network, and only the ones for a domain you routed are of any interest.')
+			.format(total, total + matched))
+	]);
+}
+
+function renderPolicies(st) {
+	if (!st || !st.policies || !st.policies.length) {
+		return E('div', { 'class': 'shunt-sub' }, _('No policy is active.'));
+	}
+
+	const rows = [
+		E('tr', { 'class': 'tr table-titles' }, [
+			E('th', { 'class': 'th' }, _('Policy')),
+			E('th', { 'class': 'th' }, _('Interface')),
+			E('th', { 'class': 'th' }, _('Mark')),
+			E('th', { 'class': 'th' }, _('Table')),
+			E('th', { 'class': 'th' }, _('Rules')),
+			E('th', { 'class': 'th' }, _('Routes')),
+			E('th', { 'class': 'th' }, _('Fallback'))
+		])
+	];
+
+	st.policies.forEach(function (p) {
+		rows.push(E('tr', { 'class': 'tr' }, [
+			E('td', { 'class': 'td' }, [p.name]),
+			E('td', { 'class': 'td' }, [p.interface || '-']),
+			E('td', { 'class': 'td' }, [fmtMark(p.mark)]),
+			E('td', { 'class': 'td' }, [fmtCount(p.rt_table)]),
+			E('td', { 'class': 'td' }, [fmtCount(p.rules)]),
+			E('td', { 'class': 'td' }, [fmtCount(p.routes)]),
+			E('td', { 'class': 'td' }, [p.fallback || 'main'])
+		]));
+	});
+
+	return E('table', { 'class': 'table' }, rows);
+}
+
+function renderIssues(st) {
+	if (!st || !st.issues || !st.issues.length) {
+		return '';
+	}
+
+	const items = st.issues.map(function (i) {
+		const where = i.entry ? '%s: %s'.format(i.policy, i.entry) : i.policy;
+		return E('li', {}, ['%s - %s'.format(where, i.reason)]);
+	});
+
+	return E('div', { 'class': 'shunt-block' }, [
+		E('div', { 'class': 'shunt-label' }, _('Rejected settings')),
+		E('ul', { 'class': 'shunt-issues' }, items),
+		E('div', { 'class': 'shunt-sub' }, _('These entries were skipped. Everything else was applied - a rejected entry never takes the service down.'))
+	]);
+}
+
+return view.extend({
+	load: function () {
+		return Promise.all([
+			L.resolveDefault(getStatus(), {}),
+			uci.load('shunt').catch(() => 0),
+			L.resolveDefault(getPackages(true), {})
+		]);
+	},
+
+	render: function (result) {
+		const pkgs = result[2] || {};
+
+		if (!uci.sections('shunt').length) {
+			ui.addNotification(null, E('p', _('No shunt config found!')), 'error');
+			return;
+		}
+
+		let m, s, o;
+
+		m = new form.Map('shunt', 'shunt',
+			_('Policy based routing by mac, source, destination and domain. For further information please check the %s.')
+				.format(`<a style="color:#37c;font-weight:bold;" href="https://github.com/openwrt/packages/blob/master/net/shunt/files/README.md" target="_blank" rel="noreferrer noopener" >${_('online documentation')}</a>`));
+		const style = E('style', { 'type': 'text/css' },
+			'#shunt-status {' +
+			'--shunt-card-bg: rgba(128,128,128,.07);' +
+			'--shunt-card-border: rgba(128,128,128,.28);' +
+			'--shunt-muted: GrayText;' +
+			'--shunt-ok: #1f8a5f;' +
+			'--shunt-warn: #b8860b;' +
+			'--shunt-off: #808080;' +
+			'}' +
+			'@media (prefers-color-scheme: dark) {' +
+			'#shunt-status {' +
+			'--shunt-ok: #63c79b;' +
+			'--shunt-warn: #e0b458;' +
+			'}}' +
+			'#shunt-status .shunt-grid { display: grid; gap: .75em; ' +
+			'grid-template-columns: repeat(auto-fit, minmax(min(12em, 100%), 1fr)); ' +
+			'margin-bottom: .75em; }' +
+			'#shunt-status .shunt-card { background: var(--shunt-card-bg); ' +
+			'border: 1px solid var(--shunt-card-border); border-radius: 8px; ' +
+			'padding: .7em .9em; min-width: 0; overflow-wrap: break-word; }' +
+			'#shunt-status .shunt-block { margin-bottom: .75em; }' +
+			'#shunt-status .shunt-label { font-size: .85em; ' +
+			'color: var(--shunt-muted); margin-bottom: .3em; }' +
+			'#shunt-status .shunt-sub { font-size: .8em; ' +
+			'color: var(--shunt-muted); margin-top: .3em; }' +
+			'#shunt-status .shunt-value { font-size: 1.5em; line-height: 1.3; ' +
+			'font-variant-numeric: tabular-nums; }' +
+			'#shunt-status .shunt-state { display: flex; align-items: center; gap: .5em; }' +
+			'#shunt-status .shunt-dot { width: .6em; height: .6em; border-radius: 50%; ' +
+			'flex: 0 0 auto; background: var(--shunt-muted); }' +
+			'#shunt-status .shunt-dot-ok { background: var(--shunt-ok); }' +
+			'#shunt-status .shunt-dot-warn { background: var(--shunt-warn); }' +
+			'#shunt-status .shunt-dot-off { background: var(--shunt-off); }' +
+			'#shunt-status .shunt-issues { margin: 0; padding-left: 1.2em; }' +
+			'#shunt-status .shunt-key { color: var(--shunt-muted); ' +
+			'font-family: monospace; font-size: .8em; margin-left: .6em; }' +
+			'#shunt-status .shunt-hit { color: var(--shunt-ok); }');
+
+		const setNodes = (id, nodes) => {
+			const el = document.getElementById(id);
+			if (el) {
+				dom.content(el, nodes);
+			}
+		};
+
+		// Shown once, not on every poll tick. rp_filter is a box-wide security
+		// setting shunt does not change; a strict value silently drops its
+		// traffic, so the UI names it where the log would otherwise be the
+		// only place. Points at the docs rather than offering a button,
+		// because the change belongs to the administrator.
+		let rpWarned = false;
+
+		const update = (st) => {
+			const svc = st ? st.service : null;
+			// Devices the kernel would drop marked traffic on, on the status
+			// root. Empty when all is loose, when each policy device is loose
+			// itself, or when rp_filter_manage has set them - the daemon reads
+			// the live value, so an enabled switch simply yields an empty list.
+			const blocked = (st && st.rp_filter_blocked) || [];
+
+			if (blocked.length && !rpWarned) {
+				rpWarned = true;
+				ui.addNotification(
+					_('Reverse path filtering is strict'),
+					E('p', {}, [
+						_('Strict rp_filter will drop shunt\'s marked traffic on %s. Set rp_filter to 2 on the policy interface, enable rp_filter_manage to have shunt do it, or loosen it box-wide; see the README.').format(
+							blocked.join(', '))
+					]),
+					'warning');
+			}
+
+			setNodes('shunt-state', renderState(st));
+			setNodes('shunt-version', E('span', {}, ['%s / %s'.format(
+				pkgs['luci-app-shunt'] || _('n/a'), pkgs['shunt'] || _('n/a'))]));
+			setNodes('shunt-learned', E('span', {}, [
+				svc ? fmtCount(svc.dedupe) : '-']));
+			setNodes('shunt-poll', E('span', {}, [svc?.poll
+				? (svc.poll.resolv
+					? _('%d name(s) every %ds').format(svc.poll.names, svc.poll.interval)
+					: _('unavailable - ucode-mod-resolv missing'))
+				: '-']));
+			setNodes('shunt-policies', renderPolicies(st));
+			setNodes('shunt-snoop', renderSnoop(svc));
+			setNodes('shunt-issues', renderIssues(st));
+		};
+
+		// TypedSection: `config global` is anonymous, so there is no section
+		// named 'global' to bind to.
+		o = m.section(form.TypedSection, 'global');
+		o.anonymous = true;
+		o.addremove = false;
+		o.render = L.bind(function () {
+			return E('div', { 'id': 'shunt-status' }, [
+				style,
+				E('div', { 'class': 'shunt-grid' }, [
+					card(_('Service'), E('span', { 'id': 'shunt-state' }, '-'),
+						E('span', {}, [
+							_('Version'), ': ',
+							E('span', { 'id': 'shunt-version' }, '-')
+						])),
+					card(_('Learned addresses'),
+						E('span', { 'id': 'shunt-learned' }, '-'),
+						_('across all policies')),
+					card(_('Poll'), E('span', { 'id': 'shunt-poll' }, '-'),
+						_('wildcards are covered by the observer only'))
+				]),
+				E('div', { 'id': 'shunt-policies' }, ''),
+				E('div', { 'id': 'shunt-snoop' }, ''),
+				E('div', { 'id': 'shunt-issues' }, '')
+			]);
+		}, this);
+
+		poll.add(function () {
+			return L.resolveDefault(getStatus(), null).then(update);
+		}, 2);
+
+		// The status subtree only exists once m.render() has resolved and
+		// View.__init__ has attached the nodes; a direct call here would find
+		// no ids and leave the cards on '-' until the first poll tick.
+		requestAnimationFrame(function () {
+			update(result[0]);
+		});
+
+		s = m.section(form.TypedSection, 'global', _('Settings'));
+		s.anonymous = true;
+		s.addremove = false;
+		s.tab('general', _('General Settings'));
+		s.tab('snoop', _('DNS Observer Settings'));
+
+		o = s.taboption('general', form.Flag, 'enabled', _('Enabled'),
+			_('Enable the shunt service.'));
+		o.rmempty = false;
+
+		o = s.taboption('general', form.Flag, 'debug', _('Debug Logging'),
+			_('Log every observed DNS answer and every set write. Useful for a bug report, noisy in normal operation - on a router running adblock roughly half of all answers are error replies, and each one gets a line.'));
+		o.rmempty = false;
+
+		o = s.taboption('general', form.Flag, 'rp_filter_manage', _('Manage rp_filter'),
+			_('Set rp_filter to 2 on shunt\'s own policy interfaces, at start and when one comes up.'));
+		o.rmempty = false;
+
+		o = s.taboption('general', form.Value, 'poll_interval', _('Poll Interval'),
+			_('Seconds between poll cycles.'));
+		o.datatype = 'and(uinteger,min(30))';
+		o.placeholder = '300';
+
+		o = s.taboption('general', form.Value, 'entry_ttl', _('Entry Lifetime'),
+			_('Seconds a learned address stays in its Set. Keep this well above the poll interval.'));
+		o.datatype = 'and(uinteger,min(60))';
+		o.placeholder = '1200';
+		o.validate = function (section_id, value) {
+			const iv = this.map.lookupOption('poll_interval', section_id);
+			const interval = (iv && iv[0]) ? (iv[0].formvalue(section_id) || 300) : 300;
+
+			if (value && +value < 2 * +interval) {
+				return _('Should be at least twice the poll interval (%d), otherwise entries expire between cycles.').format(2 * interval);
+			}
+
+			return true;
+		};
+
+		o = s.taboption('snoop', form.Flag, 'snoop', _('Passive DNS Observer'),
+			_('Read DNS answers as they pass the LAN device, whichever resolver produced them. Required for wildcard domains, which cannot be resolved ahead of time.'));
+		o.rmempty = false;
+
+		o = s.taboption('snoop', widgets.DeviceSelect, 'snoop_device',
+			_('Observed Devices'),
+			_('The LAN device the DNS answers cross on their way to the clients, normally br-lan. One entry per network segment, see the README.'));
+		o.default = 'br-lan';
+		o.multiple = true;
+		o.noaliases = true;
+
+		s = m.section(form.TypedSection, 'global');
+		s.anonymous = true;
+		s.addremove = false;
+		s.render = L.bind(function () {
+			return E('div', { 'class': 'cbi-page-actions' }, [
+				E('button', {
+					'class': 'btn cbi-button cbi-button-negative important',
+					'style': 'float:none;margin-right:.4em;',
+					'click': ui.createHandlerFn(this, function () {
+						return handleAction('stop');
+					})
+				}, [_('Stop')]),
+				E('button', {
+					'class': 'btn cbi-button cbi-button-positive important',
+					'style': 'float:none',
+					'click': ui.createHandlerFn(this, function () {
+						return handleAction('restart');
+					})
+				}, [_('Save & Restart')])
+			]);
+		});
+
+		return m.render();
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js
+++ b/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js
@@ -1,0 +1,143 @@
+'use strict';
+'require dom';
+'require view';
+'require fs';
+'require ui';
+'require uci';
+'require form';
+
+function handleAction(ev) {
+	if (ev === 'restart') {
+		const map = document.querySelector('.cbi-map');
+		return dom.callClassMethod(map, 'save')
+			.then(L.bind(ui.changes.apply, ui.changes))
+			.then(function () {
+				return fs.exec_direct('/etc/init.d/shunt', [ev]);
+			});
+	}
+	return fs.exec_direct('/etc/init.d/shunt', [ev]);
+}
+
+return view.extend({
+	load: function () {
+		return Promise.all([
+			uci.load('shunt').catch(() => 0),
+			uci.load('network').catch(() => 0)
+		]);
+	},
+
+	render: function () {
+		if (!uci.sections('shunt').length) {
+			ui.addNotification(null, E('p', _('No shunt config found!')), 'error');
+			return;
+		}
+
+		let m, s, o;
+
+		m = new form.Map('shunt', _('Policies'),
+			_('Evaluated top to bottom - the first policy a packet matches \
+				wins. Within one policy the selectors are ANDed: source plus domain means only that client, and only to those domains.'));
+		s = m.section(form.GridSection, 'policy');
+		s.addremove = true;
+		s.anonymous = false;
+		s.sortable = true;
+		s.nodescriptions = true;
+		s.addbtntitle = _('Add policy');
+
+		// The section name becomes an nftables identifier, so it is validated
+		// where it is typed rather than silently skipped later.
+		s.renderSectionAdd = function (extra_class) {
+			const el = form.GridSection.prototype.renderSectionAdd.apply(this, arguments);
+			const nameEl = el.querySelector('.cbi-section-create-name');
+
+			if (nameEl) {
+				ui.addValidator(nameEl, 'and(uciname,maxlength(24))', true);
+			}
+
+			return el;
+		};
+
+		o = s.option(form.Flag, 'enabled', _('Enabled'));
+		o.rmempty = false;
+		o.default = '1';
+		o.editable = true;
+
+		o = s.option(form.Value, 'interface', _('Interface'),
+			_('The device or logical interface this policy routes into. A \
+				netifd name is resolved to its device; any other device name is used as entered.'));
+		o.rmempty = false;
+
+		uci.sections('network', 'interface').forEach(function (n) {
+			if (n['.name'] !== 'loopback') {
+				o.value(n['.name'], '%s (%s)'.format(n['.name'], _('interface')));
+			}
+		});
+
+		o = s.option(form.ListValue, 'fallback', _('Fallback Behavior'));
+		o.value('main', _('Fall through to the normal uplink'));
+		o.value('block', _('Block the traffic (killswitch)'));
+		o.default = 'main';
+
+		o = s.option(form.DynamicList, 'src', _('Source Addresses'),
+			_('Client addresses or prefixes this policy applies to. Leave empty to apply to every client.'));
+		o.datatype = 'ipaddr';
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'src_mac', _('Source MAC Addresses'),
+			_('Client MACs this policy applies to, ORed with the addresses above.'));
+		o.datatype = 'macaddr';
+		o.modalonly = true;
+
+		o = s.option(form.MultiValue, 'proto', _('Protocols'),
+			_('Restrict to tcp, udp or both. A port without a protocol covers both.'));
+		o.value('tcp', 'tcp');
+		o.value('udp', 'udp');
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'dport', _('Destination Ports'),
+			_('Single ports or ranges like 8000-8080, ANDed with the addresses below.'));
+		o.datatype = 'or(port, portrange)';
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'dst', _('Destination Addresses'),
+			_('Destination addresses or prefixes to route into this policy.'));
+		o.datatype = 'ipaddr';
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'domain', _('Domains'),
+			_('example.com matches that name only, *.example.com matches its \
+				subdomains but not the apex - list both to cover both.'));
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'gw4', _('IPv4 Gateway Override'),
+			_('Only needed when the gateway discovered from netifd is wrong. \
+				Point to point interfaces need no gateway at all.'));
+		o.datatype = 'ip4addr';
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'gw6', _('IPv6 Gateway Override'));
+		o.datatype = 'ip6addr';
+		o.modalonly = true;
+
+		s = m.section(form.TypedSection, 'global');
+		s.anonymous = true;
+		s.addremove = false;
+		s.render = L.bind(function () {
+			return E('div', { 'class': 'cbi-page-actions' }, [
+				E('button', {
+					'class': 'btn cbi-button cbi-button-positive important',
+					'style': 'float:none',
+					'click': ui.createHandlerFn(this, function () {
+						return handleAction('restart');
+					})
+				}, [_('Save & Restart')])
+			]);
+		});
+
+		return m.render();
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js
+++ b/applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js
@@ -1,0 +1,263 @@
+'use strict';
+'require view';
+'require dom';
+'require ui';
+'require uci';
+'require rpc';
+
+const getSets = rpc.declare({
+	object: 'luci.shunt',
+	method: 'sets',
+	params: ['policy']
+});
+
+function setKind(name) {
+	return name.substring(0, 1);
+}
+
+function setPolicy(name) {
+	return name.substring(name.substring(0, 1) === 'm' ? 2 : 3);
+}
+
+function fmtExpiry(sec) {
+	if (sec == null) {
+		return '-';
+	}
+	if (sec >= 3600) {
+		return _('%dh %dm').format(Math.floor(sec / 3600),
+			Math.floor((sec % 3600) / 60));
+	}
+	if (sec >= 60) {
+		return _('%dm %ds').format(Math.floor(sec / 60), sec % 60);
+	}
+	return _('%ds').format(sec);
+}
+
+function fmtNum(n) {
+	if (n == null) {
+		return '-';
+	}
+	return '%d'.format(n);
+}
+
+function renderCards(sets, kinds, title, empty_hint) {
+	const byPolicy = {};
+
+	Object.keys(sets).forEach(function (name) {
+		if (kinds.indexOf(setKind(name)) < 0) {
+			return;
+		}
+
+		const policy = setPolicy(name);
+
+		if (!byPolicy[policy]) {
+			byPolicy[policy] = [];
+		}
+
+		sets[name].forEach(function (e) {
+			byPolicy[policy].push(e);
+		});
+	});
+
+	const policies = Object.keys(byPolicy).filter(function (p) {
+		return byPolicy[p].length > 0;
+	}).sort();
+
+	if (!policies.length) {
+		return empty_hint
+			? E('div', { 'class': 'shunt-block' }, [
+				E('div', { 'class': 'shunt-label' }, title),
+				E('div', { 'class': 'shunt-sub' }, empty_hint)
+			])
+			: '';
+	}
+
+	const cards = policies.map(function (policy) {
+		return E('div', { 'class': 'shunt-card' }, [
+			E('div', { 'class': 'shunt-card-title' }, [policy]),
+			E('div', { 'class': 'shunt-addrs' },
+				byPolicy[policy].sort(function (a, b) {
+					return String(a.addr).localeCompare(String(b.addr));
+				}).map(function (e) {
+					return E('div', {}, [
+						e.addr,
+						e.packets ? E('span', { 'class': 'shunt-hits' },
+							_('%d pkt matched').format(e.packets)) : ''
+					]);
+				}))
+		]);
+	});
+
+	return E('div', { 'class': 'shunt-block' }, [
+		E('div', { 'class': 'shunt-label' }, title),
+		E('div', { 'class': 'shunt-grid' }, cards)
+	]);
+}
+
+function renderLearned(sets) {
+	const rows = [];
+
+	Object.keys(sets).forEach(function (name) {
+		if (setKind(name) !== 'd') {
+			return;
+		}
+
+		const policy = setPolicy(name);
+
+		sets[name].forEach(function (e) {
+			rows.push({
+				policy: policy,
+				addr: e.addr,
+				expires: e.expires,
+				packets: e.packets,
+				bytes: e.bytes
+			});
+		});
+	});
+
+	rows.sort(function (a, b) {
+		return a.policy.localeCompare(b.policy)
+			|| (b.packets || 0) - (a.packets || 0)
+			|| String(a.addr).localeCompare(String(b.addr));
+	});
+
+	if (!rows.length) {
+		return E('div', { 'class': 'shunt-block' }, [
+			E('div', { 'class': 'shunt-label' }, _('Learned addresses')),
+			E('div', { 'class': 'shunt-sub' }, _('Nothing learned yet. The service fills these from its poll cycle and from observed DNS answers.'))
+		]);
+	}
+
+	const tbl = E('table', { 'class': 'table shunt-table' }, [
+		E('tr', { 'class': 'tr table-titles' }, [
+			E('th', { 'class': 'th' }, _('Policy')),
+			E('th', { 'class': 'th' }, _('Address')),
+			E('th', { 'class': 'th' }, _('Expires')),
+			E('th', { 'class': 'th' }, _('Packets routed')),
+			E('th', { 'class': 'th' }, _('Bytes routed'))
+		])
+	]);
+
+	cbi_update_table(tbl, rows.map(function (r) {
+		return [
+			r.policy,
+			r.addr,
+			fmtExpiry(r.expires),
+			fmtNum(r.packets),
+			fmtNum(r.bytes)
+		];
+	}));
+
+	return E('div', { 'class': 'shunt-block' }, [
+		E('div', { 'class': 'shunt-label' },
+			_('Learned addresses (%d)').format(rows.length)),
+		tbl
+	]);
+}
+
+return view.extend({
+	load: function () {
+		return Promise.all([
+			uci.load('shunt').catch(() => 0),
+			L.resolveDefault(getSets(''), {})
+		]);
+	},
+
+	render: function (result) {
+		const self = this;
+
+		const render_sets = function (data) {
+			const sets = (data && data.sets) || {};
+			const target = document.getElementById('shunt-sets');
+
+			if (!target) {
+				return;
+			}
+
+			dom.content(target, [
+				renderCards(sets, ['c', 'm'], _('Client Selectors'),
+					_('No client is selected, so every client is covered.')),
+				renderCards(sets, ['s'], _('Static Destinations'), null),
+				renderLearned(sets)
+			]);
+		};
+
+		const reload = function () {
+			const sel = document.getElementById('shunt-policy');
+
+			return L.resolveDefault(getSets(sel ? sel.value : ''), {})
+				.then(render_sets);
+		};
+
+		const options = [E('option', { 'value': '' }, _('all policies'))]
+			.concat(uci.sections('shunt', 'policy').map(function (p) {
+				return E('option', { 'value': p['.name'] }, [p['.name']]);
+			}));
+
+		const style = E('style', { 'type': 'text/css' },
+			'#shunt-sets {' +
+			'--shunt-card-bg: rgba(128,128,128,.07);' +
+			'--shunt-card-border: rgba(128,128,128,.28);' +
+			'--shunt-muted: GrayText;' +
+			'}' +
+			'#shunt-sets .shunt-block { margin-bottom: 1.2em; }' +
+			'#shunt-sets .shunt-label { font-size: .85em; ' +
+			'color: var(--shunt-muted); margin-bottom: .4em; }' +
+			'#shunt-sets .shunt-sub { font-size: .85em; color: var(--shunt-muted); }' +
+			'#shunt-sets .shunt-grid { display: grid; gap: .75em; ' +
+			'grid-template-columns: repeat(auto-fit, minmax(min(16em, 100%), 1fr)); }' +
+			'#shunt-sets .shunt-card { background: var(--shunt-card-bg); ' +
+			'border: 1px solid var(--shunt-card-border); border-radius: 8px; ' +
+			'padding: .7em .9em; min-width: 0; }' +
+			'#shunt-sets .shunt-card-title { font-weight: bold; margin-bottom: .3em; }' +
+			'#shunt-sets .shunt-addrs { font-family: monospace; font-size: .9em; ' +
+			'overflow-wrap: anywhere; }' +
+			'#shunt-sets .shunt-hits { color: var(--shunt-muted); ' +
+			'font-size: .85em; margin-left: .6em; }' +
+			'#shunt-sets .shunt-table { table-layout: fixed; width: 100%; }' +
+			'#shunt-sets .shunt-table th:nth-child(1),' +
+			'#shunt-sets .shunt-table td:nth-child(1) { width: 15%; }' +
+			'#shunt-sets .shunt-table th:nth-child(2),' +
+			'#shunt-sets .shunt-table td:nth-child(2) { width: 37%; ' +
+			'overflow-wrap: anywhere; }' +
+			'#shunt-sets .shunt-table th:nth-child(3),' +
+			'#shunt-sets .shunt-table td:nth-child(3) { width: 16%; }' +
+			'#shunt-sets .shunt-table th:nth-child(4),' +
+			'#shunt-sets .shunt-table td:nth-child(4) { width: 16%; }' +
+			'#shunt-sets .shunt-table th:nth-child(5),' +
+			'#shunt-sets .shunt-table td:nth-child(5) { width: 16%; }');
+
+		const page = E('div', { 'class': 'cbi-map' }, [
+			style,
+			E('h2', {}, _('Set Reporting')),
+			E('div', { 'class': 'cbi-section' }, [
+				E('div', { 'class': 'cbi-section-descr' },
+					_('What the nftables Sets currently hold. Counters are reset whenever an entry is refreshed, so they show recent activity, not a lifetime total.'))
+			]),
+			E('div', { 'id': 'shunt-sets' }, ''),
+			E('div', { 'class': 'cbi-page-actions' }, [
+				E('select', {
+					'id': 'shunt-policy',
+					'class': 'cbi-input-select',
+					'style': 'float:none;margin-right:.4em;width:auto;',
+					'change': ui.createHandlerFn(self, reload)
+				}, options),
+				E('button', {
+					'class': 'btn cbi-button cbi-button-action important',
+					'style': 'float:none',
+					'click': ui.createHandlerFn(self, reload)
+				}, [_('Refresh')])
+			])
+		]);
+
+		requestAnimationFrame(function () {
+			render_sets(result[1]);
+		});
+
+		return page;
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/applications/luci-app-shunt/po/templates/shunt.pot
+++ b/applications/luci-app-shunt/po/templates/shunt.pot
@@ -1,0 +1,532 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:319
+msgid "%d name(s) every %ds"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:165
+msgid ""
+"%d of %d observed responses were not used. That is normal: the observer sees "
+"every answer on the network, and only the ones for a domain you routed are "
+"of any interest."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:85
+msgid "%d pkt matched"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:27
+msgid "%dh %dm"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:31
+msgid "%dm %ds"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:33
+msgid "%ds"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:45
+msgid "Add policy"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:134
+msgid "Address"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:97
+msgid "Answer carried no usable address"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:160
+msgid "Answers used for a policy"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:78
+msgid "Block the traffic (killswitch)"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:137
+msgid "Bytes routed"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:87
+msgid "Client MACs this policy applies to, ORed with the addresses above."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:178
+msgid "Client Selectors"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:82
+msgid ""
+"Client addresses or prefixes this policy applies to. Leave empty to apply to "
+"every client."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:105
+msgid "Compression pointer in the question"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:368
+msgid "DNS Observer Settings"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:155
+msgid "DNS responses observed on %s since the service started"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:374
+msgid "Debug Logging"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:102
+msgid "Destination Addresses"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:97
+msgid "Destination Ports"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:103
+msgid "Destination addresses or prefixes to route into this policy."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:95
+msgid "Domain is in no policy"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:107
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:371
+msgid "Enable the shunt service."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:370
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:60
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:387
+msgid "Entry Lifetime"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:99
+msgid "Error reply, e.g. NXDOMAIN"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:38
+msgid ""
+"Evaluated top to bottom - the first policy a packet matches wins. Within one "
+"policy the selectors are ANDed: source plus domain means only that client, "
+"and only to those domains."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:135
+msgid "Expires"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:117
+msgid "Extension header chain too long"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:77
+msgid "Fall through to the normal uplink"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:183
+msgid "Fallback"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:76
+msgid "Fallback Behavior"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:112
+msgid "Frame ends mid-structure"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:367
+msgid "General Settings"
+msgstr ""
+
+#: applications/luci-app-shunt/root/usr/share/rpcd/acl.d/luci-app-shunt.json:3
+msgid "Grant access to LuCI app shunt"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:116
+msgid "IP fragment"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:112
+msgid "IPv4 Gateway Override"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:118
+msgid "IPv6 Gateway Override"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:115
+msgid "Inconsistent IP header length"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:119
+msgid "Inconsistent UDP length"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:178
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:65
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:341
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:126
+msgid "Learned addresses"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:153
+msgid "Learned addresses (%d)"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:375
+msgid ""
+"Log every observed DNS answer and every set write. Useful for a bug report, "
+"noisy in normal operation - on a router running adblock roughly half of all "
+"answers are error replies, and each one gets a line."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:378
+msgid "Manage rp_filter"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:179
+msgid "Mark"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:103
+msgid "Message ends mid-structure"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:104
+msgid "Message too long"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:108
+msgid "Name has a byte outside a-z 0-9 - _"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:107
+msgid "Name too long"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:113
+msgid "Neither IPv4 nor IPv6"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/logtemplate.js:33
+msgid "No %s related logs yet!"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:179
+msgid "No client is selected, so every client is covered."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:172
+msgid "No policy is active."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:232
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:31
+msgid "No shunt config found!"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:118
+msgid "Not UDP"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:100
+msgid "Not a response"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:96
+msgid "Not an address query"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:102
+msgid "Not exactly one question"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:127
+msgid ""
+"Nothing learned yet. The service fills these from its poll cycle and from "
+"observed DNS answers."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:407
+msgid "Observed Devices"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:113
+msgid ""
+"Only needed when the gateway discovered from netifd is wrong. Point to point "
+"interfaces need no gateway at all."
+msgstr ""
+
+#: applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json:23
+msgid "Overview"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:136
+msgid "Packets routed"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:402
+msgid "Passive DNS Observer"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:37
+#: applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json:31
+msgid "Policies"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:177
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:133
+msgid "Policy"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:239
+msgid ""
+"Policy based routing by mac, source, destination and domain. For further "
+"information please check the %s."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:344
+msgid "Poll"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:382
+msgid "Poll Interval"
+msgstr ""
+
+#: applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json:47
+msgid "Processing Log"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:91
+msgid "Protocols"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:403
+msgid ""
+"Read DNS answers as they pass the LAN device, whichever resolver produced "
+"them. Required for wildcard domains, which cannot be resolved ahead of time."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:109
+msgid "Record length does not fit the type"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:249
+msgid "Refresh"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:213
+msgid "Rejected settings"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:106
+msgid "Reserved label type"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:92
+msgid "Restrict to tcp, udp or both. A port without a protocol covers both."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:304
+msgid "Reverse path filtering is strict"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:182
+msgid "Routes"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:181
+msgid "Rules"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:431
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:133
+msgid "Save & Restart"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:388
+msgid ""
+"Seconds a learned address stays in its Set. Keep this well above the poll "
+"interval."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:383
+msgid "Seconds between poll cycles."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:336
+msgid "Service"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:232
+#: applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json:39
+msgid "Set Reporting"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:379
+msgid ""
+"Set rp_filter to 2 on shunt's own policy interfaces, at start and when one "
+"comes up."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:364
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:396
+msgid ""
+"Should be at least twice the poll interval (%d), otherwise entries expire "
+"between cycles."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:98
+msgid "Single ports or ranges like 8000-8080, ANDed with the addresses below."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:81
+msgid "Source Addresses"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:86
+msgid "Source MAC Addresses"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:180
+msgid "Static Destinations"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:424
+msgid "Stop"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:306
+msgid ""
+"Strict rp_filter will drop shunt's marked traffic on %s. Set rp_filter to 2 "
+"on the policy interface, enable rp_filter_manage to have shunt do it, or "
+"loosen it box-wide; see the README."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:180
+msgid "Table"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:408
+msgid ""
+"The LAN device the DNS answers cross on their way to the clients, normally "
+"br-lan. One entry per network segment, see the README."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:66
+msgid ""
+"The device or logical interface this policy routes into. A netifd name is "
+"resolved to its device; any other device name is used as entered."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/logtemplate.js:44
+msgid "The syslog output, pre-filtered for messages related to: %s"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:215
+msgid ""
+"These entries were skipped. Everything else was applied - a rejected entry "
+"never takes the service down."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:110
+msgid "Too many answers"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:114
+msgid "Too many stacked VLAN tags"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:101
+msgid "Truncated response"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:338
+msgid "Version"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:235
+msgid ""
+"What the nftables Sets currently hold. Counters are reset whenever an entry "
+"is refreshed, so they show recent activity, not a lifetime total."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:343
+msgid "across all policies"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/setreport.js:192
+msgid "all policies"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:108
+msgid ""
+"example.com matches that name only, *.example.com matches its subdomains but "
+"not the apex - list both to cover both."
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/policies.js:72
+msgid "interface"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:314
+msgid "n/a"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:65
+msgid "no answer from the backend"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:240
+msgid "online documentation"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:83
+msgid "ruleset present, service not running"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:77
+msgid "running, but no ruleset in the kernel"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:71
+msgid "running, policy applied"
+msgstr ""
+
+#: applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json:3
+msgid "shunt"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:88
+msgid "stopped"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:320
+msgid "unavailable - ucode-mod-resolv missing"
+msgstr ""
+
+#: applications/luci-app-shunt/htdocs/luci-static/resources/view/shunt/overview.js:345
+msgid "wildcards are covered by the observer only"
+msgstr ""

--- a/applications/luci-app-shunt/root/etc/uci-defaults/95-luci-app-shunt-housekeeping
+++ b/applications/luci-app-shunt/root/etc/uci-defaults/95-luci-app-shunt-housekeeping
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -f /var/luci-indexcache.*.json
+[ -x "/etc/init.d/rpcd" ] && /etc/init.d/rpcd reload
+exit 0

--- a/applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json
+++ b/applications/luci-app-shunt/root/usr/share/luci/menu.d/luci-app-shunt.json
@@ -1,0 +1,54 @@
+{
+	"admin/services/shunt": {
+		"title": "shunt",
+		"order": "65",
+		"action": {
+			"type": "alias",
+			"path": "admin/services/shunt/overview"
+		},
+		"depends": {
+			"acl": [
+				"luci-app-shunt"
+			],
+			"fs": {
+				"/usr/sbin/shunt": "executable",
+				"/etc/init.d/shunt": "executable"
+			},
+			"uci": {
+				"shunt": true
+			}
+		}
+	},
+	"admin/services/shunt/overview": {
+		"title": "Overview",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "shunt/overview"
+		}
+	},
+	"admin/services/shunt/policies": {
+		"title": "Policies",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "shunt/policies"
+		}
+	},
+	"admin/services/shunt/setreport": {
+		"title": "Set Reporting",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "shunt/setreport"
+		}
+	},
+	"admin/services/shunt/logread": {
+		"title": "Processing Log",
+		"order": 40,
+		"action": {
+			"type": "view",
+			"path": "shunt/logread"
+		}
+	}
+}

--- a/applications/luci-app-shunt/root/usr/share/rpcd/acl.d/luci-app-shunt.json
+++ b/applications/luci-app-shunt/root/usr/share/rpcd/acl.d/luci-app-shunt.json
@@ -1,0 +1,41 @@
+{
+	"luci-app-shunt": {
+		"description": "Grant access to LuCI app shunt",
+		"write": {
+			"uci": [
+				"shunt"
+			]
+		},
+		"read": {
+			"ubus": {
+				"luci.shunt": [
+					"status",
+					"sets"
+				],
+				"rpc-sys": [
+					"packagelist"
+				]
+			},
+			"uci": [
+				"shunt"
+			],
+			"file": {
+				"/etc/init.d/shunt stop": [
+					"exec"
+				],
+				"/etc/init.d/shunt start": [
+					"exec"
+				],
+				"/etc/init.d/shunt restart": [
+					"exec"
+				]
+			},
+			"cgi-io": [
+				"exec"
+			],
+			"log": [
+				"read"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Maintainer: @dibdot

Description:
Companion frontend for the shunt policy-based routing daemon (openwrt/packages#30365). Provides an overview with live service state, per-policy rule and route counters and learned-address totals, a policy editor covering all selectors (client address and MAC, destination, domain, port, protocol), set reporting with per-element counters, and a filtered processing log. Status data comes from a ucode rpcd object shipped with the base package.

🧪 Run Testing Details
Bananapi BPI-R3, mediatek/filogic, OpenWrt SNAPSHOT (r35906-3d1645ee26)
