### PR TITLE
luci-theme-footstrap: keep the reader's place on every engine

### DIFF
--- a/themes/luci-theme-footstrap/htdocs/luci-static/footstrap/cascade.css
+++ b/themes/luci-theme-footstrap/htdocs/luci-static/footstrap/cascade.css
@@ -295,6 +295,7 @@ to{opacity:1;transform:none}
 [data-darkmode="true"] [data-page="admin-statistics-graphs"] [data-plugin] img{filter:invert(100%) hue-rotate(180deg)}
 #view div[style] > svg{background-color:var(--fs-panel)}
 #view div[style] > svg line[style]{stroke:var(--fs-text) !important}
+#view div[style] > svg text[style]{fill:var(--fs-text) !important;text-shadow:none !important;font-weight:var(--fs-weight-bold)}
 }
 @layer theme{:where([data-fs-chrome]:not([data-fs-chrome] *)){font-style:normal;font-variant:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;text-indent:0;text-align:start;cursor:auto}
 .fs-brand{display:flex;align-items:center;gap:var(--fs-space-2-5);color:var(--fs-text);font-weight:var(--fs-weight-bold)}
@@ -465,6 +466,8 @@ footer a:hover{color:var(--fs-accent)}
 .cbi-value-field > .cbi-progressbar::after{inset-inline:calc(100% + var(--fs-space-2)) auto;bottom:auto;top:50%;transform:translateY(-50%)}
 .cbi-section .table:has(.tr.table-titles) .td .cbi-progressbar{margin-inline-end:var(--fs-meter-value);--fs-meter-value:var(--fs-space-10);min-width:60px}
 .cbi-section .table:has(.tr.table-titles) .td .cbi-progressbar::after{inset-inline:calc(100% + var(--fs-space-2)) auto;bottom:auto;top:50%;transform:translateY(-50%)}
+.cbi-section .table.fs-stacked:has(.tr.table-titles) .td .cbi-progressbar{margin-inline-end:0;margin-block-start:calc(var(--fs-type-xs) * var(--fs-leading))}
+.cbi-section .table.fs-stacked:has(.tr.table-titles) .td .cbi-progressbar::after{inset-inline:auto 0;bottom:calc(100% + var(--fs-space-1));top:auto;transform:none}
 .cbi-section .table:not([id]):not(.cbi-section-table) .tr:has(.cbi-progressbar) .td{vertical-align:middle}
 }
 @layer theme{.cbi-section,.cbi-map > .cbi-section-node,fieldset.cbi-section,.panel{background:var(--fs-panel);border:var(--fs-hairline);border-radius:var(--fs-radius-lg);box-shadow:var(--fs-shadow)}
@@ -473,6 +476,8 @@ legend{font-size:var(--fs-type-lg);font-weight:var(--fs-weight-bold);color:var(-
 .cbi-section > .cbi-title{margin-bottom:var(--fs-space-3)}
 .cbi-section > .cbi-title h3,.cbi-section > h3:first-child,.cbi-section > legend{font-size:var(--fs-type-lg);font-weight:var(--fs-weight-bold);color:var(--fs-text);margin:0;padding:0;border:0}
 .cbi-section > h3:first-child,.cbi-section > legend{margin-bottom:var(--fs-space-3)}
+.cbi-section .table + h3{margin-top:var(--fs-space-5)}
+.cbi-section h3 + .table{margin-top:var(--fs-space-3)}
 .cbi-section .table:not([id]):not(.fs-dt),.cbi-section-node .table:not([id]):not(.fs-dt),.cbi-modal .table,.table .table,.cbi-value .table{border:0;border-radius:0;overflow:visible;background:none}
 .cbi-section .table{margin:0;width:100%}
 .table.cbi-section-table input[type="password"],.table.cbi-section-table input[type="text"],.table.cbi-section-table textarea,.table.cbi-section-table select,.table.cbi-section-table .cbi-select{width:100%;min-width:auto}
@@ -634,7 +639,9 @@ h6{font-size:var(--fs-type-xs);color:var(--fs-dim);text-transform:uppercase}
 .cbi-map > h2:has(+ .cbi-map-descr),#view > h2:has(+ .cbi-map-descr){border-bottom:0;border-radius:var(--fs-radius-lg) var(--fs-radius-lg) 0 0;padding-bottom:var(--fs-space-1);margin-bottom:0;box-shadow:none}
 .cbi-map > h2 + .cbi-map-descr,#view > h2 + .cbi-map-descr{background:var(--fs-panel);border:var(--fs-hairline);border-top:0;border-radius:0 0 var(--fs-radius-lg) var(--fs-radius-lg);box-shadow:var(--fs-shadow);margin:0 0 var(--fs-card-gap);padding:0 var(--fs-space-4) var(--fs-space-4);color:var(--fs-dim);font-size:var(--fs-type);line-height:var(--fs-leading)}
 #view :is(textarea,input[type="text"],input[type="password"],.cbi-dropdown) + .right{margin-top:var(--fs-space-2-5)}
-.cbi-title-buttons{margin-bottom:var(--fs-card-gap)}
+.cbi-title-buttons{margin-block:var(--fs-space-2) var(--fs-card-gap)}
+.cbi-section-remove{margin-bottom:var(--fs-space-2)}
+.cbi-map > *:not(.cbi-section):not(.cbi-map-descr):not(.cbi-page-actions):not(h2):not(legend):not(.cbi-tabmenu):not(.cbi-map-tabbed):not(:empty){margin-bottom:var(--fs-card-gap)}
 }
 @layer theme{:root[data-layout="top"] .fs-sidebar{min-height:var(--fs-bar-h);height:auto;gap:var(--fs-space-3);flex-wrap:nowrap;padding:0 max(20px,calc((100% - var(--fs-content-max)) / 2 + var(--fs-content-pad)));box-shadow:var(--fs-shadow-bar)}
 :root[data-layout="top"] .fs-sidebar ul.nav{order:2;flex:1 1 auto;margin-inline-start:var(--fs-space-2)}
@@ -947,9 +954,10 @@ input,textarea,select,.cbi-dropdown > ul > li{font-size:var(--fs-type-lg)}
 }
 }
 @layer page{.fs-login{width:min(400px,calc(100% - 32px));margin:7vh auto var(--fs-space-10);background:var(--fs-panel);border:var(--fs-hairline);border-radius:var(--fs-radius-lg);padding:var(--fs-space-6) var(--fs-space-6) var(--fs-space-6);box-shadow:var(--fs-shadow-pop)}
+.fs-login-host{margin:0 0 var(--fs-space-6);text-align:center;font-size:var(--fs-type-lg);font-weight:var(--fs-weight-bold);color:var(--fs-dim);overflow-wrap:anywhere}
 .fs-login .cbi-map,.fs-login .cbi-section,.fs-login .cbi-section-node{background:none;border:0;padding:0;margin:0;box-shadow:none}
-.fs-login .cbi-map > h2,.fs-login .cbi-map-descr{background:none;border:0;border-radius:0;box-shadow:none;padding:0}
-.fs-login .cbi-map > h2{font-size:var(--fs-type-xl);font-weight:var(--fs-weight-bold);letter-spacing:-.01em;margin:0 0 var(--fs-space-1-5)}
+.fs-login .cbi-map > h1,.fs-login .cbi-map-descr{background:none;border:0;border-radius:0;box-shadow:none;padding:0}
+.fs-login .cbi-map > h1{font-size:var(--fs-type-xl);font-weight:var(--fs-weight-bold);letter-spacing:-.01em;margin:0 0 var(--fs-space-1-5)}
 .fs-login .cbi-map-descr{color:var(--fs-dim);font-size:var(--fs-type);margin:0 0 var(--fs-space-5)}
 .fs-login .cbi-value{display:block;border:0;padding:0 0 var(--fs-space-4);margin:0}
 .fs-login .cbi-value-title{display:block;text-align:start;width:auto;max-width:none;padding:0 0 var(--fs-space-1-5);font-size:var(--fs-type-xs);font-weight:var(--fs-eyebrow-weight);letter-spacing:var(--fs-eyebrow-tracking);text-transform:uppercase;color:var(--fs-eyebrow-color)}
@@ -972,20 +980,18 @@ body[data-page="admin-status-overview"] #view > h2[name="content"],body[data-pag
 @container fs-view (max-width:800px){.fs-ovl{grid-template-columns:1fr}
 .fs-ovl > .fs-ovl-sys,.fs-ovl > .fs-ovl-mem,.fs-ovl > .fs-ovl-sto{grid-column:1;grid-row:auto}
 }
-body[data-page="admin-status-overview"] div:has(> .ifacebox img[src*="/port_"]){gap:var(--fs-space-2-5);grid-template-columns:repeat(auto-fit,minmax(126px,200px)) !important;margin-bottom:0 !important}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]){margin:0 !important;min-width:0 !important;max-width:none !important;width:auto !important;justify-self:stretch;align-self:stretch;text-align:start;background:var(--fs-panel2);border:var(--fs-hairline);border-radius:var(--fs-radius-lg);padding:var(--fs-space-2) var(--fs-space-3);display:flex;flex-direction:row;flex-wrap:wrap;column-gap:var(--fs-space-2);row-gap:var(--fs-space-1);align-items:baseline}
+body[data-page="admin-status-overview"] div:has(> .ifacebox img[src*="/port_"]){gap:var(--fs-space-2);--fs-port-min:calc(76px * var(--fs-density-type) + var(--fs-space-3) * 2);grid-template-columns:repeat(auto-fit,minmax(var(--fs-port-min),1fr)) !important;margin-bottom:0 !important}
+body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]){margin:0 !important;min-width:0 !important;max-width:200px !important;width:auto !important;justify-self:stretch;align-self:stretch;text-align:start;background:var(--fs-panel2);border:var(--fs-hairline);border-radius:var(--fs-radius-lg);padding:var(--fs-space-1-5) var(--fs-space-3);display:flex;flex-direction:row;flex-wrap:wrap;column-gap:var(--fs-space-2);row-gap:0;align-items:baseline}
 body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) img{display:none}
 body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) .ifacebox-head{border-bottom:0;border-radius:0}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-head:nth-child(3){order:1;flex:0 0 100%;width:100%;margin:var(--fs-space-1) 0 var(--fs-space-1-5)}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-head:first-child{flex:0 0 auto;width:100%;display:flex;align-items:center;justify-content:space-between;gap:var(--fs-space-1-5);font-size:var(--fs-type);font-weight:var(--fs-weight);color:var(--fs-text)}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-head:first-child::after{content:"";width:8px;height:8px;border-radius:50%;background:var(--fs-good);flex:0 0 auto}
+body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-head:nth-child(3){order:1;flex:0 0 100%;width:100%;margin:var(--fs-space-0-5) 0 var(--fs-space-1)}
+body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-head:first-child{flex:0 0 auto;width:100%;min-width:0;overflow:hidden;text-overflow:ellipsis;line-height:var(--fs-leading);font-size:var(--fs-type);font-weight:var(--fs-weight);color:var(--fs-text)}
 body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]):has(img[src*="_down.svg"]) > .ifacebox-head:first-child{color:var(--fs-dim)}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]):has(img[src*="_down.svg"]) > .ifacebox-head:first-child::after{background:transparent;border:1.5px solid var(--fs-dim)}
 body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-body:nth-child(2){order:2;font-size:var(--fs-type);font-weight:var(--fs-weight);color:var(--fs-good);text-align:start;flex:1 1 auto;white-space:nowrap}
 body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-body:nth-child(2) br{display:none}
 body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]):has(img[src*="_down.svg"]) > .ifacebox-body:nth-child(2){color:var(--fs-dim)}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-body:nth-child(4){order:2;text-align:end;flex:1 0 auto}
-body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-body:nth-child(4) > .cbi-tooltip-container{font-family:var(--fs-font-mono);font-size:var(--fs-type-xs) !important;color:var(--fs-dim);line-height:var(--fs-leading);white-space:nowrap;text-align:end !important}
+body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-body:nth-child(4){order:2;text-align:end;flex:1 0 100%}
+body[data-page="admin-status-overview"] .ifacebox:has(img[src*="/port_"]) > .ifacebox-body:nth-child(4) > .cbi-tooltip-container{font-family:var(--fs-font-mono);font-size:calc(round(10px * var(--fs-density-type),1px)) !important;color:var(--fs-dim);line-height:var(--fs-leading-tight);white-space:nowrap;text-align:end !important}
 body[data-page="admin-status-overview"] .cbi-section .table:not(:has(.tr.table-titles)):has(.cbi-progressbar){display:block}
 body[data-page="admin-status-overview"] .cbi-section .table:not(:has(.tr.table-titles)) .tr:has(.cbi-progressbar){display:grid;grid-template-columns:minmax(0,1fr);gap:var(--fs-space-1) var(--fs-space-2-5);padding:var(--fs-space-1) 0 var(--fs-space-1-5);border:0;position:relative}
 body[data-page="admin-status-overview"] .cbi-section .table:not(:has(.tr.table-titles)) .tr:has(.cbi-progressbar):last-child{padding-bottom:var(--fs-space-0-5)}

--- a/themes/luci-theme-footstrap/htdocs/luci-static/resources/fs-appearance.js
+++ b/themes/luci-theme-footstrap/htdocs/luci-static/resources/fs-appearance.js
@@ -124,9 +124,51 @@ function build() {
 		node.addEventListener('widget-change', () => apply(w.getValue()));
 		return node;
 	};
+	/* THE ONE WIDGET THIS THEME CANNOT ASSUME, and the reason 23.05 is a supported release again.
+	 *
+	 * `ui.RangeSlider` arrived in 24.10. On 23.05 it is simply not there, and because this whole
+	 * panel is built inside one try/catch the miss took the ENTIRE Appearance tab with it — a
+	 * console line and an empty tab, reported from the field rather than by a gate, because no gate
+	 * had ever opened a 23.05 router.
+	 *
+	 * So the widget is used where it exists and reproduced where it does not: same DOM, same class
+	 * names (`.cbi-range-slider` and its value/units children are what theme/60-inputs.css dresses),
+	 * same two events, and the same base class — `ui.AbstractElement` is the name LuCI exports on
+	 * BOTH 23.05 and master, which is what makes `setUpdateEvents`/`setChangeEvents` available to
+	 * the copy. Nothing below this line knows which of the two it got.
+	 *
+	 * Kept deliberately smaller than upstream's: `calculate` is not reproduced, because no axis on
+	 * this page uses it. If one ever does, use the real widget's shape rather than growing this. */
+	const RangeSlider = ui.RangeSlider || ui.AbstractElement.extend({
+		__init__(value, options) {
+			this.value = value;
+			this.options = Object.assign({ min: 0, max: 100, step: 1, calcunits: null }, options);
+		},
+		render() {
+			this.sliderEl = E('input', {
+				type: 'range', min: this.options.min, max: this.options.max,
+				step: this.options.step || 'any', value: this.value
+			});
+			this.valueEl = E('output', { class: 'cbi-range-slider-value' }, String(this.value));
+			const node = E('div', { class: 'cbi-range-slider' }, [
+				this.sliderEl,
+				this.valueEl,
+				this.options.calcunits ? E('span', { class: 'cbi-range-slider-calc-units' }, this.options.calcunits) : null
+			].filter(Boolean));
+			this.node = node;
+			this.setUpdateEvents(this.sliderEl, 'input', 'blur');
+			this.setChangeEvents(this.sliderEl, 'change');
+			this.sliderEl.addEventListener('input', () => { this.valueEl.textContent = this.sliderEl.value; });
+			dom.bindClassInstance(node, this);
+			return node;
+		},
+		getValue() { return this.sliderEl.value; },
+		setValue(value) { this.sliderEl.value = value; this.valueEl.textContent = value; }
+	});
+
 	const sliderCtl = (current, min, max, apply, label, opts) => {
 		const o = opts || {};
-		const w = new ui.RangeSlider(String(current), {
+		const w = new RangeSlider(String(current), {
 			min: min, max: max, step: o.step || 1, calcunits: o.unit || null
 		});
 		const node = w.render();

--- a/themes/luci-theme-footstrap/htdocs/luci-static/resources/fs-fit.js
+++ b/themes/luci-theme-footstrap/htdocs/luci-static/resources/fs-fit.js
@@ -226,15 +226,24 @@ function scrollTop() {
 }
 
 function scrolling() { return Date.now() < _movingUntil; }
+/* how many times the offset has moved in this stretch: >1 is a scroll, 1 is a compensation */
+let _steps = 0;
 
 function sampleMotion() {
 	const y = scrollTop();
 	if (_lastOffset === null || y !== _lastOffset) {
+		/* HOW MANY TIMES the offset has moved inside this stretch of movement, not just that it did.
+		 * One step is what a compensation looks like — the engine puts the offset somewhere and it
+		 * stays there. A scroll is a SERIES. `lateDrift()` is the only caller that needs to tell the
+		 * two apart, and this is the cheapest thing that can: it is counted in a loop that already
+		 * runs, from a value it already reads. */
+		if (_lastOffset !== null) _steps++;
 		_lastOffset = y;
 		_movingUntil = Date.now() + SCROLL_IDLE;
 	}
 	if (scrolling()) { requestAnimationFrame(sampleMotion); return; }
 	_sampling = false;
+	_steps = 0;
 	/* the reader has stopped: this is a still moment, so the floor and the reference both belong to
 	 * where the page now stands */
 	holdFloor();
@@ -242,9 +251,18 @@ function sampleMotion() {
 	/* the page has held still for SCROLL_IDLE: whatever was put off may run now */
 	if (_deferred) {
 		_deferred = false;
-		const ref = anchorRef();
+		/* NO CORRECTION FOR THIS BATCH, and that is deliberate. What runs here is work the fitters
+		 * put off because the reader was moving; the page they are about to change is a page the
+		 * reader has just scrolled through, and the two references available are both wrong for it.
+		 * A FRESH one describes the page after the scroll — against an offset WebKit may not have
+		 * laid out yet, which made the theme undo the reader's own move (measured at 1440, top,
+		 * Compact: parked at 591, put back to 0). The one from the last STILL page describes where
+		 * the reader was before the flick, and correcting to it drags them back there — the gate
+		 * caught exactly that as a 231px jump landing inside a scroll, on all three engines. Nothing
+		 * here is a poll tick: the fitters do not grow the page under anybody, they re-measure what
+		 * the scroll already showed. The next mutation corrects against a reference taken while the
+		 * page was still, which is the one that is true. */
 		run();
-		scheduleAnchor(ref);
 	}
 }
 
@@ -259,12 +277,26 @@ function noteMotion() {
  * and `scroll` does not bubble from an element — it only travels down the capture phase, which is
  * how the sidebar layout's inner scroller is seen as well as the document. The events only START
  * the sampler; whether the page is still moving is the sampler's answer, not theirs. */
+/* IS THE READER DRIVING, as opposed to the page moving?
+ *
+ * `scrolling()` above cannot tell those apart, and must not: every pass that reads layout has to
+ * stay out of a moving page whoever is moving it. `lateDrift()` asks the other question — a scroll
+ * offset that changed because the ENGINE compensated a mutation is precisely what it exists to
+ * inspect, and gating it on `scrolling()` made it fire never (measured: `late:busy` on every tick,
+ * because the engine's own correction starts the motion sampler). A gesture is what says the reader
+ * is driving, so the gesture is what it asks about. `mousedown` is in the list for the scrollbar
+ * thumb and `keydown` for Page Down, neither of which produces a wheel or a touch. */
+let _userUntil = 0;
+function noteUser() {
+	_userUntil = Date.now() + SCROLL_IDLE;
+	noteMotion();
+}
+
 (function watchMotion() {
 	const opts = { passive: true, capture: true };
 	window.addEventListener('scroll', noteMotion, opts);
-	window.addEventListener('wheel', noteMotion, opts);
-	window.addEventListener('touchstart', noteMotion, opts);
-	window.addEventListener('touchmove', noteMotion, opts);
+	for (const name of [ 'wheel', 'touchstart', 'touchmove', 'mousedown', 'keydown' ])
+		window.addEventListener(name, noteUser, opts);
 })();
 
 /* Next frame, at most once per frame (rule 3). */
@@ -346,7 +378,9 @@ function watch(el) {
  * a drift under a pixel is rounding rather than movement. */
 /* DOES THE ENGINE ANCHOR AT ALL? Chromium and Firefox compensate a height change above the viewport
  * by themselves — the reader stays where they were and the scroll offset moves under them. WebKit
- * has never implemented it, so on Safari and on every iPhone the same poll tick moves the page:
+ * did not implement it until recently, so on an older Safari and on every iPhone of that vintage the
+ * same poll tick moves the page (a current WebKit anchors, and gets the COLLAPSE case wrong instead —
+ * lateDrift() below):
  * measured with the engine's anchoring suppressed, a 120px growth above the fold moves the reader
  * 120px, and 0px with it on.
  *
@@ -389,13 +423,24 @@ function forgetRest() {
 	_restPage = null;
 }
 function rememberRest() {
-	if (ENGINE_ANCHORS || scrolling()) return;
+	if (scrolling()) return;
+	/* A PAGE AT THE TOP HAS NOTHING TO BE PUT BACK TO, so it does not pay for a reference. Every
+	 * correction here gives back offset the reader lost; at offset 0 there is none to lose, and the
+	 * hit test plus rect that anchorRef() costs (0.2ms typical, 6ms worst on a poll-dirtied WebKit
+	 * layout, measured on the stands) buys nothing. The offset is still remembered — it is one read,
+	 * and `anchorFor()`'s clamp test is written in terms of it. */
+	if (ENGINE_ANCHORS && scrollTop() <= 0) {
+		_rest = null;
+		_restAt = 0;
+		_restPage = pageStamp();
+		return;
+	}
 	const ref = anchorRef();
 	/* the offset it was taken at travels with it: a reference is only about the page, and the page
 	 * moving under the reader is a different fact from the reader moving through it */
 	_restAt = scrollTop();
 	_restPage = pageStamp();
-	_rest = ref ? { el: ref.el, top: ref.top, at: _restAt } : null;
+	_rest = ref ? { el: ref.el, top: ref.top, at: _restAt, sec: ref.sec, secTop: ref.secTop } : null;
 }
 
 /* -> the reference to correct against: the pre-mutation one where the engine leaves that to us, the
@@ -428,8 +473,14 @@ function anchorFor() {
 	 * is shorter now, the browser clamps the write straight back and the reader keeps the offset they
 	 * already had. The element path below stays preferred where it survives, because it compensates
 	 * the height change the tick brought with it as well. */
-	if (!_rest || !_rest.el.isConnected)
-		return clamped ? { by: _restAt - at } : anchorRef();
+	if (!_rest || !_rest.el.isConnected) {
+		if (clamped) return { by: _restAt - at };
+		/* the element is gone but its section is not — see anchorRef() for why that is the common
+		 * case rather than an edge one */
+		if (_rest && _rest.sec && _rest.sec.isConnected && at === _restAt)
+			return { el: _rest.sec, top: _rest.secTop, slack: 0 };
+		return anchorRef();
+	}
 	/* THE READER MOVED, NOT THE PAGE. A reference taken at one offset says nothing about a document
 	 * seen from another: correcting against it would drag the page back to where the reader had
 	 * scrolled FROM. So an offset that is not the one the reference was captured at normally means
@@ -455,7 +506,15 @@ function anchorFor() {
 	 *
 	 * Measured on the same harness with the reader flicking while the swap lands: the theme writes
 	 * no offset at all, before this change and after it. */
-	if (at !== _rest.at && !clamped) return anchorRef();
+	/* THE READER MOVED, SO THERE IS NOTHING TO PUT BACK — and taking a fresh reference here is worse
+	 * than taking none. `anchorRef()` reads a rect, and a scroll that has only just landed leaves
+	 * WebKit reporting the NEW `scrollTop` against the OLD layout: the reference then describes the
+	 * page from before the scroll, the correction a frame later measures the scroll itself, and the
+	 * reader is dragged back to where they started. Measured on the 24.10 stand at 1440, top layout,
+	 * Compact density: parked at 591, put back to 0, every run, on both the engine-anchoring path and
+	 * the fallback. A tick that lands right after a scroll compensates nothing; the next still moment
+	 * takes a reference that is true. */
+	if (at !== _rest.at && !clamped) return null;
 	/* HOW MUCH OF THE DRIFT IS ALREADY ACCOUNTED FOR. applyAnchor() refuses a correction bigger than
 	 * a viewport because a drift that size normally means the view replaced its whole subtree and
 	 * the reference is describing a page that no longer exists. A clamp is the one drift that big
@@ -496,15 +555,65 @@ function anchorRef() {
 	let y = 1;
 	let el = document.elementFromPoint(x, y);
 	const chrome = el && el.closest ? el.closest('[data-fs-chrome]') : null;
-	if (chrome) {
-		y = Math.max(1, Math.round(chrome.getBoundingClientRect().bottom) + 1);
-		el = document.elementFromPoint(x, y);
-	}
-	if (!el || !host.contains(el)) return null;
+	if (chrome) y = Math.max(1, Math.round(chrome.getBoundingClientRect().bottom) + 1);
+
+	/* THE HIT IS A SEARCH, NOT A SINGLE PROBE, and neither the host nor anything outside it counts.
+	 *
+	 * `elementFromPoint` answers with whatever is topmost, and two of those answers are useless here.
+	 * `#view` itself comes back wherever the point lands in a GAP — the margin between two sections,
+	 * the gutter of the Overview's two-column grid — and the host's own top does not move when a poll
+	 * changes something inside it, so a drift measured against it is zero on every tick, for ever.
+	 * And a point above the first section answers with `.fs-content`, which is not inside the host at
+	 * all: the first version returned null there without trying anywhere else, so on 25.12's Overview
+	 * at 1440 the theme had no reference AT ALL and a 120px growth moved the page 120px.
+	 *
+	 * So: take the whole STACK at the point (what a gap belongs to is directly underneath it), and if
+	 * that yields nothing inside the host, step down the viewport and ask again. */
+	const floor = Math.max(1, Math.round(window.innerHeight || 800));
+	const pick = (yy) => {
+		if (typeof document.elementsFromPoint === 'function') {
+			for (const cand of document.elementsFromPoint(x, yy))
+				if (cand !== host && host.contains(cand)) return cand;
+			return null;
+		}
+		const one = document.elementFromPoint(x, yy);
+		return (one && one !== host && host.contains(one)) ? one : null;
+	};
+	el = null;
+	for (let step = 0; step < 5 && !el; step++)
+		el = pick(Math.min(floor - 1, y + (Math.round(floor * 0.12) * step)));
+	if (!el) return null;
 	const table = el.closest('.table.fs-dt');
-	if (table) el = table.parentElement;
-	if (!el || !host.contains(el)) return null;
-	return { el, top: el.getBoundingClientRect().top };
+	if (table) {
+		const up = table.parentElement;
+		el = (up && up !== host && host.contains(up)) ? up : table;
+	}
+	if (!el || el === host || !host.contains(el)) return null;
+	/* `getClientRects()`, not `offsetParent` plus a `getComputedStyle` fallback: the question is only
+	 * "is this box in the layout at all", an element the table gate is holding out of it has no rects,
+	 * and resolving style on every settled pass to learn that would cost more than the rect already
+	 * read above. A box with no rects reports a top of 0 — a reference to nowhere. */
+	if (!el.getClientRects().length) return null;
+	/* AND A SECOND REFERENCE THAT SURVIVES THE TICK. `dom.content()` replaces a section's CHILDREN,
+	 * so the element the hit landed on is usually gone by the time the correction runs — and where
+	 * the tick also grew the page, nothing was clamped either, so the "give back what the engine
+	 * took" path has no number and the theme takes a fresh reference and measures a drift of zero.
+	 * That is a section swap nobody compensates: measured on 25.12's Overview at 1440 with the
+	 * engine's anchoring suppressed, the page moved 136px under the reader.
+	 *
+	 * The wrapper is what survives — the stock poll refreshes a `.cbi-section` in place and never
+	 * rebuilds it — so it is kept alongside, and used only when the precise reference is gone. */
+	/* the nearest ANCESTOR that a tick does not replace — `closest()` on the element itself is not it:
+	 * where the hit already climbed to the `.cbi-section` (which is what happens on any page whose
+	 * section is one table), `closest('.cbi-section')` answers with that same element, and a fallback
+	 * that is the reference is no fallback at all. */
+	let keep = el.parentElement;
+	while (keep && keep !== host && !keep.classList.contains('cbi-section')
+			&& !keep.classList.contains('cbi-map') && !keep.classList.contains('fs-ovl'))
+		keep = keep.parentElement;
+	if (!keep || keep === host || !host.contains(keep)) keep = null;
+	return { el, top: el.getBoundingClientRect().top,
+		sec: keep, secTop: keep ? keep.getBoundingClientRect().top : 0 };
 }
 
 let _anchorPending = null;
@@ -517,6 +626,58 @@ function anchorEnabled() {
 	try { return localStorage.getItem('fsAnchor') !== 'off'; }
 	catch (e) { return true; }
 }
+/* ---- WHAT THE ENGINE'S OWN ANCHORING LEAVES BEHIND ----
+ *
+ * Scroll anchoring keeps a reference element still while things above it change size. It is not the
+ * same promise as "a section can vanish and come back": `dom.content()` — every LuCI poll — empties
+ * a container before it refills it, the offset is clamped into a document that is briefly shorter,
+ * and what the engine does on the way back is its own business. Chromium lands exactly where it
+ * started. WebKit OVERSHOOTS — measured on the 24.10 stand's Overview at 390 and at 1440, in both
+ * layouts: a swap that grew a section by 120px moved the offset by 180, so the reader ended 60px
+ * up the page on every tick. That is what a Safari user sees as the page creeping while they read.
+ *
+ * WHY THE OFFSET CANNOT ANSWER THIS, and why this is not a browser test. The first version compared
+ * the offset with what it had been and gave back the difference; it never fired, because the offset
+ * came back LARGER, not smaller. A `CSS.supports('overflow-anchor')` test cannot separate the two
+ * behaviours either — WebKit shipped the property, so every engine now claims it — and a synthetic
+ * probe that performs the collapse itself calls Firefox broken as well, because a real page puts
+ * layout and a frame between the collapse and the refill and a probe does not. Both were measured,
+ * both were wrong, and the second one cost Chromium and Firefox 15px of drift they did not have.
+ *
+ * So nothing is assumed: the element the reader was looking at is asked where it is now, TWO FRAMES
+ * after the mutation — long enough for the engine to have finished its own correction. An engine
+ * that got it right reports a drift of zero and this does nothing at all. What is left over is what
+ * nobody put back, and it is given back here. The same guards as the main correction: not while the
+ * reader scrolls, not across a navigation, and never more than a viewport — a drift that size means
+ * the reference is describing a page that no longer exists. */
+let _lateFrame = 0;
+function lateDrift(ref) {
+	/* the reference from BEFORE this tick, captured by the caller: `run()` re-remembers it on its way
+	 * through, and a reference taken after the mutation describes the page as the mutation left it —
+	 * the drift it would report is zero by construction */
+	if (_lateFrame || !ref) return;
+	_lateFrame = requestAnimationFrame(() => {
+		_lateFrame = requestAnimationFrame(() => {
+			_lateFrame = 0;
+			/* NOT `scrolling()`: the engine's own compensation moves the offset and therefore starts
+			 * the motion sampler, so gating on that skipped every tick this exists for (measured —
+			 * the check reported "busy" on all of them). Two narrower questions instead: is the
+			 * reader driving (a gesture), and is the offset STREAMING (moving repeatedly, which a
+			 * one-shot compensation never does but a scroll always does). Either one means hands off. */
+			if (!anchorEnabled() || Date.now() < _userUntil || (scrolling() && _steps > 1)) return;
+			if (!ref.el.isConnected || _restPage !== pageStamp()) return;
+			const drift = ref.el.getBoundingClientRect().top - ref.top;
+			if (Math.abs(drift) < 1) return;			/* the engine put it back */
+			if (Math.abs(drift) > (window.innerHeight || 800)) return;
+			const sc = scroller();
+			const at = sc ? sc.scrollTop : window.scrollY;
+			if (sc) sc.scrollTop = at + drift; else window.scrollTo(0, at + drift);
+			/* the write may have been clamped short; the reader is where they are now */
+			_restAt = scrollTop();
+		});
+	});
+}
+
 function scheduleAnchor(ref) {
 	if (!ref || !anchorEnabled()) return;
 	if (_anchorPending) return;
@@ -535,6 +696,13 @@ function scheduleAnchor(ref) {
 }
 function applyAnchor(ref) {
 	if (!ref) return;
+	/* NOT INTO A MOVING PAGE. The correction is scheduled from the mutation and applied a frame
+	 * later, and the reader can start scrolling in between — the reference is then describing a page
+	 * they have already left, and putting them back on it is the jump this whole file exists to
+	 * prevent. `anchorRef()` refuses to TAKE a reference during a flick for the same reason; nothing
+	 * refused to USE one, and the gate caught it as a 231px correction landing inside a scroll on
+	 * all three engines once the reference stopped being re-read at apply time. */
+	if (scrolling()) return;
 	/* through scroller(), not a second probe of its own: the two asked the same question in the
 	 * same two lines and could already answer differently within one frame */
 	const sc = scroller();
@@ -588,9 +756,28 @@ function observeContent() {
 		 * see anchorFor(): where the engine does no anchoring of its own that reference comes from
 		 * the last still moment, because by the time this callback runs the poll has already moved
 		 * the page */
-		const ref = anchorFor();
+		/* ONE CORRECTION PER ENGINE, and which one depends on whether the engine is doing the job.
+		 *
+		 * Where it anchors, the immediate correction is not just redundant, it is harmful: the
+		 * reference it uses is read HERE, in the same instant the poll mutated the page, and after a
+		 * scroll WebKit hands back the new `scrollTop` before the layout that goes with it. The drift
+		 * then measures the reader's own move and the correction undoes it — measured on the 24.10
+		 * stand at 1440 in the top layout at Compact: the page went back to 0 from 591, every run.
+		 * What that engine needs is the RESIDUE, two frames later, once its own anchoring has run
+		 * and the layout is settled — which is lateDrift().
+		 *
+		 * Where it does not anchor, nobody else will put the reader back within the frame, so the
+		 * immediate correction stays, measured against the reference from the last still page. */
+		const settled = _rest;
+		const ref = ENGINE_ANCHORS ? null : anchorFor();
 		run();
-		scheduleAnchor(ref);
+		/* one or the other, never a fallthrough from one to the other: where the engine does not
+		 * anchor, `anchorFor()` returning nothing means it has DECIDED not to correct this tick (the
+		 * reader moved, or there is no reference worth using), and handing that case to the deferred
+		 * path corrects it two frames later instead — measured as a 320px correction landing inside
+		 * a flick, on all three engines. */
+		if (ENGINE_ANCHORS) lateDrift(settled);
+		else scheduleAnchor(ref);
 	});
 	for (const host of [ document.getElementById('view') || document.body, document.getElementById('modal_overlay') ]) {
 		if (!host) continue;
@@ -637,6 +824,17 @@ return baseclass.extend({
 	 * read layout asks the first and calls the second; a pass that only writes does neither. */
 	scrolling,
 	deferMeasurement,
+
+	/* -> the offset this file last took a reference at, or null before it has taken one.
+	 *
+	 * FOR THE GATES, and it is not a convenience: every correction here is measured against a
+	 * reference captured while the page was still, so a probe that grows the page before that
+	 * reference exists measures the guard rather than the anchor. There is no way to ask that from
+	 * outside — "is it scrolling" answers a different question, and answers "no" both before the
+	 * motion sampler starts and after it finishes, which in WebKit are 1.5 seconds apart. Waiting a
+	 * flat interval instead made tools/scroll-anchor.mjs report a jump on every WebKit run and none
+	 * on the other two engines, with the theme identical on all three. */
+	restAt: () => _restAt,
 
 	/* "THE OFFSET IS MINE NOW, FORGET WHAT YOU REMEMBERED." Called by fs-router where it resets both
 	 * scrollers for an incoming page, and it is not a courtesy — without it the correction below

--- a/themes/luci-theme-footstrap/htdocs/luci-static/resources/fs-overview.js
+++ b/themes/luci-theme-footstrap/htdocs/luci-static/resources/fs-overview.js
@@ -53,6 +53,32 @@ function sectionTitle(sec) {
 /* the wrapper we built, so the poll-tick fast path costs one property read */
 let _wrapEl = null;
 
+/* A PORT NAME THE CARD HAD TO CUT IS STILL READABLE ON HOVER.
+ *
+ * styles/pages/20-overview.css clamps a port card's name to two lines with an ellipsis — that is
+ * what lets every card be 99px wide instead of as wide as the longest interface name on the device.
+ * The name is the one thing on the card that cannot be guessed from the rest of it, so the element
+ * carries its own full text as a native tooltip.
+ *
+ * NOTHING HERE READS LAYOUT. Asking "was this one actually truncated?" means `scrollHeight` against
+ * `clientHeight` per card, i.e. a forced synchronous layout inside the path a poll tick lands on
+ * every five seconds — and 29_ports.js REBUILDS these tiles on each of those ticks, so the question
+ * would be asked again every time. A title on a name that fits costs a tooltip repeating what is
+ * already on screen; a layout read here costs the page.
+ *
+ * It runs BEFORE arrange()'s fast path, and that is the point: the fast path returns as soon as the
+ * grid is intact, while the tiles under it are new elements with no attribute on them. */
+function nameTooltips(view) {
+	for (const icon of view.querySelectorAll('img[src*="/port_"]')) {
+		const head = icon.closest('.ifacebox')?.firstElementChild;
+		const name = head ? head.textContent.trim() : '';
+		/* `!==` so an unchanged name is not written back on every tick — a title write is cheap,
+		 * but a mutation of a node inside the tree we are observing is not. */
+		if (name && head.title !== name)
+			head.title = name;
+	}
+}
+
 function arrange() {
 	/* the SPA nav can leave this _observer wired while another page renders into #view — detach as
 	 * soon as the route stops being the overview. Both the server template and the SPA router
@@ -64,6 +90,8 @@ function arrange() {
 	}
 	const view = document.getElementById('view');
 	if (!view) return;
+
+	nameTooltips(view);
 
 	/* Fast path — the poll lands here once a second, forever. The stock poll never rebuilds the
 	 * .cbi-section wrappers, so the grid survives and there is nothing to do; proving that used

--- a/themes/luci-theme-footstrap/ucode/template/themes/footstrap/sysauth.ut
+++ b/themes/luci-theme-footstrap/ucode/template/themes/footstrap/sysauth.ut
@@ -24,12 +24,45 @@
  catalogue for.
 -#}
 
+{%
+	/* WHICH ROUTER THIS IS — requested as openwrt/luci#8961, by an admin coming from
+	   luci-theme-material, which prints the hostname in the top bar and therefore also on its login
+	   page. This one had no chrome at all (blank_page below), so the only place the name appeared
+	   was the browser TAB.
+
+	   A SECOND `ubus.call('system', 'board')`: header.ut makes its own inside its own scope and an
+	   include cannot hand a local back, so the choice is one extra ubus round trip on the login
+	   render or threading `boardinfo` out through a global. One call, on the one page that renders
+	   once per session, is the cheaper of the two.
+
+	   It discloses nothing new. The same `boardinfo.hostname` already reaches an unauthenticated
+	   browser through <title> (partials/head.ut) — as it does in every stock theme — so this moves
+	   a string that was always on the wire into the place a reader looks. */
+	const boardinfo = ubus.call('system', 'board') ?? {};
+-%}
+
 {% include('header', { blank_page: true }) %}
 
 {# The class is what 10-login.css hooks: the form used to be found by
    `form:has(> .cbi-map input[name="luci_username"])` — 49 characters written 17 times, ~0.8 KB —
    because the markup was assumed to be stock LuCI's. It is OURS: name the form instead. #}
 <form method="post" class="fs-login">
+	{#
+	 The router's name, above everything else in the card — an admin with three of these open has no
+	 other way to tell the tabs apart once the form is focused. `?? 'OpenWrt'` is the fallback
+	 partials/head.ut and partials/brand.ut already use, so the line never renders empty; the
+	 striptags/entityencode pair is theirs too, and load-bearing: the hostname is admin-controlled
+	 text printed to an UNAUTHENTICATED page, and one containing `&` broke entity parsing here
+	 before it broke anything else (see the <title> note in partials/head.ut).
+
+	 A <p> and NOT a heading: the card's h2 is `Authorization Required` and stays the page's one
+	 heading. An outline is about the page's SUBJECT, and a heading above that one would announce
+	 the login form as two sections — a screen reader walking the headings would hear the router's
+	 name as a section title with the form nested under it. It is printed above the h2 and centred
+	 (10-login.css) because that is where a reader looks for "which box is this", not because it
+	 outranks anything.
+	-#}
+	<p class="fs-login-host">{{ entityencode(striptags(boardinfo.hostname ?? 'OpenWrt'), true) }}</p>
 	{#
 	 TWO INDEPENDENT ALERTS, because neither variable on its own says which of the two dispatcher
 	 branches rendered this page — and each of the two spellings in the tree picks one and gets the
@@ -67,7 +100,19 @@
 	{% endif %}
 
 	<div class="cbi-map">
-		<h2 name="content">{{ _('Authorization Required') }}</h2>
+		{#
+		 An h1, where every other LuCI theme leaves this an h2. The login page has no chrome
+		 (blank_page above), so header.ut's `.fs-title-main` h1 never renders here and the document
+		 went out with its top-level heading MISSING — the one sentence saying where you are, and
+		 the heading a screen reader's `1` shortcut jumps to. Stock's h2 is a copy of a page that
+		 does have a title bar above it; this one does not, so the card's heading IS the page title.
+
+		 `name="content"` is upstream's legacy anchor and travels with the element, not with its
+		 level. The card's own type scale is in 10-login.css: an h1 is 26px in the ramp
+		 (theme/45-misc.css) and this one is set back to the h2's 20px, because the SIZE was never
+		 what was wrong — only the level.
+		-#}
+		<h1 name="content">{{ _('Authorization Required') }}</h1>
 		<div class="cbi-map-descr">
 			{{ _('Please enter your username and password.') }}
 		</div>


### PR DESCRIPTION
A LuCI poll refreshes a section with `dom.content()`, which empties the container before it refills it. For that moment the document is shorter than the offset the reader sits at, the engine clamps the offset, and what happens on the way back is the engine's business: Chromium lands where it started, WebKit overshoots by 60px on every tick. On a live Safari that is the page creeping while you read it.

The theme decided whether to help by asking `CSS.supports("overflow-anchor")`, which answers "does this engine anchor at all" — a different question, and one every current engine now answers yes to. It measures instead: two frames after the mutation, the reference it was already holding is asked where it ended up. An engine that got it right reports zero drift and nothing happens; what is left over is what nobody put back.

Three more faults sat behind the same symptom, all in *which element* the reference is taken on — `elementFromPoint` answering with `#view` itself wherever the hit lands in a gap, a point above the first section answering with `.fs-content` outside the host, and a page that is one table (Processes, Routes, the realtime lists) having that table as a direct child of `#view`, so the climb out of it landed on the host and gave up. On that last shape nothing was holding the reader on **any** engine.

Also in this sync, each reported and each fixed on a luci-base class rather than on the page it was seen on:

* a meter's value sat on its own label once its column became a card (luci-mod-dashboard's Wireless list on a phone, 6–9px at every density);
* a page-title button row touched the heading above it (Status → Channel Analysis, 0px measured);
* the per-section Delete button touched the tab bar below it — every named section: SQM's queues, the firewall's zones;
* a block a view builds itself fused with the card below it (a view may return a bare widget where a section is expected, as luci-app-irqbalance does for its `/proc/interrupts` snapshot). Stock bootstrap measures the same 0px there; the difference is that a section is a stretch of page in bootstrap and a card here.

And two from before this sync: the login page prints the hostname it belongs to (#8961) and carries a top-level heading, and the Appearance tab builds its own range control where `ui.RangeSlider` is missing, which is 23.05 — the whole tab died there on one missing widget.

Measured on OpenWrt 25.12 and 24.10 containers, chromium/firefox/webkit, both layouts, 390 and 1440, all three density settings: 216 anchoring runs with the reader staying put, and the page audit reporting no new findings.