### PR TITLE
luci-app-dockerman: handle Docker multiplexed stream logs

### DIFF
--- a/applications/luci-app-dockerman/htdocs/luci-static/resources/dockerman/api.js
+++ b/applications/luci-app-dockerman/htdocs/luci-static/resources/dockerman/api.js
@@ -116,6 +116,28 @@ function processLines(buffer, onChunk) {
 	return buffer;
 }
 
+// Parse the docker multiplexed stream format, https://docs.docker.com/reference/api/engine/version/v1.43/#stream-format
+function parse_multiplexed_stream(buffer) {
+	const output = [];
+	// Only three stream types are defined: 0=stdin, 1=stdout, 2=stderr.
+	const decoders = [new TextDecoder(), new TextDecoder(), new TextDecoder()];
+
+	while (buffer.length > 0) {
+		if (buffer.length < 8) break; // Not enough data for header
+		let stream_type = buffer[0];
+		let payload_length = ((buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7]) >>> 0; // Convert to unsigned
+		if (buffer.length < 8 + payload_length) break; // Not enough data for payload
+		if (stream_type <= 2) {
+			let payload = buffer.subarray(8, 8 + payload_length);
+			output.push({ type: stream_type, payload: decoders[stream_type].decode(payload, { stream: true }) });
+		} else {
+			console.warn(`Unknown stream type ${stream_type} in multiplexed stream, ignoring`);
+		}
+		buffer = buffer.subarray(8 + payload_length);
+	}
+
+	return output;
+}
 
 function call_docker(method, path, options = {}) {
 	return loadPromise.then(() => {
@@ -221,6 +243,17 @@ function call_docker(method, path, options = {}) {
 				const headersObj = {};
 				for (const [key, value] of response.headers.entries()) {
 					headersObj[key] = value;
+				}
+
+				if ("application/vnd.docker.multiplexed-stream" === headersObj['content-type']) {
+					return response.arrayBuffer().then(buffer => {
+						const parsed = parse_multiplexed_stream(new Uint8Array(buffer));
+						return {
+							code: response.status,
+							body: parsed,
+							headers: headersObj,
+						};
+					});
 				}
 
 				return response.text().then(text => {

--- a/applications/luci-app-dockerman/htdocs/luci-static/resources/view/dockerman/container.js
+++ b/applications/luci-app-dockerman/htdocs/luci-static/resources/view/dockerman/container.js
@@ -1685,7 +1685,12 @@ return dm2.dv.extend({
 					return false;
 				}
 
-				const logText = response?.body || _('No logs available');
+				let logText = response?.body;
+				if ("application/vnd.docker.multiplexed-stream" === response?.headers?.['content-type']) {
+					logText = (response?.body || []).map(frame => frame.payload).join('');
+				}
+				logText = logText || _('No logs available');
+
 				// Convert ANSI codes to HTML and set innerHTML
 				logsDiv.innerHTML = dm2.ansiToHtml(logText);
 				logsDiv.scrollTop = logsDiv.scrollHeight;

--- a/applications/luci-app-dockerman/root/usr/share/rpcd/ucode/docker_rpc.uc
+++ b/applications/luci-app-dockerman/root/usr/share/rpcd/ucode/docker_rpc.uc
@@ -100,6 +100,23 @@ function coerce_values_to_string(obj) {
 	return obj;
 };
 
+// Parse the docker multiplexed stream format, https://docs.docker.com/reference/api/engine/version/v1.43/#stream-format
+function parse_multiplexed_stream(buffer) {
+	let output = [];
+
+	while (length(buffer) > 0) {
+		if (length(buffer) < 8) break; // Not enough data for header
+		let stream_type = ord(buffer, 0);
+		let payload_length = ord(buffer, 4) << 24 | ord(buffer, 5) << 16 | ord(buffer, 6) << 8 | ord(buffer, 7);
+		if (length(buffer) < 8 + payload_length) break; // Not enough data for payload
+		let payload = substr(buffer, 8, payload_length);
+		push(output, { type: stream_type, payload: payload });
+		buffer = substr(buffer, 8 + payload_length);
+	}
+
+	return output;
+};
+
 function call_docker(method, path, options) {
 	options = options || {};
 	const headers = options.headers || {};
@@ -277,6 +294,8 @@ function call_docker(method, path, options) {
 		} else {
 			response_body = data;
 		}
+	} else if (response_headers['content-type'] === 'application/vnd.docker.multiplexed-stream' && response_body) {
+		response_body = parse_multiplexed_stream(response_body);
 	}
 
 	return {


### PR DESCRIPTION
Docker API can return container logs using the
application/vnd.docker.multiplexed-stream format [1].
The response consists of framed stdout/stderr records rather than plain text.

Currently these responses are not decoded correctly, resulting in
garbled or missing log output.

Parse the multiplexed stream format in both the ucode RPC handler and the
LuCI API client, then combine the frame payloads before passing the logs
to the existing ANSI-to-HTML renderer.

[1] https://docs.docker.com/reference/api/engine/version/v1.43/#stream-format

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
`docker.container logs` does not work with "application/vnd.docker.multiplexed-stream" response.

1. Create a container **without pseudo-TTY (`-t`)** `docker run --name testlog alpine ls -la`
2. Run `ubus call docker.container logs '{"id":"testlog","query":{"stdout":true,"stderr":true,"tail":100}}'`

Before this patch:
```json
{
        "code": 200,
        "headers": {
                "api-version": "1.47",
                "content-type": "application/vnd.docker.multiplexed-stream",
                "docker-experimental": "false",
                "ostype": "linux",
                "server": "Docker/27.3.1 (linux)",
                "date": "Mon, 24 Aug 2026 13:15:12 GMT",
                "connection": "close",
                "transfer-encoding": "chunked"
        },
        "body": "\u0001"
}
```

After patch:
```json
{
        "code": 200,
        "headers": {
                "api-version": "1.47",
                "content-type": "application/vnd.docker.multiplexed-stream",
                "docker-experimental": "false",
                "ostype": "linux",
                "server": "Docker/27.3.1 (linux)",
                "date": "Mon, 24 Aug 2026 13:16:07 GMT",
                "connection": "close",
                "transfer-encoding": "chunked"
        },
        "body": [
                {
                        "type": 1,
                        "payload": "total 64\n"
                },
                {
                        "type": 1,
                        "payload": "drwxr-xr-x    1 root     root          4096 Aug 24 12:29 .\n"
                },
                {
                        "type": 1,
                        "payload": "drwxr-xr-x    1 root     root          4096 Aug 24 12:29 ..\n"
                },
                {
                        "type": 1,
                        "payload": "-rwxr-xr-x    1 root     root             0 Aug 24 12:29 .dockerenv\n"
                },
                {
                        "type": 1,
                        "payload": "drwxr-xr-x    2 root     root          4096 Oct  8  2025 bin\n"
                },
               ...
        ]
}
```


### Screenshot or video of changes _(if applicable)_
Before:
<img width="1692" height="840" alt="image" src="https://github.com/user-attachments/assets/b292aa67-1c15-4068-a3a6-79509c22f5c4" />

After:
<img width="1676" height="1522" alt="image" src="https://github.com/user-attachments/assets/37654863-bf71-4bef-92dc-895098daf591" />

### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.5 <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** LuCI openwrt-25.12 branch <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Chrome 151.0.7922.76 <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

(Both JS API and RPC were tested)

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
