### PR TITLE
luci-app-wg-obfuscator: add LuCI support for wg-obfuscator

### DIFF
--- a/applications/luci-app-wg-obfuscator/Makefile
+++ b/applications/luci-app-wg-obfuscator/Makefile
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+#
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for WireGuard Obfuscator
+LUCI_DESCRIPTION:=Web interface to configure and control wg-obfuscator, the WireGuard traffic obfuscator.
+LUCI_DEPENDS:=+luci-base +wg-obfuscator
+
+PKG_VERSION:=1.6
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-3.0-only
+PKG_MAINTAINER:=Alexey Cluster <cluster@cluster.wtf>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js
+++ b/applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+
+'use strict';
+'require view';
+'require form';
+'require fs';
+'require poll';
+'require rpc';
+'require ui';
+'require uci';
+'require validation';
+
+// Written by wg-obfuscator-config.sh on every service start, hence tmpfs.
+const configFile = '/var/etc/wg-obfuscator.conf';
+const initScript = '/etc/init.d/wg-obfuscator';
+
+const callServiceList = rpc.declare({
+	object: 'service',
+	method: 'list',
+	params: ['name'],
+	expect: { '': {} }
+});
+
+// The init script does not name its procd instance, so match on any of them
+// rather than hardcoding the generated name.
+function getServiceStatus() {
+	return L.resolveDefault(callServiceList('wg-obfuscator'), {}).then(res => {
+		const service = L.isObject(res) ? res['wg-obfuscator'] : null;
+		const instances = L.isObject(service) ? service.instances : null;
+
+		for (const name in instances)
+			if (instances[name].running)
+				return true;
+
+		return false;
+	});
+}
+
+function getConfigPresent() {
+	return L.resolveDefault(fs.stat(configFile), null).then(stat => stat != null);
+}
+
+function countEnabledInstances() {
+	return uci.sections('wg-obfuscator', 'wg_obfuscator')
+		.filter(section => section.enabled == '1').length;
+}
+
+function renderStatus(isRunning, configPresent, enabledCount) {
+	const span = '<span style="color:%s"><strong>%s</strong></span>';
+
+	return [
+		'%s: %s'.format(_('Service Status'), isRunning
+			? span.format('green', _('Running'))
+			: span.format('red', _('Stopped'))),
+		'%s: %s'.format(_('Configuration'), configPresent
+			? span.format('green', _('Exists'))
+			: span.format('red', _('Not found'))),
+		'%s: %d'.format(_('Enabled instances'), enabledCount)
+	].join('&#160;&#160;|&#160;&#160;');
+}
+
+function updateStatus() {
+	return Promise.all([
+		getServiceStatus(),
+		getConfigPresent()
+	]).then(res => {
+		const view = document.getElementById('service_status');
+
+		if (view)
+			view.innerHTML = renderStatus(res[0], res[1], countEnabledInstances());
+	});
+}
+
+function handleRestart() {
+	return fs.exec(initScript, ['restart']).then(res => {
+		if (res.code === 0)
+			ui.addNotification(null, E('p', _('Action completed successfully')), 'info');
+		else
+			ui.addNotification(null, E('p', _('Action failed')), 'error');
+	}).catch(err => {
+		ui.addNotification(null, E('p', err.message), 'error');
+	});
+}
+
+const stubValidator = {
+	factory: validation,
+	apply(type, value, args) {
+		if (value != null)
+			this.value = value;
+
+		return validation.types[type].apply(this, args);
+	},
+	assert(condition) {
+		return !!condition;
+	}
+};
+
+return view.extend({
+	load() {
+		return uci.load('wg-obfuscator');
+	},
+
+	render() {
+		let m, s, o;
+
+		// Registered here rather than from the section: Map.save() re-runs the
+		// section render, and poll.add() only dedupes on function identity, so
+		// every Save & Apply would add another poller.
+		poll.add(updateStatus);
+
+		m = new form.Map('wg-obfuscator', _('WireGuard Obfuscator Configuration'),
+			_('Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic.'));
+
+		s = m.section(form.TypedSection);
+		s.anonymous = true;
+		s.render = function () {
+			return E('div', { class: 'cbi-section', id: 'status_bar' }, [
+				E('p', { id: 'service_status' }, _('Collecting data...')),
+				E('p', {}, E('button', {
+					class: 'cbi-button cbi-button-apply',
+					click: ui.createHandlerFn(this, handleRestart)
+				}, _('Restart Service')))
+			]);
+		};
+
+		s = m.section(form.TypedSection, 'wg_obfuscator', _('Instances'),
+			_('Configure individual obfuscator instances. Each instance can have different settings.'));
+		s.anonymous = false;
+		s.addremove = true;
+		s.addbtntitle = _('Add instance');
+
+		o = s.option(form.Flag, 'enabled', _('Enable'), _('Enable this instance'));
+		o.default = o.disabled;
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'source_lport', _('Source Port'),
+			_('Local port to listen for incoming connections'));
+		o.datatype = 'port';
+		o.default = '13255';
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'target', _('Target'),
+			_('Target server in format host:port'));
+		o.datatype = 'hostport';
+		o.placeholder = 'example.com:13255';
+		o.rmempty = false;
+
+		// No default on purpose: a prefilled key would be a shared secret
+		// everyone already knows.
+		o = s.option(form.Value, 'key', _('Obfuscation Key'),
+			_('Key used for obfuscation (must be the same on both sides)'));
+		o.password = true;
+		o.rmempty = false;
+
+		o = s.option(form.Value, 'source_if', _('Source Interface'),
+			_('Interface to bind to (0.0.0.0 for all interfaces)'));
+		o.datatype = 'ipaddr';
+		o.placeholder = '0.0.0.0';
+
+		o = s.option(form.ListValue, 'masking', _('Masking Type'),
+			_('Protocol masking for DPI evasion'));
+		o.value('NONE', _('None'));
+		o.value('AUTO', _('Auto-detect'));
+		o.value('STUN', _('STUN'));
+		o.default = 'AUTO';
+
+		o = s.option(form.ListValue, 'verbose', _('Log Level'),
+			_('Verbosity level for logging'));
+		o.value('ERRORS', _('Errors only'));
+		o.value('WARNINGS', _('Warnings'));
+		o.value('INFO', _('Info'));
+		o.value('DEBUG', _('Debug'));
+		o.value('TRACE', _('Trace'));
+		o.default = 'INFO';
+
+		o = s.option(form.Value, 'log_file', _('Log File'),
+			_('Write the log to this file instead of the system log. Leave empty to keep using the system log (logread). Avoid writing to the router flash memory, use /tmp or an external drive instead.'));
+		o.placeholder = '/tmp/wg-obfuscator.log';
+		o.validate = function (section_id, value) {
+			if (value && !value.startsWith('/'))
+				return _('Log file path must be absolute');
+
+			return true;
+		};
+
+		o = s.option(form.ListValue, 'log_timestamps', _('Log Timestamps'),
+			_('Prefix log lines with a timestamp. Automatic means timestamps are added only when a log file is used, since the system log adds its own.'));
+		o.value('AUTO', _('Automatic'));
+		o.value('TRUE', _('Always'));
+		o.value('FALSE', _('Never'));
+		o.default = 'AUTO';
+
+		o = s.option(form.Value, 'max_clients', _('Max Clients'),
+			_('Maximum number of concurrent clients'));
+		o.datatype = 'range(1,65535)';
+		o.default = '1024';
+
+		o = s.option(form.Value, 'idle_timeout', _('Idle Timeout'),
+			_('Idle timeout in seconds'));
+		o.datatype = 'uinteger';
+		o.default = '300';
+
+		o = s.option(form.Value, 'in_timeout', _('Incoming Timeout'),
+			_('Same as Idle Timeout, but only counts data received from the target (0 = disabled). Intended for clients: detects a dead or silently blocked server. If the client is still active and static bindings are not used, a new session is created with a fresh outbound UDP port. Useful when DPI bans a particular IP:port pair.'));
+		o.datatype = 'uinteger';
+		o.default = '0';
+
+		o = s.option(form.Value, 'resolve_interval', _('Resolve Interval'),
+			_('Re-resolve the target hostname and hostnames in static bindings every N seconds (0 = only at start and on service reload). A non-zero value also retries a failed resolve at startup instead of exiting. Lookups run in the background and do not stall traffic.'));
+		o.datatype = 'uinteger';
+		o.default = '0';
+
+		o = s.option(form.Value, 'max_dummy', _('Max Dummy Data'),
+			_('Maximum dummy data length for packets (0-255)'));
+		o.datatype = 'range(0,255)';
+		o.default = '4';
+
+		o = s.option(form.Value, 'fwmark', _('Firewall Mark'),
+			_('Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. Useful together with a routing rule that keeps traffic to the VPN server outside of the tunnel.'));
+		o.placeholder = '0xdead';
+		o.default = '0';
+		o.validate = function (section_id, value) {
+			if (!value)
+				return true;
+
+			// Same range the daemon accepts: decimal or 0x-prefixed hex, 16 bit.
+			if (!/^(0x[0-9a-fA-F]+|[0-9]+)$/.test(value))
+				return _('Firewall mark must be 0-65535, decimal or 0x hex');
+
+			const parsed = value.slice(0, 2).toLowerCase() === '0x'
+				? parseInt(value, 16)
+				: parseInt(value, 10);
+
+			if (parsed > 65535)
+				return _('Firewall mark must be 0-65535, decimal or 0x hex');
+
+			return true;
+		};
+
+		o = s.option(form.Flag, 'allow_clean', _('Allow Non-Obfuscated Clients'),
+			_('For servers only: accept clients that send plain (non-obfuscated) WireGuard traffic and forward it as is, in both directions. Disables automatic obfuscation direction detection, so do not enable it on the client side. Not compatible with static bindings.'));
+		o.default = o.disabled;
+		o.rmempty = false;
+
+		o = s.option(form.TextValue, 'static_bindings', _('Static Bindings'),
+			_('Static bindings for two-way mode. Enter each binding as ip:port:localport, one per line.'));
+		o.rows = 3;
+		o.monospace = true;
+		o.placeholder = '1.2.3.4:12883:6670\n5.6.7.8:12083:6679';
+		o.validate = function (section_id, value) {
+			if (!value)
+				return true;
+
+			// The daemon takes a comma separated list and also resolves
+			// hostnames here, so accept both separators and any host.
+			const bindings = value.split(/[\r\n,]+/)
+				.map(binding => binding.trim())
+				.filter(binding => binding.length);
+
+			for (const binding of bindings) {
+				const parts = binding.split(':');
+
+				if (parts.length != 3)
+					return _('Invalid format. Expected: ip:port:localport');
+
+				if (!stubValidator.apply('host', parts[0]))
+					return _('Invalid host: %s').format(parts[0]);
+
+				if (!stubValidator.apply('port', parts[1]))
+					return _('Invalid remote port: %s').format(parts[1]);
+
+				if (!stubValidator.apply('port', parts[2]))
+					return _('Invalid local port: %s').format(parts[2]);
+			}
+
+			return true;
+		};
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-wg-obfuscator/po/de/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/de/wg-obfuscator.po
@@ -1,0 +1,397 @@
+# German translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "Aktion erfolgreich abgeschlossen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "Aktion fehlgeschlagen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Instanz hinzufügen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Nicht verschleierte Clients zulassen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Immer"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Automatisch erkennen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Daten werden gesammelt..."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"WireGuard-Obfuscator-Instanzen einrichten, um WireGuard-Datenverkehr zu "
+"verschleiern."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Einzelne Obfuscator-Instanzen einrichten. Jede Instanz kann eigene "
+"Einstellungen haben."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Debug"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Diese Instanz aktivieren"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Aktivierte Instanzen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Nur Fehler"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Vorhanden"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Firewall-Markierung"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "Firewall-Markierung muss 0–65535 sein, dezimal oder 0x-hexadezimal"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Nur für Server: Clients akzeptieren, die unverschleierten WireGuard-"
+"Datenverkehr senden, und diesen in beide Richtungen unverändert "
+"weiterleiten. Deaktiviert die automatische Erkennung der "
+"Verschleierungsrichtung und darf daher auf der Client-Seite nicht "
+"aktiviert werden. Nicht mit statischen Bindungen kompatibel."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "Zugriff auf die WireGuard-Obfuscator-Konfiguration gewähren"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Leerlauf-Zeitüberschreitung"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Leerlauf-Zeitüberschreitung in Sekunden"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Eingangs-Zeitüberschreitung"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Info"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Instanzen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr ""
+"Schnittstelle, an die gebunden wird (0.0.0.0 für alle Schnittstellen)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Ungültiges Format. Erwartet: IP:Port:LokalerPort"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Ungültiger Host: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Ungültiger lokaler Port: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Ungültiger Remote-Port: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr ""
+"Schlüssel für die Verschleierung (muss auf beiden Seiten identisch sein)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Lokaler Port, auf dem eingehende Verbindungen erwartet werden"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Protokolldatei"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Protokollstufe"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Zeitstempel im Protokoll"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "Der Pfad zur Protokolldatei muss absolut sein"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Markierung (SO_MARK), die auf die vom Obfuscator gesendeten Pakete gesetzt"
+" wird, 0 = deaktiviert. Nützlich zusammen mit einer Routing-Regel, die den"
+" Datenverkehr zum VPN-Server außerhalb des Tunnels hält."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Maskierungstyp"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Max. Clients"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Max. Fülldaten"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "Maximale Länge der Fülldaten in Paketen (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Maximale Anzahl gleichzeitiger Clients"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Nie"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Keine"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "Nicht gefunden"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Verschleierungsschlüssel"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Jeder Protokollzeile einen Zeitstempel voranstellen. „Automatisch“ "
+"bedeutet, dass Zeitstempel nur bei Verwendung einer Protokolldatei "
+"hinzugefügt werden, da das Systemprotokoll eigene setzt."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "Protokollmaskierung zur Umgehung von DPI"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Den Ziel-Hostnamen und die Hostnamen in statischen Bindungen alle N "
+"Sekunden neu auflösen (0 = nur beim Start und beim Neuladen des Dienstes)."
+" Ein Wert ungleich null wiederholt außerdem eine fehlgeschlagene Auflösung"
+" beim Start, statt das Programm zu beenden. Die Abfragen laufen im "
+"Hintergrund und blockieren den Datenverkehr nicht."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Auflösungsintervall"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Dienst neu starten"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "Läuft"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"Wie die Leerlauf-Zeitüberschreitung, zählt aber nur vom Ziel empfangene "
+"Daten (0 = deaktiviert). Für Clients gedacht: erkennt einen toten oder "
+"stillschweigend blockierten Server. Ist der Client noch aktiv und werden "
+"keine statischen Bindungen verwendet, wird eine neue Sitzung mit einem "
+"neuen ausgehenden UDP-Port aufgebaut. Nützlich, wenn DPI ein bestimmtes "
+"IP:Port-Paar sperrt."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "Dienststatus"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Quellschnittstelle"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Quellport"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Statische Bindungen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Statische Bindungen für den bidirektionalen Modus. Jede Bindung als "
+"IP:Port:LokalerPort eingeben, eine pro Zeile."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Gestoppt"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Ziel"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "Zielserver im Format Host:Port"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "Trace"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Ausführlichkeit der Protokollierung"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Warnungen"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "WireGuard-Obfuscator-Konfiguration"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Das Protokoll in diese Datei statt in das Systemprotokoll schreiben. Leer "
+"lassen, um weiterhin das Systemprotokoll (logread) zu verwenden. Nicht in "
+"den Flash-Speicher des Routers schreiben, stattdessen /tmp oder einen "
+"externen Datenträger verwenden."
+
+#~ msgid "Name"
+#~ msgstr "Name"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Status aktualisieren"
+
+#~ msgid "Processing..."
+#~ msgstr "Wird verarbeitet..."
+
+#~ msgid "Connection error"
+#~ msgstr "Verbindungsfehler"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "WireGuard-Obfuscator-Dienst neu starten?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "Das Ziel darf nicht leer sein"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr "Ungültiges Format. Erwartet: Host:Port (z. B. example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "Der Host darf nicht leer sein"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Ungültiger Port. Muss zwischen 1 und 65535 liegen"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Ungültige IP-Adresse: "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Ungültiger Remote-Port: "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Ungültiger lokaler Port: "

--- a/applications/luci-app-wg-obfuscator/po/es/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/es/wg-obfuscator.po
@@ -1,0 +1,393 @@
+# Spanish translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "Acción completada correctamente"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "La acción ha fallado"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Añadir instancia"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Permitir clientes sin ofuscar"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Siempre"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Detección automática"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Automático"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Recopilando datos..."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Configuración"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"Configure instancias de WireGuard Obfuscator para ofuscar el tráfico de "
+"WireGuard."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Configure cada instancia del ofuscador. Cada instancia puede tener sus "
+"propios ajustes."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Depuración"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Activar"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Activar esta instancia"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Instancias activadas"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Solo errores"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Existe"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Marca de cortafuegos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "La marca de cortafuegos debe estar entre 0 y 65535, decimal o hexadecimal 0x"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Solo para servidores: aceptar clientes que envían tráfico WireGuard sin "
+"ofuscar y reenviarlo tal cual en ambos sentidos. Desactiva la detección "
+"automática del sentido de la ofuscación, así que no lo active en el lado "
+"del cliente. No es compatible con los enlaces estáticos."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "Conceder acceso a la configuración de WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Tiempo de espera por inactividad"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Tiempo de espera por inactividad en segundos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Tiempo de espera de entrada"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Información"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Instancias"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "Interfaz a la que enlazar (0.0.0.0 para todas las interfaces)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Formato no válido. Se esperaba: ip:puerto:puertolocal"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Host no válido: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Puerto local no válido: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Puerto remoto no válido: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr "Clave usada para la ofuscación (debe ser la misma en ambos lados)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Puerto local en el que escuchar las conexiones entrantes"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Archivo de registro"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Nivel de registro"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Marcas de tiempo en el registro"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "La ruta del archivo de registro debe ser absoluta"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Marca (SO_MARK) aplicada a los paquetes que envía el ofuscador, 0 = "
+"desactivado. Útil junto con una regla de enrutamiento que mantenga el "
+"tráfico hacia el servidor VPN fuera del túnel."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Tipo de enmascaramiento"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Clientes máx."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Datos de relleno máx."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "Longitud máxima de los datos de relleno en los paquetes (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Número máximo de clientes simultáneos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Nunca"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Ninguno"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "No encontrada"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Clave de ofuscación"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Anteponer una marca de tiempo a cada línea del registro. «Automático» "
+"significa que solo se añaden cuando se usa un archivo de registro, ya que "
+"el registro del sistema añade las suyas."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "Enmascaramiento de protocolo para evadir el DPI"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Volver a resolver el nombre de host de destino y los de los enlaces "
+"estáticos cada N segundos (0 = solo al iniciar y al recargar el servicio)."
+" Un valor distinto de cero también reintenta una resolución fallida al "
+"inicio en lugar de salir. Las consultas se ejecutan en segundo plano y no "
+"detienen el tráfico."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Intervalo de resolución"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Reiniciar servicio"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "En ejecución"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"Igual que el tiempo de espera por inactividad, pero solo cuenta los datos "
+"recibidos del destino (0 = desactivado). Pensado para clientes: detecta un"
+" servidor caído o bloqueado en silencio. Si el cliente sigue activo y no "
+"se usan enlaces estáticos, se crea una sesión nueva con un puerto UDP de "
+"salida nuevo. Útil cuando el DPI bloquea un par IP:puerto concreto."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "Estado del servicio"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Interfaz de origen"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Puerto de origen"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Enlaces estáticos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Enlaces estáticos para el modo bidireccional. Introduzca cada enlace como "
+"ip:puerto:puertolocal, uno por línea."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Detenido"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Destino"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "Servidor de destino con el formato host:puerto"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "Traza"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Nivel de detalle del registro"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Advertencias"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "Configuración de WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Escribir el registro en este archivo en lugar del registro del sistema. "
+"Déjelo vacío para seguir usando el registro del sistema (logread). Evite "
+"escribir en la memoria flash del router; use /tmp o una unidad externa."
+
+#~ msgid "Name"
+#~ msgstr "Nombre"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Actualizar estado"
+
+#~ msgid "Processing..."
+#~ msgstr "Procesando..."
+
+#~ msgid "Connection error"
+#~ msgstr "Error de conexión"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "¿Reiniciar el servicio WireGuard Obfuscator?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "El destino no puede estar vacío"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr ""
+#~ "Formato no válido. Se esperaba: host:puerto (p. ej., example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "El host no puede estar vacío"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Puerto no válido. Debe estar entre 1 y 65535"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Dirección IP no válida: "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Puerto remoto no válido: "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Puerto local no válido: "

--- a/applications/luci-app-wg-obfuscator/po/fr/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/fr/wg-obfuscator.po
@@ -1,0 +1,396 @@
+# French translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "Action effectuée avec succès"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "Échec de l'action"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Ajouter une instance"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Autoriser les clients non offusqués"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Toujours"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Détection automatique"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Automatique"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Récupération des données…"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Configuration"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"Configurer les instances de WireGuard Obfuscator pour offusquer le trafic "
+"WireGuard."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Configurer chaque instance de l'obfuscateur. Chaque instance peut avoir "
+"ses propres paramètres."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Débogage"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Activer"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Activer cette instance"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Instances activées"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Erreurs uniquement"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Présente"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Marque de pare-feu"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "La marque de pare-feu doit être comprise entre 0 et 65535, décimal ou hexadécimal 0x"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Pour les serveurs uniquement : accepter les clients qui envoient du trafic"
+" WireGuard non offusqué et le transmettre tel quel, dans les deux sens. "
+"Désactive la détection automatique du sens de l'offuscation, ne pas "
+"activer côté client. Incompatible avec les liaisons statiques."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "Accorder l'accès à la configuration de WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Délai d'inactivité"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Délai d'inactivité en secondes"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Délai de réception"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Informations"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Instances"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "Interface d'écoute (0.0.0.0 pour toutes les interfaces)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Format invalide. Attendu : ip:port:portlocal"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Hôte invalide : %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Port local invalide : %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Port distant invalide : %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr ""
+"Clé utilisée pour l'offuscation (doit être identique des deux côtés)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Port local d'écoute des connexions entrantes"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Fichier journal"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Niveau de journalisation"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Horodatage des journaux"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "Le chemin du fichier journal doit être absolu"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Marque (SO_MARK) appliquée aux paquets émis par l'obfuscateur, 0 = "
+"désactivé. Utile avec une règle de routage qui garde le trafic vers le "
+"serveur VPN en dehors du tunnel."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Type de masquage"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Clients max."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Données de remplissage max."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr ""
+"Longueur maximale des données de remplissage dans les paquets (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Nombre maximal de clients simultanés"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Jamais"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Aucun"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "Introuvable"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Clé d'offuscation"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Préfixer chaque ligne du journal par un horodatage. « Automatique » "
+"signifie que l'horodatage n'est ajouté que lorsqu'un fichier journal est "
+"utilisé, car le journal système ajoute le sien."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "Masquage du protocole pour contourner le DPI"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Résoudre à nouveau le nom d'hôte cible et ceux des liaisons statiques "
+"toutes les N secondes (0 = uniquement au démarrage et au rechargement du "
+"service). Une valeur non nulle réessaie également une résolution échouée "
+"au démarrage au lieu de quitter. Les requêtes s'exécutent en arrière-plan "
+"et ne bloquent pas le trafic."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Intervalle de résolution"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Redémarrer le service"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "En cours d'exécution"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"Identique au délai d'inactivité, mais ne compte que les données reçues de "
+"la cible (0 = désactivé). Destiné aux clients : détecte un serveur mort ou"
+" silencieusement bloqué. Si le client est toujours actif et que les "
+"liaisons statiques ne sont pas utilisées, une nouvelle session est créée "
+"avec un nouveau port UDP sortant. Utile lorsque le DPI bannit un couple "
+"IP:port précis."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "État du service"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Interface source"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Port source"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Liaisons statiques"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Liaisons statiques pour le mode bidirectionnel. Saisir chaque liaison sous"
+" la forme ip:port:portlocal, une par ligne."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Arrêté"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Cible"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "Serveur cible au format hôte:port"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "Trace"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Niveau de détail des journaux"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Avertissements"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "Configuration de WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Écrire le journal dans ce fichier au lieu du journal système. Laisser vide"
+" pour continuer à utiliser le journal système (logread). Éviter d'écrire "
+"dans la mémoire flash du routeur, utiliser plutôt /tmp ou un support "
+"externe."
+
+#~ msgid "Name"
+#~ msgstr "Nom"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Actualiser l'état"
+
+#~ msgid "Processing..."
+#~ msgstr "Traitement en cours..."
+
+#~ msgid "Connection error"
+#~ msgstr "Erreur de connexion"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "Redémarrer le service WireGuard Obfuscator ?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "La cible ne peut pas être vide"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr "Format invalide. Attendu : hôte:port (par ex. example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "L'hôte ne peut pas être vide"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Port invalide. Doit être compris entre 1 et 65535"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Adresse IP invalide : "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Port distant invalide : "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Port local invalide : "

--- a/applications/luci-app-wg-obfuscator/po/pt_BR/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/pt_BR/wg-obfuscator.po
@@ -1,0 +1,392 @@
+# Brazilian Portuguese translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: Brazilian Portuguese\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "Ação concluída com sucesso"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "A ação falhou"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Adicionar instância"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Permitir clientes não ofuscados"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Sempre"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Detecção automática"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Automático"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Coletando dados..."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Configuração"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"Configure instâncias do WireGuard Obfuscator para ofuscar o tráfego do "
+"WireGuard."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Configure cada instância do ofuscador. Cada instância pode ter suas "
+"próprias configurações."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Depuração"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Ativar"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Ativar esta instância"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Instâncias ativadas"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Somente erros"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Existe"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Marca de firewall"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "A marca de firewall deve estar entre 0 e 65535, decimal ou hexadecimal 0x"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Somente para servidores: aceitar clientes que enviam tráfego WireGuard "
+"puro (não ofuscado) e encaminhá-lo como está, nos dois sentidos. Desativa "
+"a detecção automática do sentido da ofuscação, portanto não ative no lado "
+"do cliente. Incompatível com vínculos estáticos."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "Conceder acesso à configuração do WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Tempo limite de inatividade"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Tempo limite de inatividade em segundos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Tempo limite de entrada"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Informações"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Instâncias"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "Interface na qual escutar (0.0.0.0 para todas as interfaces)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Formato inválido. Esperado: ip:porta:portalocal"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Host inválido: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Porta local inválida: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Porta remota inválida: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr "Chave usada para a ofuscação (deve ser a mesma nos dois lados)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Porta local para escutar conexões de entrada"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Arquivo de log"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Nível de log"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Carimbos de data/hora no log"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "O caminho do arquivo de log deve ser absoluto"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Marca (SO_MARK) aplicada aos pacotes enviados pelo ofuscador, 0 = "
+"desativado. Útil junto com uma regra de roteamento que mantém o tráfego "
+"para o servidor VPN fora do túnel."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Tipo de mascaramento"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Máx. de clientes"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Máx. de dados de preenchimento"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "Comprimento máximo dos dados de preenchimento nos pacotes (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Número máximo de clientes simultâneos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Nunca"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Nenhum"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "Não encontrada"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Chave de ofuscação"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Prefixar cada linha do log com um carimbo de data/hora. “Automático” "
+"significa que os carimbos são adicionados apenas quando um arquivo de log "
+"é usado, já que o log do sistema adiciona os seus."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "Mascaramento de protocolo para evadir DPI"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Resolver novamente o nome de host de destino e os nomes nos vínculos "
+"estáticos a cada N segundos (0 = apenas na inicialização e ao recarregar o"
+" serviço). Um valor diferente de zero também repete uma resolução "
+"malsucedida na inicialização em vez de encerrar. As consultas são feitas "
+"em segundo plano e não interrompem o tráfego."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Intervalo de resolução"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Reiniciar serviço"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "Em execução"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"Igual ao tempo limite de inatividade, mas conta apenas os dados recebidos "
+"do destino (0 = desativado). Voltado a clientes: detecta um servidor morto"
+" ou bloqueado silenciosamente. Se o cliente ainda estiver ativo e não "
+"houver vínculos estáticos, uma nova sessão é criada com uma nova porta UDP"
+" de saída. Útil quando o DPI bane um par IP:porta específico."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "Status do serviço"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Interface de origem"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Porta de origem"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Vínculos estáticos"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Vínculos estáticos para o modo bidirecional. Informe cada vínculo como "
+"ip:porta:portalocal, um por linha."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Parado"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Destino"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "Servidor de destino no formato host:porta"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "Rastreamento"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Nível de detalhamento do log"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Avisos"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "Configuração do WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Gravar o log neste arquivo em vez do log do sistema. Deixe vazio para "
+"continuar usando o log do sistema (logread). Evite gravar na memória flash"
+" do roteador; use /tmp ou uma unidade externa."
+
+#~ msgid "Name"
+#~ msgstr "Nome"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Atualizar status"
+
+#~ msgid "Processing..."
+#~ msgstr "Processando..."
+
+#~ msgid "Connection error"
+#~ msgstr "Erro de conexão"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "Reiniciar o serviço WireGuard Obfuscator?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "O destino não pode ficar vazio"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr "Formato inválido. Esperado: host:porta (ex.: example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "O host não pode ficar vazio"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Porta inválida. Deve estar entre 1 e 65535"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Endereço IP inválido: "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Porta remota inválida: "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Porta local inválida: "

--- a/applications/luci-app-wg-obfuscator/po/ru/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/ru/wg-obfuscator.po
@@ -1,0 +1,392 @@
+# Russian translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2025 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2025-10-27 18:00+0000\n"
+"PO-Revision-Date: 2025-10-27 18:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "Действие выполнено успешно"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "Действие не выполнено"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Добавить экземпляр"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Разрешить необфусцированных клиентов"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Всегда"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Автоопределение"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Автоматически"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Сбор данных..."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Конфигурация"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"Настройка экземпляров WireGuard Obfuscator для обфускации WireGuard "
+"трафика."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Настройка отдельных экземпляров обфускатора. Каждый экземпляр может иметь "
+"свои параметры."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Отладка"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Включить"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Включить этот экземпляр"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Включено экземпляров"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Только ошибки"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Существует"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Метка фаервола"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "Метка фаервола должна быть от 0 до 65535, десятичная или шестнадцатеричная с 0x"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Только для серверов: принимать клиентов, отправляющих обычный "
+"(необфусцированный) трафик WireGuard, и пересылать его как есть в обе "
+"стороны. Отключает автоматическое определение направления обфускации, "
+"поэтому не включайте на стороне клиента. Несовместимо со статическими "
+"привязками."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "Предоставить доступ к настройкам WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Таймаут простоя"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Таймаут простоя в секундах"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Входящий таймаут"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Информация"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Экземпляры"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "Интерфейс для привязки (0.0.0.0 для всех интерфейсов)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Неверный формат. Ожидается: ip:порт:локальный_порт"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Неверный хост: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Неверный локальный порт: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Неверный удалённый порт: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr "Ключ для обфускации (должен совпадать на обеих сторонах)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Локальный порт для входящих соединений"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Файл лога"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Уровень логирования"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Метки времени в логе"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "Путь к файлу лога должен быть абсолютным"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Метка (SO_MARK), устанавливаемая на отправляемые обфускатором пакеты, 0 = "
+"выключено. Полезна вместе с правилом маршрутизации, которое выводит трафик"
+" до VPN-сервера за пределы туннеля."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Тип маскировки"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Макс. клиентов"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Макс. пустых данных"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "Максимальная длина пустых данных в пакетах (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Максимальное количество одновременных клиентов"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Никогда"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Нет"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "Не найдена"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Ключ обфускации"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Добавлять метку времени в начало каждой строки лога. «Автоматически» "
+"означает, что метки добавляются только при записи в файл, так как "
+"системный лог добавляет свои."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "Маскировка протокола для обхода DPI"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Повторно резолвить имя target и имена в статических привязках каждые N "
+"секунд (0 = только при старте и при перезагрузке службы). Ненулевое "
+"значение также повторяет неудачный резолв при старте вместо выхода. "
+"Запросы идут в фоне и не тормозят трафик."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Интервал резолва"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Перезапустить сервис"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "Работает"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"То же, что Idle Timeout, но учитывает только данные от целевого сервера (0"
+" = выключено). Для клиентов: детектирует мёртвый или молча заблокированный"
+" сервер. Если клиент ещё активен и статические привязки не используются, "
+"сразу создаётся новая сессия с новым исходящим UDP-портом. Полезно, когда "
+"DPI банит конкретную пару IP:порт."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "Состояние сервиса"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Исходящий интерфейс"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Исходящий порт"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Статические привязки"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Статические привязки для двустороннего режима. Вводите каждую привязку как"
+" ip:порт:локальный_порт, по одной на строку."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Остановлен"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Целевой сервер"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "Целевой сервер в формате хост:порт"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "Трассировка"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Уровень детализации логов"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Предупреждения"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "Настройка WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Писать лог в этот файл вместо системного лога. Оставьте пустым, чтобы "
+"продолжать использовать системный лог (logread). Не пишите лог во флеш-"
+"память роутера, используйте /tmp или внешний накопитель."
+
+#~ msgid "Name"
+#~ msgstr "Имя"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Обновить статус"
+
+#~ msgid "Processing..."
+#~ msgstr "Обработка..."
+
+#~ msgid "Connection error"
+#~ msgstr "Ошибка соединения"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "Перезапустить сервис WireGuard Obfuscator?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "Целевой сервер не может быть пустым"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr "Неверный формат. Ожидается: хост:порт (например, example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "Хост не может быть пустым"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Неверный порт. Должен быть от 1 до 65535"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Неверный IP адрес: "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Неверный удалённый порт: "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Неверный локальный порт: "

--- a/applications/luci-app-wg-obfuscator/po/templates/wg-obfuscator.pot
+++ b/applications/luci-app-wg-obfuscator/po/templates/wg-obfuscator.pot
@@ -1,0 +1,304 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have different "
+"settings."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) WireGuard "
+"traffic and forward it as is, in both directions. Disables automatic "
+"obfuscation direction detection, so do not enable it on the client side. Not "
+"compatible with static bindings."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added only "
+"when a log file is used, since the system log adds its own."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the "
+"background and do not stall traffic."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked server. "
+"If the client is still active and static bindings are not used, a new "
+"session is created with a fresh outbound UDP port. Useful when DPI bans a "
+"particular IP:port pair."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport, "
+"one per line."
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr ""
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""

--- a/applications/luci-app-wg-obfuscator/po/tr/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/tr/wg-obfuscator.po
@@ -1,0 +1,393 @@
+# Turkish translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: Turkish\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "İşlem başarıyla tamamlandı"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "İşlem başarısız oldu"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Örnek ekle"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Gizlenmemiş İstemcilere İzin Ver"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Her zaman"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Otomatik algıla"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Otomatik"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Veriler toplanıyor..."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Yapılandırma"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"WireGuard trafiğini gizlemek için WireGuard Obfuscator örneklerini "
+"yapılandırın."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Her bir gizleyici örneğini yapılandırın. Her örnek farklı ayarlara sahip "
+"olabilir."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Hata ayıklama"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Etkinleştir"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Bu örneği etkinleştir"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Etkin örnekler"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Yalnızca hatalar"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Mevcut"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Güvenlik Duvarı İşareti"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "Güvenlik duvarı işareti 0-65535 arasında olmalıdır, ondalık veya 0x onaltılık"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Yalnızca sunucular için: düz (gizlenmemiş) WireGuard trafiği gönderen "
+"istemcileri kabul et ve trafiği her iki yönde olduğu gibi ilet. Gizleme "
+"yönünün otomatik algılanmasını devre dışı bırakır, bu nedenle istemci "
+"tarafında etkinleştirmeyin. Statik bağlamalarla uyumlu değildir."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "WireGuard Obfuscator yapılandırmasına erişim izni ver"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Boşta Kalma Zaman Aşımı"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Saniye cinsinden boşta kalma zaman aşımı"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Gelen Veri Zaman Aşımı"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Bilgi"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Örnekler"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "Bağlanılacak arayüz (tüm arayüzler için 0.0.0.0)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Geçersiz biçim. Beklenen: ip:port:yerelport"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Geçersiz ana makine: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Geçersiz yerel bağlantı noktası: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Geçersiz uzak bağlantı noktası: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr "Gizleme için kullanılan anahtar (her iki tarafta da aynı olmalıdır)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Gelen bağlantıların dinleneceği yerel bağlantı noktası"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Günlük Dosyası"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Günlük Düzeyi"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Günlük Zaman Damgaları"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "Günlük dosyası yolu mutlak olmalıdır"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Gizleyicinin gönderdiği paketlere uygulanan işaret (SO_MARK), 0 = devre "
+"dışı. VPN sunucusuna giden trafiği tünelin dışında tutan bir yönlendirme "
+"kuralıyla birlikte kullanışlıdır."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Maskeleme Türü"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Maks. İstemci"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Maks. Dolgu Verisi"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "Paketlerdeki en fazla dolgu verisi uzunluğu (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Eş zamanlı en fazla istemci sayısı"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Asla"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Yok"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "Bulunamadı"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Gizleme Anahtarı"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Her günlük satırının başına bir zaman damgası ekle. “Otomatik”, zaman "
+"damgalarının yalnızca bir günlük dosyası kullanıldığında ekleneceği "
+"anlamına gelir; sistem günlüğü kendi damgasını ekler."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "DPI atlatma için protokol maskeleme"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Hedef ana bilgisayar adını ve statik bağlamalardaki adları her N saniyede "
+"bir yeniden çözümle (0 = yalnızca başlangıçta ve servis yeniden "
+"yüklendiğinde). Sıfır olmayan bir değer, başlangıçta başarısız olan "
+"çözümlemeyi çıkmak yerine yeniden dener. Sorgular arka planda çalışır ve "
+"trafiği durdurmaz."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Çözümleme Aralığı"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Servisi Yeniden Başlat"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "Çalışıyor"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"Boşta kalma zaman aşımıyla aynıdır, ancak yalnızca hedeften alınan "
+"verileri sayar (0 = devre dışı). İstemciler içindir: ölü ya da sessizce "
+"engellenmiş bir sunucuyu algılar. İstemci hâlâ etkinse ve statik "
+"bağlamalar kullanılmıyorsa, yeni bir giden UDP bağlantı noktasıyla yeni "
+"bir oturum oluşturulur. DPI belirli bir IP:port çiftini yasakladığında "
+"kullanışlıdır."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "Servis Durumu"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Kaynak Arayüzü"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Kaynak Bağlantı Noktası"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Statik Bağlamalar"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Çift yönlü mod için statik bağlamalar. Her bağlamayı ip:port:yerelport "
+"olarak, satır başına bir tane girin."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Durduruldu"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Hedef"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "host:port biçiminde hedef sunucu"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "İzleme"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Günlük kaydının ayrıntı düzeyi"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Uyarılar"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "WireGuard Obfuscator Yapılandırması"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Günlüğü sistem günlüğü yerine bu dosyaya yaz. Sistem günlüğünü (logread) "
+"kullanmaya devam etmek için boş bırakın. Yönlendiricinin flash belleğine "
+"yazmaktan kaçının, bunun yerine /tmp veya harici bir sürücü kullanın."
+
+#~ msgid "Name"
+#~ msgstr "Ad"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Durumu Yenile"
+
+#~ msgid "Processing..."
+#~ msgstr "İşleniyor..."
+
+#~ msgid "Connection error"
+#~ msgstr "Bağlantı hatası"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "WireGuard Obfuscator servisi yeniden başlatılsın mı?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "Hedef boş olamaz"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr "Geçersiz biçim. Beklenen: host:port (örn. example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "Ana bilgisayar boş olamaz"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Geçersiz bağlantı noktası. 1 ile 65535 arasında olmalıdır"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Geçersiz IP adresi: "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Geçersiz uzak bağlantı noktası: "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Geçersiz yerel bağlantı noktası: "

--- a/applications/luci-app-wg-obfuscator/po/uk/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/uk/wg-obfuscator.po
@@ -1,0 +1,392 @@
+# Ukrainian translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: Ukrainian\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "Дію виконано успішно"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "Дію не виконано"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "Додати екземпляр"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "Дозволити необфусковані клієнти"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "Завжди"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "Автовизначення"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "Збір даних…"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "Конфігурація"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr ""
+"Налаштування екземплярів WireGuard Obfuscator для обфускації трафіку "
+"WireGuard."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr ""
+"Налаштування окремих екземплярів обфускатора. Кожен екземпляр може мати "
+"власні параметри."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "Налагодження"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "Увімкнути"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "Увімкнути цей екземпляр"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "Увімкнено екземплярів"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "Лише помилки"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "Існує"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "Позначка фаєрвола"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "Мітка фаєрвола має бути від 0 до 65535, десяткова або шістнадцяткова з 0x"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"Лише для серверів: приймати клієнтів, які надсилають звичайний "
+"(необфускований) трафік WireGuard, і пересилати його як є в обидва боки. "
+"Вимикає автоматичне визначення напрямку обфускації, тому не вмикайте на "
+"боці клієнта. Несумісно зі статичними прив'язками."
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "Надати доступ до налаштувань WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "Тайм-аут простою"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "Тайм-аут простою в секундах"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "Вхідний тайм-аут"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "Інформація"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "Екземпляри"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "Інтерфейс для прив'язки (0.0.0.0 для всіх інтерфейсів)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "Неправильний формат. Очікується: ip:порт:локальний_порт"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "Неправильний хост: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "Неправильний локальний порт: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "Неправильний віддалений порт: %s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr "Ключ для обфускації (має збігатися з обох боків)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "Локальний порт для вхідних з'єднань"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "Файл журналу"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "Рівень журналювання"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "Позначки часу в журналі"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "Шлях до файлу журналу має бути абсолютним"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr ""
+"Позначка (SO_MARK), яка встановлюється на пакети, що надсилає обфускатор, "
+"0 = вимкнено. Корисна разом із правилом маршрутизації, яке виводить трафік"
+" до VPN-сервера за межі тунелю."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "Тип маскування"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "Макс. клієнтів"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "Макс. порожніх даних"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "Максимальна довжина порожніх даних у пакетах (0-255)"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "Максимальна кількість одночасних клієнтів"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "Ніколи"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "Немає"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "Не знайдено"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "Ключ обфускації"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr ""
+"Додавати позначку часу на початку кожного рядка журналу. «Автоматично» "
+"означає, що позначки додаються лише під час запису у файл, оскільки "
+"системний журнал додає власні."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "Маскування протоколу для обходу DPI"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"Повторно розв'язувати ім'я target та імена у статичних прив'язках кожні N "
+"секунд (0 = лише під час запуску та перезавантаження служби). Ненульове "
+"значення також повторює невдалий резолвінг під час запуску замість виходу."
+" Запити виконуються у фоні й не блокують трафік."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "Інтервал резолвінгу"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "Перезапустити службу"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "Працює"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"Те саме, що тайм-аут простою, але враховує лише дані від цільового сервера"
+" (0 = вимкнено). Для клієнтів: виявляє мертвий або мовчки заблокований "
+"сервер. Якщо клієнт ще активний і статичні прив'язки не використовуються, "
+"одразу створюється новий сеанс з новим вихідним UDP-портом. Корисно, коли "
+"DPI банить конкретну пару IP:порт."
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "Стан служби"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "Вихідний інтерфейс"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "Вихідний порт"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "Статичні прив'язки"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr ""
+"Статичні прив'язки для двостороннього режиму. Вводьте кожну прив'язку як "
+"ip:порт:локальний_порт, по одній на рядок."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "Зупинено"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "Цільовий сервер"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "Цільовий сервер у форматі хост:порт"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "Трасування"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "Рівень деталізації журналу"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "Попередження"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "Налаштування WireGuard Obfuscator"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr ""
+"Писати журнал у цей файл замість системного журналу. Залиште порожнім, щоб"
+" і надалі використовувати системний журнал (logread). Не пишіть у флеш-"
+"пам'ять роутера, використовуйте /tmp або зовнішній носій."
+
+#~ msgid "Name"
+#~ msgstr "Назва"
+
+#~ msgid "Refresh Status"
+#~ msgstr "Оновити стан"
+
+#~ msgid "Processing..."
+#~ msgstr "Обробка..."
+
+#~ msgid "Connection error"
+#~ msgstr "Помилка з'єднання"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "Перезапустити службу WireGuard Obfuscator?"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "Цільовий сервер не може бути порожнім"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr ""
+#~ "Неправильний формат. Очікується: хост:порт (наприклад, example.com:51820)"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "Хост не може бути порожнім"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "Неправильний порт. Має бути від 1 до 65535"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "Неправильна IP-адреса: "
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "Неправильний віддалений порт: "
+
+#~ msgid "Invalid local port: "
+#~ msgstr "Неправильний локальний порт: "

--- a/applications/luci-app-wg-obfuscator/po/zh_Hans/wg-obfuscator.po
+++ b/applications/luci-app-wg-obfuscator/po/zh_Hans/wg-obfuscator.po
@@ -1,0 +1,370 @@
+# Simplified Chinese translation for WireGuard Obfuscator LuCI application
+# Copyright (C) 2024-2026 Alexey Cluster <cluster@cluster.wtf>
+# This file is distributed under the same license as the wg-obfuscator package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: wg-obfuscator 1.6\n"
+"POT-Creation-Date: 2026-09-03 00:00+0000\n"
+"PO-Revision-Date: 2026-09-03 00:00+0000\n"
+"Last-Translator: AI Assistant\n"
+"Language-Team: Simplified Chinese\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:67
+msgid "Action completed successfully"
+msgstr "操作已成功完成"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:69
+msgid "Action failed"
+msgstr "操作失败"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:125
+msgid "Add instance"
+msgstr "添加实例"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:219
+msgid "Allow Non-Obfuscated Clients"
+msgstr "允许未混淆的客户端"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:185
+msgid "Always"
+msgstr "总是"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:159
+msgid "Auto-detect"
+msgstr "自动检测"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:184
+msgid "Automatic"
+msgstr "自动"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:113
+msgid "Collecting data..."
+msgstr "收集数据中..."
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:57
+msgid "Configuration"
+msgstr "配置"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:97
+msgid ""
+"Configure WireGuard Obfuscator instances to obfuscate WireGuard traffic."
+msgstr "配置 WireGuard Obfuscator 实例以混淆 WireGuard 流量。"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:122
+msgid ""
+"Configure individual obfuscator instances. Each instance can have "
+"different settings."
+msgstr "配置各个混淆器实例。每个实例可以有不同的设置。"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:168
+msgid "Debug"
+msgstr "调试"
+
+# Enable/Disable
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable"
+msgstr "启用"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:127
+msgid "Enable this instance"
+msgstr "启用此实例"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:60
+msgid "Enabled instances"
+msgstr "已启用的实例"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:165
+msgid "Errors only"
+msgstr "仅错误"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:58
+msgid "Exists"
+msgstr "存在"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:214
+msgid "Firewall Mark"
+msgstr "防火墙标记"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:230
+msgid "Firewall mark must be 0-65535, decimal or 0x hex"
+msgstr "防火墙标记必须为 0-65535（十进制或 0x 十六进制）"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:220
+msgid ""
+"For servers only: accept clients that send plain (non-obfuscated) "
+"WireGuard traffic and forward it as is, in both directions. Disables "
+"automatic obfuscation direction detection, so do not enable it on the "
+"client side. Not compatible with static bindings."
+msgstr ""
+"仅适用于服务端：接受发送明文（未混淆）WireGuard "
+"流量的客户端，并在两个方向上原样转发。这会禁用混淆方向的自动检测，因此请勿在客户端启用。与静态绑定不兼容。"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json:3
+msgid "Grant access to WireGuard Obfuscator configuration"
+msgstr "授予访问 WireGuard Obfuscator 配置的权限"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:194
+msgid "Idle Timeout"
+msgstr "空闲超时"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:195
+msgid "Idle timeout in seconds"
+msgstr "空闲超时（秒）"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:199
+msgid "Incoming Timeout"
+msgstr "接收超时"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:167
+msgid "Info"
+msgstr "信息"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:121
+msgid "Instances"
+msgstr "实例"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:151
+msgid "Interface to bind to (0.0.0.0 for all interfaces)"
+msgstr "要绑定的接口（0.0.0.0 表示所有接口）"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:243
+msgid "Invalid format. Expected: ip:port:localport"
+msgstr "格式无效。应为：ip:端口:本地端口"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:246
+msgid "Invalid host: %s"
+msgstr "主机无效：%s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:252
+msgid "Invalid local port: %s"
+msgstr "本地端口无效：%s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:249
+msgid "Invalid remote port: %s"
+msgstr "远程端口无效：%s"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:145
+msgid "Key used for obfuscation (must be the same on both sides)"
+msgstr "用于混淆的密钥（两端必须相同）"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:132
+msgid "Local port to listen for incoming connections"
+msgstr "用于监听传入连接的本地端口"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:172
+msgid "Log File"
+msgstr "日志文件"
+
+# Logging settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:163
+msgid "Log Level"
+msgstr "日志级别"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:182
+msgid "Log Timestamps"
+msgstr "日志时间戳"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:177
+msgid "Log file path must be absolute"
+msgstr "日志文件路径必须是绝对路径"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:215
+msgid ""
+"Mark (SO_MARK) applied to the packets the obfuscator sends, 0 = disabled. "
+"Useful together with a routing rule that keeps traffic to the VPN server "
+"outside of the tunnel."
+msgstr "为混淆器发出的数据包设置的标记（SO_MARK），0 = 禁用。与将 VPN 服务器流量保持在隧道之外的路由规则配合使用时很有用。"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:156
+msgid "Masking Type"
+msgstr "伪装类型"
+
+# Advanced settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:189
+msgid "Max Clients"
+msgstr "最大客户端数"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:209
+msgid "Max Dummy Data"
+msgstr "最大填充数据"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:210
+msgid "Maximum dummy data length for packets (0-255)"
+msgstr "数据包中填充数据的最大长度（0-255）"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:190
+msgid "Maximum number of concurrent clients"
+msgstr "并发客户端的最大数量"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:186
+msgid "Never"
+msgstr "从不"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:158
+msgid "None"
+msgstr "无"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:59
+msgid "Not found"
+msgstr "未找到"
+
+# Security settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:144
+msgid "Obfuscation Key"
+msgstr "混淆密钥"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:183
+msgid ""
+"Prefix log lines with a timestamp. Automatic means timestamps are added "
+"only when a log file is used, since the system log adds its own."
+msgstr "在每行日志前加上时间戳。“自动”表示仅在使用日志文件时添加时间戳，因为系统日志会自带时间戳。"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:157
+msgid "Protocol masking for DPI evasion"
+msgstr "用于规避 DPI 的协议伪装"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:205
+msgid ""
+"Re-resolve the target hostname and hostnames in static bindings every N "
+"seconds (0 = only at start and on service reload). A non-zero value also "
+"retries a failed resolve at startup instead of exiting. Lookups run in the"
+" background and do not stall traffic."
+msgstr ""
+"每 N 秒重新解析目标主机名以及静态绑定中的主机名（0 = "
+"仅在启动和重载服务时解析）。非零值还会在启动时重试失败的解析，而不是直接退出。解析在后台进行，不会阻塞流量。"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:204
+msgid "Resolve Interval"
+msgstr "解析间隔"
+
+# Control buttons template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:117
+msgid "Restart Service"
+msgstr "重启服务"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:55
+msgid "Running"
+msgstr "运行中"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:160
+msgid "STUN"
+msgstr "STUN"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:200
+msgid ""
+"Same as Idle Timeout, but only counts data received from the target (0 = "
+"disabled). Intended for clients: detects a dead or silently blocked "
+"server. If the client is still active and static bindings are not used, a "
+"new session is created with a fresh outbound UDP port. Useful when DPI "
+"bans a particular IP:port pair."
+msgstr ""
+"与空闲超时相同，但只统计从目标接收到的数据（0 = "
+"禁用）。适用于客户端：可检测已失效或被静默封锁的服务器。如果客户端仍然活跃且未使用静态绑定，将使用新的出站 UDP 端口创建新会话。当 DPI "
+"封禁特定的 IP:端口 组合时很有用。"
+
+# Service status template
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:54
+msgid "Service Status"
+msgstr "服务状态"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:150
+msgid "Source Interface"
+msgstr "源接口"
+
+# Network settings
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:131
+msgid "Source Port"
+msgstr "源端口"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:224
+msgid "Static Bindings"
+msgstr "静态绑定"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:225
+msgid ""
+"Static bindings for two-way mode. Enter each binding as ip:port:localport,"
+" one per line."
+msgstr "双向模式的静态绑定。每行输入一条，格式为 ip:端口:本地端口。"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:56
+msgid "Stopped"
+msgstr "已停止"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:137
+msgid "Target"
+msgstr "目标"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:138
+msgid "Target server in format host:port"
+msgstr "目标服务器，格式为 主机:端口"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:169
+msgid "Trace"
+msgstr "跟踪"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:164
+msgid "Verbosity level for logging"
+msgstr "日志的详细程度"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:166
+msgid "Warnings"
+msgstr "警告"
+
+#: applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json:3
+msgid "WireGuard Obfuscator"
+msgstr "WireGuard Obfuscator"
+
+# Main configuration page
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:96
+msgid "WireGuard Obfuscator Configuration"
+msgstr "WireGuard Obfuscator 配置"
+
+#: applications/luci-app-wg-obfuscator/htdocs/luci-static/resources/view/wg-obfuscator/settings.js:173
+msgid ""
+"Write the log to this file instead of the system log. Leave empty to keep "
+"using the system log (logread). Avoid writing to the router flash memory, "
+"use /tmp or an external drive instead."
+msgstr "将日志写入此文件而不是系统日志。留空则继续使用系统日志（logread）。请勿写入路由器的闪存，建议使用 /tmp 或外部存储设备。"
+
+#~ msgid "Name"
+#~ msgstr "名称"
+
+#~ msgid "Refresh Status"
+#~ msgstr "刷新状态"
+
+#~ msgid "Processing..."
+#~ msgstr "处理中..."
+
+#~ msgid "Connection error"
+#~ msgstr "连接错误"
+
+#~ msgid "Restart WireGuard Obfuscator service?"
+#~ msgstr "确定重启 WireGuard Obfuscator 服务吗？"
+
+# Validation messages
+#~ msgid "Target cannot be empty"
+#~ msgstr "目标不能为空"
+
+#~ msgid "Invalid format. Expected: host:port (e.g., example.com:51820)"
+#~ msgstr "格式无效。应为：主机:端口（例如 example.com:51820）"
+
+#~ msgid "Host cannot be empty"
+#~ msgstr "主机不能为空"
+
+#~ msgid "Invalid port. Must be between 1 and 65535"
+#~ msgstr "端口无效。必须介于 1 和 65535 之间"
+
+#~ msgid "Invalid IP address: "
+#~ msgstr "IP 地址无效："
+
+#~ msgid "Invalid remote port: "
+#~ msgstr "远程端口无效："
+
+#~ msgid "Invalid local port: "
+#~ msgstr "本地端口无效："

--- a/applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json
+++ b/applications/luci-app-wg-obfuscator/root/usr/share/luci/menu.d/luci-app-wg-obfuscator.json
@@ -1,0 +1,14 @@
+{
+	"admin/services/wg-obfuscator": {
+		"title": "WireGuard Obfuscator",
+		"order": 60,
+		"action": {
+			"type": "view",
+			"path": "wg-obfuscator/settings"
+		},
+		"depends": {
+			"acl": [ "luci-app-wg-obfuscator" ],
+			"fs": { "/usr/bin/wg-obfuscator": "executable" }
+		}
+	}
+}

--- a/applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json
+++ b/applications/luci-app-wg-obfuscator/root/usr/share/rpcd/acl.d/luci-app-wg-obfuscator.json
@@ -1,0 +1,20 @@
+{
+	"luci-app-wg-obfuscator": {
+		"description": "Grant access to WireGuard Obfuscator configuration",
+		"read": {
+			"file": {
+				"/var/etc/wg-obfuscator.conf": [ "list" ]
+			},
+			"ubus": {
+				"service": [ "list" ]
+			},
+			"uci": [ "wg-obfuscator" ]
+		},
+		"write": {
+			"file": {
+				"/etc/init.d/wg-obfuscator restart": [ "exec" ]
+			},
+			"uci": [ "wg-obfuscator" ]
+		}
+	}
+}


### PR DESCRIPTION
## Pull request details

### Description

Adds a LuCI interface for `wg-obfuscator`, the WireGuard traffic obfuscator.

The page sits under **Services → WireGuard Obfuscator** and is a client-side JavaScript view, so it depends on `luci-base` alone and needs no Lua runtime. It maps every UCI option that the daemon's configuration generator reads: listen address and port, target, obfuscation key, protocol masking, dummy padding, the idle/incoming/resolve timeouts, firewall mark, log destination and timestamps, maximum clients, and the static bindings used for two-way mode. Above the form it polls the service state through `ubus service list`, reports whether the generated configuration exists, counts the enabled instances and offers a restart button.

Validation uses the stock `luci-base` datatypes (`hostport`, `port`, `ipaddr`, `range`) instead of hand-written checks. The static bindings field is validated line by line against `host:port:localport`, accepting hostnames since the daemon resolves them.

Translations are included for German, Spanish, French, Brazilian Portuguese, Russian, Turkish, Ukrainian and Simplified Chinese; `po/templates/wg-obfuscator.pot` was generated with `build/i18n-sync.sh`.

### Screenshot or video of changes _(if applicable)_

<img width="1212" height="1305" alt="image" src="https://github.com/user-attachments/assets/ad178f78-7dc7-4618-b750-6b64bb131f8d" />

### Maintainer _(preferred)_

@ClusterM
<sub>(New package. I am the upstream author of `wg-obfuscator` and will maintain this app.)</sub>

---

## Tested on

**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4) on a Cudy WR3000 v1 (mediatek/filogic)
**LuCI version:** luci-base 26.180.75667~128a781
**Web browser(s):** Google Chrome 150.0.7871.186 (Official Build) (64-bit) 

Verified on that device:

- the app and all eight `luci-i18n-wg-obfuscator-*` packages build and install cleanly
- `/admin/services/wg-obfuscator` dispatches to the view and the menu dependency on `/usr/bin/wg-obfuscator` resolves
- the ACL grants exactly what the view uses, and each call was exercised through a real LuCI session: `service list` for the status, and the init script `restart`, which regenerates the daemon configuration
- all eight catalogs are delivered to the client by `/cgi-bin/luci/admin/translations/<lang>`

---

## Checklist

- [x] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).

Depends on openwrt/packages#30441, which adds the `wg-obfuscator` daemon this app configures and which `LUCI_DEPENDS` references. Filed as a draft until that one lands.
