### PR TITLE
luci-base/luci-mod-network: add xDSL data link configuration and capability gating

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -282,6 +282,12 @@ const methods = {
 				vrf:        access('/sys/module/vrf/refcnt') == true, // vrf.ko is loaded
 				netifd_vrf: false,
 				mptcp:      access('/proc/sys/net/mptcp/enabled'),
+				dsl_datalink_ptm: access('/usr/sbin/rbctl-dsl') == true,
+				dsl_datalink_atm: access('/usr/sbin/rbctl-dsl') == true,
+				dsl_bitswap:      access('/usr/sbin/rbctl-dsl') == true,
+				dsl_sra:          access('/usr/sbin/rbctl-dsl') == true,
+				dsl_snr_offset:   access('/sbin/vdsl_cpe_control') == true,
+				dsl_firmware:     access('/sbin/dsl_cpe_control') == true || access('/sbin/vdsl_cpe_control') == true,
 			};
 
 			const wifi_features = [ 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1896,7 +1896,8 @@ return view.extend({
 		o.datatype = 'uinteger';
 
 		if (dslModemType != null) {
-			s = m.section(form.TypedSection, 'dsl', _('DSL'));
+			s = m.section(form.TypedSection, 'dsl', _('DSL'),
+				_('xDSL line settings such as annex, tone and transfer mode. Changes are applied when the line is reinitialized.'));
 			s.anonymous = true;
 
 			o = s.option(form.ListValue, 'annex', _('Annex'));
@@ -1940,16 +1941,190 @@ return view.extend({
 				o.value('adsl', _('ADSL'));
 				o.value('vdsl', _('VDSL'));
 
-				o = s.option(form.ListValue, 'ds_snr_offset', _('Downstream SNR offset'));
-				o.default = '0';
+				if (L.hasSystemFeature('dsl_snr_offset')) {
+					o = s.option(form.ListValue, 'ds_snr_offset', _('Downstream SNR offset'));
+					o.default = '0';
 
-				for (let i = -100; i <= 100; i += 5)
-					o.value(i, _('%.1f dB').format(i / 10));
+					for (let i = -100; i <= 100; i += 5)
+						o.value(i, _('%.1f dB').format(i / 10));
+				}
 			}
 
-			s.option(form.Value, 'firmware', _('Firmware File'));
-		}
+			if (L.hasSystemFeature('dsl_bitswap')) {
+				o = s.option(form.Flag, 'bitswap', _('Bitswap'));
+				o.default = '1';
+			}
 
+			if (L.hasSystemFeature('dsl_sra')) {
+				o = s.option(form.Flag, 'sra', _('Seamless Rate Adaptation'));
+				o.default = '1';
+			}
+
+			if (L.hasSystemFeature('dsl_firmware'))
+				s.option(form.Value, 'firmware', _('Firmware File'));
+
+			// Data Links section, embedded in the DSL tab. The container
+			// is a NamedSection bound to the existing 'dsl' section with
+			// its own sectiontype: on a tabbed map the DOM id derives
+			// from the section type, so reusing 'dsl' would collide with
+			// the DSL section itself.
+			if (L.hasSystemFeature('dsl_datalink_ptm') || L.hasSystemFeature('dsl_datalink_atm')) {
+				/* data link interfaces are VLANs on the parent of the
+				 * xDSL management interface (e.g. lan0.500 -> lan0) */
+				const dslParent = (uci.get('network', 'dsl', 'config_iface') || 'lan0').replace(/\..*$/, '');
+
+				/* PTM and ATM links share a single index space (0-7);
+				 * find the lowest index not used by any of them */
+				const nextFreeLinkIndex = function() {
+					const used = {};
+
+					for (let s of uci.sections('network', 'ptm').concat(uci.sections('network', 'atm'))) {
+						const index = +s.index;
+
+						if (!isNaN(index) && index >= 0 && index <= 7)
+							used[index] = true;
+					}
+
+					for (let i = 0; i < 8; i++)
+						if (!used[i])
+							return i;
+
+					return null;
+				};
+
+				o = s.option(form.SectionValue, 'data_links',
+					form.NamedSection, 'dsl', 'data-links', _('Data Links'),
+					_('Configure how the connection is carried: PTM/ATM data links terminated by the xDSL board. Each configured link is exposed as a virtual network interface that can be used by WAN interfaces.'));
+
+				const dls = o.subsection;
+
+				if (L.hasSystemFeature('dsl_datalink_atm')) {
+					dls.tab('atm', _('ATM Links'));
+
+					o = dls.taboption('atm', form.SectionValue, 'atm_links',
+						form.TypedSection, 'atm', _('xDSL ATM Data Links'),
+						_('ATM data links carry the xDSL connection as PVCs terminated by the xDSL board. Each link is exposed as <code>%s.2000 + index</code> on this device and can be used as device for WAN interfaces. Up to 8 links (PTM and ATM combined) are supported.').format(dslParent));
+
+					const ss = o.subsection;
+
+					ss.addremove = true;
+					ss.anonymous = false;
+					ss.addbtntitle = _('Add ATM Data Link');
+
+					ss.handleAdd = function(ev, name) {
+						if (!name)
+							return;
+
+						if (uci.get('network', name)) {
+							ui.addNotification(null,
+								E('p', _('A section named "%s" already exists.').format(name)),
+								'warning');
+							return;
+						}
+
+						const index = nextFreeLinkIndex();
+
+						if (index == null) {
+							ui.addNotification(null,
+								E('p', _('No free data link index: all 8 links (PTM and ATM combined) are already in use.')),
+								'error');
+							return;
+						}
+
+						return this.map.save(function() {
+							const sid = uci.add('network', 'atm', name);
+
+							uci.set('network', sid, 'index', index);
+							uci.set('network', sid, 'vpi', 8);
+							uci.set('network', sid, 'vci', 35);
+							uci.set('network', sid, 'encaps', 'llc');
+							uci.set('network', sid, 'payload', 'bridged');
+						});
+					};
+
+					o = ss.option(form.Value, 'index', _('Data link index'),
+						_('Determines the transport interface on this device (%s.2000 + index). Must be unique across all PTM and ATM data links.').format(dslParent));
+					o.datatype = 'and(uinteger, min(0), max(7))';
+					o.rmempty = false;
+
+					o = ss.option(form.Value, 'vpi', _('ATM Virtual Path Identifier (VPI)'));
+					o.datatype = 'and(uinteger, min(0), max(255))';
+					o.default = '8';
+					o.rmempty = false;
+
+					o = ss.option(form.Value, 'vci', _('ATM Virtual Channel Identifier (VCI)'));
+					o.datatype = 'and(uinteger, min(1), max(65535))';
+					o.default = '35';
+					o.rmempty = false;
+
+					o = ss.option(form.ListValue, 'encaps', _('Encapsulation mode'));
+					o.value('llc', _('LLC'));
+					o.value('vcmux', _('VC-Mux'));
+					o.default = 'llc';
+
+					o = ss.option(form.ListValue, 'payload', _('Payload type'));
+					o.value('bridged', _('Bridged'));
+					o.value('routed', _('Routed'));
+					o.default = 'bridged';
+				}
+
+				if (L.hasSystemFeature('dsl_datalink_ptm')) {
+					dls.tab('ptm', _('PTM Links'));
+
+					o = dls.taboption('ptm', form.SectionValue, 'ptm_links',
+						form.TypedSection, 'ptm', _('xDSL PTM Data Links'),
+						_('PTM data links carry the xDSL connection as VLAN interfaces provided by the xDSL board. Each link is exposed as <code>%s.2000 + index</code> on this device and can be used as device for WAN interfaces. Up to 8 links (PTM and ATM combined) are supported; at most one link may be untagged.').format(dslParent));
+
+					const ss = o.subsection;
+
+					ss.addremove = true;
+					ss.anonymous = false;
+					ss.addbtntitle = _('Add PTM Data Link');
+
+					ss.handleAdd = function(ev, name) {
+						if (!name)
+							return;
+
+						if (uci.get('network', name)) {
+							ui.addNotification(null,
+								E('p', _('A section named "%s" already exists.').format(name)),
+								'warning');
+							return;
+						}
+
+						const index = nextFreeLinkIndex();
+
+						if (index == null) {
+							ui.addNotification(null,
+								E('p', _('No free data link index: all 8 links (PTM and ATM combined) are already in use.')),
+								'error');
+							return;
+						}
+
+						return this.map.save(function() {
+							const sid = uci.add('network', 'ptm', name);
+
+							uci.set('network', sid, 'index', index);
+							uci.set('network', sid, 'pbit', 0);
+						});
+					};
+
+					o = ss.option(form.Value, 'index', _('Data link index'),
+						_('Determines the transport interface on this device (%s.2000 + index). Must be unique across all PTM and ATM data links.').format(dslParent));
+					o.datatype = 'and(uinteger, min(0), max(7))';
+					o.rmempty = false;
+
+					o = ss.option(form.Value, 'vid', _('Service VLAN ID'),
+						_('Service VLAN tagged by the xDSL board. Leave empty for an untagged link; only one untagged link is allowed.'));
+					o.datatype = 'and(uinteger, min(1), max(4094))';
+
+					o = ss.option(form.ListValue, 'pbit', _('802.1p priority'));
+					for (let i = 0; i <= 7; i++)
+						o.value(i);
+					o.default = '0';
+				}
+			}
+		}
 
 		// Show ATM bridge section if we have the capabilities
 		if (L.hasSystemFeature('br2684ctl')) {


### PR DESCRIPTION
### Description

Some routers carry their xDSL modem on a remote co-processor (e.g. an
Airoha EN7516 "EcoNet" companion SoC next to the main MediaTek SoC).
On those boards the modem firmware, line control and data links are
managed by a userspace daemon talking to the companion SoC: there are
no native netifd devices for the links, the firmware is not loaded by
the host kernel, and the current DSL UI cannot express any of it.

This adds the missing UI plumbing, gated behind individual system
features so every driver (lantiq stacks as well as remote-board
daemons) can announce exactly the capabilities they implement:

**luci-base** — new capability probes in `rpcd getFeatures`:
`dsl_ptm`, `dsl_atm` (PTM/ATM data link section support),
`dsl_bitswap`, `dsl_sra` (line feature control), `dsl_snr_offset` and
`dsl_firmware` (lantiq-stack-only options). The probes coincide per
driver today but are independent flags, so implementations can enable
subsets later.

**luci-mod-network** (`view/network/interfaces.js`):
* The DSL line options are gated per capability: "Downstream SNR
  offset" and "Firmware File" are only shown when a lantiq stack is
  present; "Bitswap" and "Seamless Rate Adaptation" flags are added
  when the providing daemon announces them. Lantiq platforms keep
  their existing options; nothing changes for them except grouping.
* The DSL section gains a "Data Links" group with one tab per link
  kind:
  * **ATM Bridge** — the existing `atm-bridge` manager
    (br2684ctl-gated), moved from its own top-level section into the
    group.
  * **ATM Links** / **PTM Links** — managers for named
    `network.<name>=atm` / `=ptm` sections terminated by the remote
    board, gated by `dsl_atm` / `dsl_ptm`. Both share one index space
    (0–7, up to 8 links in total, at most one untagged PTM link);
    "Add" consumes the typed section name and auto-assigns the next
    free index across both types. Fields: index, optional service
    vid, 802.1p priority (PTM); index, vpi/vci, encapsulation,
    payload (ATM). Transport interface names in the descriptions are
    derived from the parent of `network.dsl.config_iface`, so boards
    hanging the modem off a different port show correct names.
* The group is embedded via `form.SectionValue` bound to a
  `NamedSection` with a dedicated section type: on a tabbed map the
  page-tab and DOM ids derive from the section type, so the container
  must not reuse the `dsl` type of the DSL section itself.

The reference userspace implementation is available as an OpenWrt
feed at https://github.com/hitech95/openwrt_tplink_vx830v_rbctrl-dsl
(the `rbctl-dsl` daemon for EcoNet companion SoCs). The UI itself is
implementation-agnostic — any daemon providing the probed binaries
and the UCI schema gets the same UI.

### Screenshot or video of changes _(if applicable)_

<img width="1858" height="907" alt="xDSL Status" src="https://github.com/user-attachments/assets/578f309f-12c4-4fab-874b-d531e7621bf8" />
<img width="1851" height="1324" alt="xDSL network tab" src="https://github.com/user-attachments/assets/01c57d33-c89e-4118-852c-df396bd23f60" />

### Maintainer _(preferred)_
@jow-

---

## Tested on
**OpenWrt version:** SNAPSHOT r35484+239-11a859cca7 (kernel 6.18.44, mediatek/filogic)
**LuCI version:** master (26.243 branch, base 6e1eb21fae + this PR)
**Web browser(s):** Firefox

---

## Checklist
- [x] Verified the ATM Bridge code path is unchanged apart from relocation (gated by the existing `br2684ctl` feature)
- [x] Includes the userspace implementation it depends on: https://github.com/hitech95/openwrt_tplink_vx830v_rbctrl-dsl