### PR TITLE
luci-app-mwan3: add resolveDefault to rule.js

### DIFF
--- a/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/rule.js
+++ b/applications/luci-app-mwan3/htdocs/luci-static/resources/view/mwan3/network/rule.js
@@ -8,7 +8,7 @@
 return view.extend({
 	load: function() {
 		return Promise.all([
-			fs.exec_direct('/usr/libexec/luci-mwan3', ['ipset', 'dump']),
+			L.resolveDefault(fs.exec_direct('/usr/libexec/luci-mwan3', ['ipset', 'dump']), ''),
 			uci.load('mwan3')
 		]);
 	},


### PR DESCRIPTION

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
rule.js reports an error stating that access to command is denied. This is caused by the call to `fs.exec_direct` for `/usr/libexec/luci-mwan3 ipset dump` in the load function. Dump does not write names on my setup leading to the error.

Thus, hardening the call for cases, when the result is empty, is reasonable.


### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->
*Before*
<img width="1109" height="523" alt="image" src="https://github.com/user-attachments/assets/c18d5079-d524-45fc-80e7-6088d2fd8e62" />

*After*
<img width="1579" height="408" alt="image" src="https://github.com/user-attachments/assets/0148f8e2-31fc-44da-8383-3e7346d3f516" />



### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
@systemcrash @feckert 

---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** openwrt-25.12<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** luci openwrt-25.12<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** firefox<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---
