### PR TITLE
luci-app-csshnpd: warn if manager atSign same as device atSign

### DIFF
--- a/applications/luci-app-csshnpd/Makefile
+++ b/applications/luci-app-csshnpd/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-csshnpd
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 LUCI_TITLE:=NoPorts Web UI
 LUCI_DESCRIPTION:=LuCI config app for NoPorts daemon (csshnpd)

--- a/applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js
+++ b/applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js
@@ -2,10 +2,64 @@
 'require view';
 'require form';
 
+function normalizeAtsign(s) {
+	if (!s)
+		return '';
+	s = s.trim().toLowerCase();
+	if (s.length === 0)
+		return '';
+	return s.startsWith('@') ? s : '@' + s;
+}
+
 function validateAtsign(section_id, value) {
-	if (value.length < 1) {
+	if (!value || value.trim().length < 1) {
 		return _('Must not be empty and should start with @ (e.g., "@a").');
 	}
+
+	if (value.indexOf(',') !== -1) {
+		return _('Device atSign must be a single atSign.');
+	}
+
+	let mgr = this.section ? this.section.getOption('manager') : null;
+	if (mgr) {
+		mgr.triggerValidation(section_id);
+	}
+
+	return true;
+}
+
+function validateManager(section_id, value) {
+	if (!value || value.trim().length < 1) {
+		return _('Must not be empty and should start with @ (e.g., "@a").');
+	}
+
+	let devOpt = this.section ? this.section.getOption('atsign') : null;
+	let devAtsign = null;
+	if (devOpt) {
+		devAtsign = devOpt.formvalue(section_id);
+		if (devAtsign == null) {
+			devAtsign = devOpt.cfgvalue(section_id);
+		}
+		if (devAtsign == null) {
+			devAtsign = devOpt.default;
+		}
+	}
+
+	let normDev = normalizeAtsign(devAtsign);
+
+	let managers = value.split(',').map(s => s.trim()).filter(s => s.length > 0);
+	if (managers.length === 0) {
+		return _('Must not be empty and should start with @ (e.g., "@a").');
+	}
+
+	if (normDev && normDev !== '@') {
+		for (let mgr of managers) {
+			if (normalizeAtsign(mgr) === normDev) {
+				return _('Manager atSign must not be the same as Device atSign.');
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -37,8 +91,22 @@ function validateOTP(section_id, value) {
 }
 
 function firstAt(section_id, value) {
-	if (value && !value.startsWith('@')) {
-		value = '@' + value; // Ensure @ at start
+	if (value) {
+		value = value.trim();
+		if (!value.startsWith('@')) {
+			value = '@' + value; // Ensure @ at start
+		}
+	}
+	return this.super('write', [section_id, value]);
+}
+
+function writeManager(section_id, value) {
+	if (value) {
+		let list = value.split(',')
+			.map(s => s.trim())
+			.filter(s => s.length > 0)
+			.map(s => s.startsWith('@') ? s : '@' + s);
+		value = list.join(',');
 	}
 	return this.super('write', [section_id, value]);
 }
@@ -62,8 +130,8 @@ return view.extend({
 		o = s.option(form.Value, 'manager', _('Manager atSign'),
 			_('The manager atSign e.g. @manager'));
 		o.default = '@manager';
-		o.validate = validateAtsign;
-		o.write = firstAt;
+		o.validate = validateManager;
+		o.write = writeManager;
 
 		o = s.option(form.Value, 'device', _('Device name'),
 			_('The name for this device e.g. openwrt'));

--- a/applications/luci-app-csshnpd/po/templates/csshnpd.pot
+++ b/applications/luci-app-csshnpd/po/templates/csshnpd.pot
@@ -1,35 +1,39 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:73
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:141
 msgid "Additional arguments"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:82
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:150
 msgid "Check here to enable the service"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:51
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:119
 msgid "Daemon Configuration"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:56
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:124
 msgid "Device atSign"
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:20
+msgid "Device atSign must be a single atSign."
 msgstr ""
 
 #: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/enroll.js:81
 msgid "Device must be configured"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:136
 msgid "Device name"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:24
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:78
 msgid "Device names may contain a-z 0-9 _ or - (e.g., \"my_thing1\")."
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:149
 msgid "Enabled"
 msgstr ""
 
@@ -37,7 +41,7 @@ msgstr ""
 msgid "Enroll"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:76
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:144
 msgid "Enrollment OTP/SPP"
 msgstr ""
 
@@ -45,11 +49,11 @@ msgstr ""
 msgid "Existing key found at:"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:18
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:72
 msgid "First character should be a lowercase letter (e.g., \"a\")."
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:74
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:142
 msgid "Further command line arguments for the NoPorts daemon"
 msgstr ""
 
@@ -57,27 +61,33 @@ msgstr ""
 msgid "Grant UCI access for luci-app-csshnpd"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:62
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:130
 msgid "Manager atSign"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:27
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:58
+msgid "Manager atSign must not be the same as Device atSign."
+msgstr ""
+
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:81
 msgid "Maximum device name length is 36 characters."
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:14
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:68
 msgid "Must be at least one character long (e.g., \"a\")."
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:34
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:88
 msgid "Must be six characters (e.g., \"S3CR3T\")."
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:7
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:16
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:33
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:52
 msgid "Must not be empty and should start with @ (e.g., \"@a\")."
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:50
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:118
 #: applications/luci-app-csshnpd/root/usr/share/luci/menu.d/luci-app-csshnpd.json:3
 msgid "NoPorts"
 msgstr ""
@@ -98,7 +108,7 @@ msgstr ""
 msgid "OTP must be configured. An OTP can be generated using:"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:77
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:145
 msgid "One Time Passcode (OTP) for device atSign enrollment"
 msgstr ""
 
@@ -106,15 +116,15 @@ msgstr ""
 msgid "Press the Enroll button then run this command on a system where"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:57
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:125
 msgid "The device atSign e.g. @device"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:63
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:131
 msgid "The manager atSign e.g. @manager"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:69
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:137
 msgid "The name for this device e.g. openwrt"
 msgstr ""
 
@@ -122,6 +132,6 @@ msgstr ""
 msgid "atSign must be configured"
 msgstr ""
 
-#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:53
+#: applications/luci-app-csshnpd/htdocs/luci-static/resources/view/sshnpd/config.js:121
 msgid "sshnpd config"
 msgstr ""


### PR DESCRIPTION
## Pull request details

### Description
Adding check to ensure that device and manager atSigns are different


### Screenshot of changes

<img width="633" height="186" alt="image" src="https://github.com/user-attachments/assets/fbc9860f-e9db-490f-8b13-329beaf1cc5c" />


### Maintainer
@cpswan

---

## Tested on

**OpenWrt version:** OpenWrt 25.12.5 (r33051-f5dae5ece4)
**LuCI version:** LuCI openwrt-25.12 branch (26.239.42882~e60322b)
**Web browser(s):** Chrome 152.0.7977.82, Edge 152.0.4191.62

---

## Checklist

- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
