### PR TITLE
protocols: remove myself as maintainer for vpnc

### DIFF
--- a/protocols/luci-proto-vpnc/Makefile
+++ b/protocols/luci-proto-vpnc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for VPNC VPN
 LUCI_DEPENDS:=+vpnc
 
-PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+PKG_MAINTAINER:=
 PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk


### PR DESCRIPTION
## Pull request details

### Description

I  have not had touched this in years, and was
added as maintainer during treewide
PKG_MAINTAINER additions. I do not
have anything to test this against. Therefore,
removing myself as maintainer.

### Maintainer
None

### Also notify
@hnyman @systemcrash 

---

## Tested on

N/A

---

## Checklist
- [ ] Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
