### PR TITLE
themes: hide "No password set" warning on the password page

### DIFF
--- a/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
+++ b/themes/luci-theme-bootstrap/ucode/template/themes/bootstrap/header.ut
@@ -54,7 +54,7 @@
 		</header>
 
 		<div id="maincontent" class="container">
-			{% if (getuid() == 0 && getspnam('root')?.pwdp === ''): %}
+			{% if (getuid() == 0 && getspnam('root')?.pwdp === '' && join('-', ctx.request_path) != 'admin-system-admin'): %}
 				<div class="alert-message warning">
 					<h4>{{ _('No password set!') }}</h4>
 					<p>{{ _('There is no password set on this router. Please configure a root password to protect the web interface.') }}</p>

--- a/themes/luci-theme-material/ucode/template/themes/material/header.ut
+++ b/themes/luci-theme-material/ucode/template/themes/material/header.ut
@@ -77,7 +77,7 @@
 		<div class="darkMask"></div>
 		<div id="maincontent">
 			<div class="container">
-				{% if (getuid() == 0 && getspnam('root')?.pwdp === '' && ctx.authsession): %}
+				{% if (getuid() == 0 && getspnam('root')?.pwdp === '' && ctx.authsession && join('-', ctx.request_path) != 'admin-system-admin'): %}
 					<div class="alert-message warning">
 						<h4>{{ _('No password set!') }}</h4>
 						<p>{{ _('There is no password set on this router. Please configure a root password to protect the web interface.') }}</p>


### PR DESCRIPTION
### Description

The "No password set!" banner is rendered server-side in each theme's header from
`getspnam('root')?.pwdp === ''`. On the password page (`admin/system/admin`) this contradicts
itself: after LuCI sets the password over ubus (a bare Save with no page reload —
`password.js` has `handleSaveApply: null`), the "The system password has been successfully
changed." notification and the stale "No password set!" banner sit on screen at the same time,
leaving the user unsure whether the save worked. The banner's own "Go to password
configuration..." button is also pointless there — it links to the page you are already on.

`luci-theme-openwrt` and `luci-theme-openwrt-2020` already suppress the banner on this page with
`join('-', ctx.request_path) != 'admin-system-admin'`. This PR adds the identical guard to the two
themes that were missing it: **bootstrap** and **material**.

Scope notes (matching the two reference themes):
- The guard matches the requested URL, so it covers `/admin/system/admin` (the menu entry and the
  banner button, dispatched to the password view via firstchild) but not the explicit tab URLs
  (`.../admin/password`, `.../admin/pwpolicy`), which carry a fourth path segment.
- `luci-theme-footstrap` also renders the banner, but its client-side router preserves
  server-rendered notices across page swaps, so a server-side guard alone is not sufficient there;
  it is left unchanged for a separate theme-specific fix.

Tested on a Cudy WR3000P v1 (main snapshot build, bootstrap theme): with no password set, the
banner shows on every page except System → Administration; setting a password there shows only the
success notification, with no stale contradiction. Guard semantics verified against the ucode
interpreter on-device for the firstchild and control cases; `ctx.request_path` is null-safe here
(`join('-', null) != '...'` is true, so error/login pages keep the old behaviour).

### Screenshot or video of changes _(if applicable)_

n/a (removal of a banner on one page)

### Maintainer _(preferred)_

