### PR TITLE
themes: add granular individual classes to alerts

### DIFF
--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -55,7 +55,7 @@
 
 		<div id="maincontent" class="container">
 			{% if (getuid() == 0 && getspnam('root')?.pwdp === ''): %}
-				<div class="alert-message warning">
+				<div class="alert-message warning password-absent">
 					<h4>{{ _('No password set!') }}</h4>
 					<p>{{ _('There is no password set on this router. Please configure a root password to protect the web interface.') }}</p>
 					{% if (dispatcher.lookup("admin/system/admin")): %}
@@ -65,7 +65,7 @@
 			{% endif %}
 
 			{% if (boardinfo.rootfs_type == "initramfs"): %}
-				<div class="alert-message warning">
+				<div class="alert-message warning recovery-mode">
 					<h4>{{ _('System running in recovery (initramfs) mode.') }}</h4>
 					<p>{{ _('No changes to settings will be stored and are lost after rebooting. This mode should only be used to install a firmware upgrade') }}</p>
 					{% if (dispatcher.lookup("admin/system/flash")): %}
@@ -75,7 +75,7 @@
 			{% endif %}
 
 			<noscript>
-				<div class="alert-message warning">
+				<div class="alert-message warning js-required">
 					<h4>{{ _('JavaScript required!') }}</h4>
 					<p>{{ _('You must enable JavaScript in your browser or LuCI will not work properly.') }}</p>
 				</div>


### PR DESCRIPTION
## Pull request details

### Description
Putting this up for discussion - let me know if there's a better way to achieve this. I will do the same in the other themes if there's consensus.

This allows applications to control how specific alerts are displayed.

One example is an application which ships with its own flow for setting
a root password. It'd be confusing to show an alert on top of this flow,
which sends users to a different password flow.

Until now you'd need to fork the theme to achieve this.


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@jow- 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** snapshot
**LuCI version:** main
**Web browser(s):** Firefox
