### PR TITLE
luci-app-frp: avoid saving the same form twice

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -1412,7 +1412,7 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
+			return E('div', {},
 				E('fieldset', { class: 'cbi-section' }, [
 					E('p', { id: 'service_status' }, _('Collecting data ...'))
 				])

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -964,7 +964,7 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
+			return E('div', {},
 				E('fieldset', { class: 'cbi-section' }, [
 					E('p', { id: 'service_status' }, _('Collecting data ...'))
 				])


### PR DESCRIPTION
The status section renders a nested cbi-map without a bound form instance. LuCI resolves it to the enclosing map, so save and reset invoke that map twice. Concurrent saves can submit duplicate UCI delete requests and report resource not found.

<!-- 

Thank you for your contribution to the LuCI repository.

/*************************************************************************/
/*   PLEASE READ THIS BEFORE CREATING YOUR PULL REQUEST (PR)   */
/*************************************************************************/

Review the Contributing Guidelines: https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
(Especially if this is your first time to contribute to this repo.)

MUST NOT:
- Add a PR from your *main* branch - instead, put it on a separate branch.
- Add merge commits to your PR - instead, rebase locally and force-push.

MUST:
- Increment any PKG_VERSION in the affected Makefile.
- Set to draft if this PR depends on other PRs as well (e.g. openwrt/openwrt).
- Have each commit subject line starting with '<package name>: title', and the title starting in lowercase, with a reasonable number of characters total.
- Have a commit comment as it cannot be empty, with a reasonable number of characters per line.
- Have each commit with a valid `Signed-off-by:` (S.O.B.) with a reachable email (GitHub noreply emails are not accepted).
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- Your S.O.B. *may* be a nickname.
- Delete the *optional* entries in the checklist that do not apply.
- Skip a `<package name>: title` first line subject if the commit is for house-keeping or a chore.

-->

## Pull request details

### Description
<!-- Describe the changes proposed in this PR. -->
Remove the form marker from the status wrapper while retaining its fieldset and polling. This addresses the duplicate-save cause of issue https://github.com/openwrt/luci/issues/7679.

### Screenshot or video of changes _(if applicable)_
<!-- Insert your screenshot or video here. -->
Related with issue #7679.

### Maintainer _(preferred)_
<!-- You can find this by checking the history of the package Makefile. -->
Cannot find it in the Makefile, maybe ask @ysc3839 for help?
---

## Tested on
<!-- You can find this by:
- looking at the footer on LuCI, 
- or using the following command: ubus call system board -->
**OpenWrt version:** ImmortalWrt 25.12.1 (OpenWrt downstream)<!-- e.g. OpenWrt 25.12.2 (r32802-f505120278) -->
**LuCI version:** ImmortalWrt branch openwrt-25.12 26.187.07797~ed7692c (OpenWrt downstream)<!-- e.g. LuCI openwrt-25.12 branch (26.100.49936~3cefdb7) -->
**Web browser(s):** Edge 152.0.4191.53<!-- e.g. Chrome 147.0.7727.55, Safari 26.5 (21624.2.2) -->

---

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
