### PR TITLE
treewide: wrap loose view content in cbi-section

### DIFF
--- a/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
+++ b/applications/luci-app-package-manager/htdocs/luci-static/resources/view/package-manager.js
@@ -1247,7 +1247,7 @@ return view.extend({
 				))
 			]),
 
-			E('div', { 'class': 'controls' }, [
+			E('div', { 'class': 'cbi-section' }, E('div', { 'class': 'controls' }, [
 				E('div', {}, [
 					E('label', {'id': 'disk-space-label'}, _('Disk space') + ':'),
 					E('div', { 'class': 'cbi-progressbar', 'title': _('unknown') }, E('div', {}, [ '\u00a0' ]))
@@ -1322,7 +1322,7 @@ return view.extend({
 						])
 					])
 				])
-			]),
+			])),
 
 			E('ul', { 'class': 'cbi-tabmenu mode' }, [
 				E('li', { 'data-mode': 'available', 'class': 'available cbi-tab', 'click': handleMode }, E('a', { 'href': '#' }, [ _('Available') ])),
@@ -1330,6 +1330,7 @@ return view.extend({
 				E('li', { 'data-mode': 'updates', 'class': 'installed cbi-tab-disabled', 'click': handleMode }, E('a', { 'href': '#' }, [ _('Updates') ]))
 			]),
 
+			E('div', { 'class': 'cbi-section' }, [
 			E('div', { 'class': 'controls', 'style': 'display:none' }, [
 				E('div', { 'class': 'pager center' }, [
 					E('button', { 'class': 'btn cbi-button-neutral prev', 'aria-label': _('Previous page'), 'click': handlePage }, [ '«' ]),
@@ -1354,6 +1355,7 @@ return view.extend({
 					E('div', { 'class': 'text' }, [ 'dummy' ]),
 					E('button', { 'class': 'btn cbi-button-neutral next', 'aria-label': _('Next page'), 'click': handlePage }, [ '»' ])
 				])
+			])
 			])
 		]);
 

--- a/modules/luci-base/htdocs/luci-static/resources/tools/views.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/views.js
@@ -251,7 +251,7 @@ var CBILogreadBox = function(logtag, name) {
 
 			return E([], [
 				E('h2', {}, [ this.logName ]),
-				E('div', { 'id': 'content_syslog' }, [
+				E('div', { 'id': 'content_syslog', 'class': 'cbi-section' }, [
 					E('div', { class: 'cbi-section-descr' }, this.logTagFilter ? _('The syslog output, pre-filtered for messages related to: ' + this.logTagFilter) : '') ,
 					E('div', { 'style': 'margin-bottom:10px' }, [
 						E('label', { 'for': 'invertLogFacilitySearch', 'style': 'margin-right:5px' }, _('Not')),

--- a/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js
+++ b/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js
@@ -59,7 +59,7 @@ return view.extend({
 			]));
 		}
 
-		return E('div', { 'class': 'cbi-section' }, table);
+		return table;
 	},
 
 	renderTable(data) {
@@ -80,12 +80,13 @@ return view.extend({
 			]));
 		}
 
-		return E('div', { 'class': 'cbi-section' }, table);
+		return table;
 	},
 
 	renderContent(data) {
 		return E([], [
 
+			E('div', { 'class': 'cbi-section' }, [
 			E('h3', {}, [ _('Connection State') ]),
 
 			this.renderSimpleTable([
@@ -94,16 +95,18 @@ return view.extend({
 				[ _('Line Uptime'), '%t'.format(data.uptime) ],
 				[ _('Annex'), data.annex ],
 				[ _('Power Management Mode'), data.power_state ]
-			]),
+			]) ]),
 
+			E('div', { 'class': 'cbi-section' }, [
 			E('h3', {}, [ _('Inventory') ]),
 
 			this.renderSimpleTable([
 				[ _('Modem Chipset'), data.chipset ],
 				[ _('Modem Firmware'), data.firmware_version ],
 				[ _('xTU-C Vendor ID'), data.atu_c.vendor || data.atu_c.vendor_id ]
-			]),
+			]) ]),
 
+			E('div', { 'class': 'cbi-section' }, [
 			E('h3', {}, [ _('Line Details') ]),
 
 			E('h4', {}, [ _('Data Rates') ]),
@@ -132,8 +135,9 @@ return view.extend({
 				[ _('Signal Attenuation (SATN)'), '%.1f dB', data.downstream.satn, data.upstream.satn ],
 				[ _('Noise Margin (SNRM)'), '%.1f dB', data.downstream.snr, data.upstream.snr ],
 				[ _('Aggregate Transmit Power (ACTATP)'), '%.1f dB', data.downstream.actatp, data.upstream.actatp ]
-			]),
+			]) ]),
 
+			E('div', { 'class': 'cbi-section' }, [
 			E('h3', {}, [ _('Error Counters') ]),
 
 			E('h4', {}, [ _('Error Seconds') ]),
@@ -164,7 +168,7 @@ return view.extend({
 				[ _('Retransmitted DTUs (rtx-tx)'), '%d', data.errors.far.tx_retransmitted, data.errors.near.tx_retransmitted ],
 				[ _('Corrected DTUs (rtx-c)'), '%d', data.errors.near.rx_corrected, data.errors.far.rx_corrected ],
 				[ _('Uncorrected DTUs (rtx-uc)'), '%d', data.errors.near.rx_uncorrected_protected, data.errors.far.rx_uncorrected_protected ]
-			])
+			]) ])
 
 		]);
 	},

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -2676,7 +2676,10 @@ return view.extend({
 
 			cbi_update_table(table, [], E('em', { 'class': 'spinning' }, _('Collecting data...')));
 
-			return E([ nodes, E('h3', _('Associated Stations')), table ]);
+			return E([ nodes, E('div', { 'class': 'cbi-section' }, [
+				E('h3', _('Associated Stations')),
+				table
+			]) ]);
 		}, this, m));
 	},
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -252,7 +252,7 @@ return view.extend({
 
 		return E([], [
 			E('h2', {}, [ _('Kernel Log') ]),
-			E('div', { 'id': 'content_syslog' }, [
+			E('div', { 'id': 'content_syslog', 'class': 'cbi-section' }, [
 				E('div', { 'style': 'margin-bottom:10px' }, [
 					E('label', { 'for': 'invertLogFacilitySearch', 'style': 'margin-right:5px' }, _('Not')),
 					rangeTimeInvert,

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
@@ -18,7 +18,7 @@ return view.extend({
 		const title = '%s: %s'.format(_('Table'), table);
 
 		if (!tdiv) {
-			tdiv = E('div', { 'data-table': '%s-%s'.format(is_ipv6 ? 'ipv6' : 'ipv4', table) }, [
+			tdiv = E('div', { 'class': 'cbi-section', 'data-table': '%s-%s'.format(is_ipv6 ? 'ipv6' : 'ipv4', table) }, [
 				E('h3', {}, title),
 				E('div')
 			]);

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
@@ -703,7 +703,7 @@ return view.extend({
 			break;
 		}
 
-		const node = E('div', { 'class': 'nft-chain' }, [
+		const node = E('div', { 'class': 'nft-chain cbi-section' }, [
 			E('h4', {
 				'id': '%h.%h'.format(spec.table, spec.name)
 			}, [ title ])
@@ -775,14 +775,15 @@ return view.extend({
 		const node = E([], [
 			E('style', { 'type': 'text/css' }, [
 				'.nft-rules .ifacebadge { margin: .125em }',
-				'.nft-rules tr > td { padding: .25em !important }',
+				/* dense rows: a long chain would otherwise run off the screen */
+				'.nft-rules.cbi-section-table tr > td { padding: .25em }',
 				'.nft-set, .nft-list { display: inline-block; vertical-align: middle }',
 				'.nft-set-items, .nft-list-items { display: inline-block; vertical-align: middle; max-width: 200px; overflow: hidden; text-overflow: ellipsis }',
 				'.ifacebadge.cbi-tooltip-container { cursor: help }',
 				'.ifacebadge.cbi-tooltip-container .cbi-tooltip { padding: .5em }'
 			]),
 			E('div', { 'class': 'nft-table' }, [
-				E('h3', [ title ]),
+				E('div', { 'class': 'cbi-section' }, E('h3', [ title ])),
 				E('div', { 'class': 'nft-chains' })
 			])
 		]);

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js
@@ -60,23 +60,25 @@ return view.extend({
 	},
 
 	render: function(processes) {
+		var table = E('table', { 'class': 'table' }, [
+			E('tr', { 'class': 'tr table-titles' }, [
+				E('th', { 'class': 'th' }, _('PID')),
+				E('th', { 'class': 'th' }, _('Owner')),
+				E('th', { 'class': 'th' }, _('Command')),
+				E('th', { 'class': 'th' }, _('CPU usage (%)')),
+				E('th', { 'class': 'th' }, _('Memory usage (%)')),
+				E('th', { 'class': 'th center nowrap cbi-section-actions' })
+			])
+		]);
+
 		var v = E([], [
 			E('h2', _('Processes')),
 			E('div', { 'class': 'cbi-map-descr' }, _('This list gives an overview over currently running system processes and their status.')),
 
-			E('table', { 'class': 'table' }, [
-				E('tr', { 'class': 'tr table-titles' }, [
-					E('th', { 'class': 'th' }, _('PID')),
-					E('th', { 'class': 'th' }, _('Owner')),
-					E('th', { 'class': 'th' }, _('Command')),
-					E('th', { 'class': 'th' }, _('CPU usage (%)')),
-					E('th', { 'class': 'th' }, _('Memory usage (%)')),
-					E('th', { 'class': 'th center nowrap cbi-section-actions' })
-				])
-			])
+			E('div', { 'class': 'cbi-section' }, table)
 		]);
 
-		this.updateTable(v.lastElementChild, processes);
+		this.updateTable(table, processes);
 
 		return v;
 	},

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js
@@ -108,11 +108,11 @@ return view.extend({
 		var view = E('div', {}, [
 			E('h2', _('Startup')),
 			E('div', {}, [
-				E('div', { 'data-tab': 'init', 'data-tab-title': _('Initscripts') }, [
+				E('div', { 'class': 'cbi-section', 'data-tab': 'init', 'data-tab-title': _('Initscripts') }, [
 					E('p', {}, _('You can enable or disable installed init scripts here. Changes will be applied after a device reboot.<br /><strong>Warning: If you disable essential init scripts like "network", your device might become inaccessible!</strong>')),
 					table
 				]),
-				E('div', { 'data-tab': 'rc', 'data-tab-title': _('Local Startup') }, [
+				E('div', { 'class': 'cbi-section', 'data-tab': 'rc', 'data-tab-title': _('Local Startup') }, [
 					E('p', {}, _('This is the content of /etc/rc.local. Insert your own commands here (in front of \'exit 0\') to execute them at the end of the boot process.')),
 					E('p', {}, E('textarea', { 'style': 'width:100%', 'rows': 20, 'disabled': isReadonlyView }, [ (rcLocal != null ? rcLocal : '') ])),
 					E('div', { 'class': 'cbi-page-actions' }, [


### PR DESCRIPTION
Some views return headings, tables and control rows straight into the view, with no element around them. A theme that draws `.cbi-section` as a panel then has nothing to draw, and the content sits loose on the page.

Pages touched: Status → Processes, System Log, Kernel Log, Firewall (nftables and legacy iptables), DSL stats; System → Startup, Software; Network → Wireless (Associated Stations).

The nftables rule tables also lose the `!important` on their cell padding, which no theme could override — the same value wins on specificity now.

Verified against the stock bootstrap theme: every affected page renders pixel-identical before and after (md5 of the rendered page at 1280×900). Themes that draw `.cbi-section` as a panel get the structure they need.
