### PR TITLE
luci-app-dockerman: fix whitespace rendering in container logs

### DIFF
--- a/applications/luci-app-dockerman/htdocs/luci-static/resources/view/dockerman/container.js
+++ b/applications/luci-app-dockerman/htdocs/luci-static/resources/view/dockerman/container.js
@@ -1190,7 +1190,7 @@ return dm2.dv.extend({
 				]),
 				E('div', {
 					'id': 'container-logs-text',
-					'style': 'width: 100%; font-family: monospace; padding: 10px; border: 1px solid #ccc; overflow: auto;',
+					'style': 'width: 100%; font-family: monospace; padding: 10px; border: 1px solid #ccc; overflow: auto; white-space: pre-wrap;',
 					'innerHTML': ''
 				})
 			]);


### PR DESCRIPTION
Container logs contain significant whitespace, which gets collapsed by
normal HTML rendering, and that "white-space: pre-wrap;" preserves
that whitespace while still allowing long lines to wrap.

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
Fix logs missing spacebar on render.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->
Before:
<img width="1694" height="1238" alt="image" src="https://github.com/user-attachments/assets/b4af104b-0e28-47c6-af55-dd1da7cfe7f2" />

After:
<img width="1640" height="1346" alt="image" src="https://github.com/user-attachments/assets/57adb0e7-08cd-43fa-b7c1-2de77f6ee6aa" />


### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** OpenWrt 25.12.5 <!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** LuCI openwrt-25.12 branch <!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Chrome 151.0.7922.76 <!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
