### PR TITLE
luci-app-apfree-wifidog: add new application

### DIFF
--- a/applications/luci-app-apfree-wifidog/Makefile
+++ b/applications/luci-app-apfree-wifidog/Makefile
@@ -1,0 +1,13 @@
+# This is free software, licensed under the Apache License, Version 2.0
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI Support for apfree-wifidog
+LUCI_DEPENDS:=+apfree-wifidog
+
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js
+++ b/applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js
@@ -1,0 +1,1029 @@
+'use strict';
+'require view';
+'require ui';
+'require form';
+'require rpc';
+'require uci';
+'require tools.widgets as widgets';
+
+var CBIWifidogxGroupSelect = form.ListValue.extend({
+	__name__: 'CBI.WifidogxGroupSelect',
+
+	group_type: '1',
+
+	load: function(section_id) {
+		this.sappList = [];
+		var sections = uci.sections('wifidogx', 'group');
+
+		for (var i = 0; i < sections.length; i++) {
+			if (sections[i]['g_type'] == this.group_type)
+				this.sappList.push(sections[i]['.name']);
+		}
+
+		return this.super('load', section_id);
+	},
+
+	setGroupType: function(group_type) {
+		if (group_type == 'mac') {
+			this.group_type = '2';
+		} else if (group_type == 'wildcard') {
+			this.group_type = '3';
+		}
+	},
+
+	filter: function(section_id, value) {
+		return true;
+	},
+
+	renderWidget: function(section_id, option_index, cfgvalue) {
+		var values = L.toArray((cfgvalue != null) ? cfgvalue : this.default),
+		    choices = {},
+		    checked = {},
+		    i, name;
+
+		for (i = 0; i < values.length; i++)
+			checked[values[i]] = true;
+
+		values = [];
+
+		if (!this.multiple && (this.rmempty || this.optional))
+			choices[''] = E('em', _('unspecified'));
+
+		for (i = 0; i < this.sappList.length; i++) {
+			name = this.sappList[i];
+
+			if (checked[name])
+				values.push(name);
+
+			choices[name] =  E('span', { 'class': 'ifacebadge' }, name);
+		}
+
+		var widget = new ui.Dropdown(this.multiple ? values : values[0], choices, {
+			id: this.cbid(section_id),
+			sort: true,
+			multiple: this.multiple,
+			optional: this.optional || this.rmempty,
+			disabled: (this.readonly != null) ? this.readonly : this.map.readonly,
+			select_placeholder: E('em', _('unspecified')),
+			display_items: this.display_size || this.size || 3,
+			dropdown_items: this.dropdown_size || this.size || 5,
+			validate: L.bind(this.validate, this, section_id),
+			create: !this.nocreate,
+			create_markup: '' +
+				'<li data-value="{{value}}">' +
+					'<span class="ifacebadge" style="background:repeating-linear-gradient(45deg,rgba(204,204,204,0.5),rgba(204,204,204,0.5) 5px,rgba(255,255,255,0.5) 5px,rgba(255,255,255,0.5) 10px)">' +
+						'{{value}}: <em>('+_('create')+')</em>' +
+					'</span>' +
+				'</li>'
+		});
+
+		return widget.render();
+	}
+});
+
+var callGetLocation = rpc.declare({
+	object: 'luci.wifidogx',
+	method: 'get_location',
+	params: [],
+	expect: { result: {} }
+});
+
+var callGetWanMac = rpc.declare({
+	object: 'luci.wifidogx',
+	method: 'get_wan_mac',
+	params: [],
+	expect: { result: {} }
+});
+
+function generateDeviceId(macAddress) {
+	var macPart = macAddress.replace(/-/g, '');
+	var randomPart = '';
+	for (var i = 0; i < 7; i++) {
+		randomPart += Math.floor(Math.random() * 10);
+	}
+	return 'AW' + randomPart + macPart;
+}
+
+function generateLocationId() {
+	var adminCode = '110101';
+	var serviceType = '100';
+	var sequenceNum = '';
+	for (var i = 0; i < 5; i++) {
+		sequenceNum += Math.floor(Math.random() * 10);
+	}
+	return adminCode + serviceType + sequenceNum;
+}
+
+return view.extend({
+	render: function () {
+		var m, s, o, ss;
+
+		m = new form.Map('wifidogx', _('ApFree-WiFiDog'));
+		m.description = _('apfree-wifidog offers a stable and secure captive portal solution. For more details, see the %s.')
+			.format('<a href="https://github.com/liudf0716/apfree-wifidog" target="_blank" rel="noreferrer noopener">' + _('GitHub project page') + '</a>');
+
+
+		s = m.section(form.NamedSection, 'common', _('Configuration'));
+		s.addremove = false;
+		s.anonymous = true;
+
+		s.tab('basic', _('Basic Settings'));
+		s.tab('longconn', _('Long Connection Settings'));
+		s.tab('auth', _('Auth Server Settings'));
+		s.tab('gateway', _('Gateway Settings'));
+		s.tab('advanced', _('Advanced Settings'));
+		s.tab('rule', _('Rule Settings'));
+		s.tab('location', _('Authentication Location Settings'));
+
+		// basic settings
+		o = s.taboption('basic', form.Flag, 'enabled', _('Enable'), _('Enable apfree-wifidog service.'));
+		o.rmempty = false;
+
+		o = s.taboption('basic', form.ListValue, 'auth_server_mode', _('Auth Server Mode'),
+			_('The mode of the authentication server.'));
+		o.value('cloud', _('Cloud Auth'));
+		o.value('local', _('Local Auth'));
+		o.value('bypass', _('Bypass Auth'));
+		o.default = 'cloud';
+		o.optional = false;
+
+		// Dropdown listing the currently defined authentication servers
+		o = s.taboption('basic', form.ListValue, 'selected_auth_server', _('Authentication Server'),
+			_('Select the authentication server to use for cloud authentication.'));
+		o.rmempty = false;
+		o.optional = false;
+		o.depends('auth_server_mode', 'cloud');
+		o.load = function (section_id) {
+			this.keylist = [];
+			this.vallist = [];
+
+			var sections = uci.sections('wifidogx', 'auth');
+			if (sections.length == 0) {
+				this.value('', _('Please create an authentication server first'));
+			} else {
+				sections.forEach(L.bind(function (section) {
+					var name = section['.name'];
+					var hostname = section.auth_server_hostname || _('Unknown');
+					this.value(name, '%s (%s)'.format(name, hostname));
+				}, this));
+			}
+
+			return this.super('load', [section_id]);
+		};
+
+		o = s.taboption('basic', form.ListValue, 'selected_long_conn', _('Long Connection Profile'),
+			_('Select which long connection configuration to use. This option is always available regardless of authentication mode.'));
+		o.rmempty = true;
+		o.optional = true;
+		o.load = function (section_id) {
+			this.keylist = [];
+			this.vallist = [];
+
+			var sections = uci.sections('wifidogx', 'longconn');
+			if (sections.length == 0) {
+				this.value('', _('Please create a long connection profile first'));
+			} else {
+				sections.forEach(L.bind(function (section) {
+					var name = section['.name'];
+					var mode = section.long_conn_mode || _('Unknown');
+					this.value(name, '%s (%s)'.format(name, mode));
+				}, this));
+			}
+
+			return this.super('load', [section_id]);
+		};
+
+		o = s.taboption('basic', widgets.NetworkSelect, 'external_interface', _('External Interface'),
+			_('The external interface of the device, if bypass mode, do not choose.'));
+		o.rmempty = true;
+		o.nocreate = true;
+		o.loopback = false;
+		o.default = 'wan';
+
+		o = s.taboption('basic', form.Value, 'device_id', _('Device ID'), _('The ID of the device.'));
+		o.rmempty = false;
+		o.datatype = 'string';
+		o.optional = false;
+
+		o = s.taboption('basic', form.Value, 'local_portal', _('Local Portal'),
+			_('The local portal url.'));
+		o.rmempty = false;
+		o.datatype = 'string';
+		o.optional = true;
+		o.placeholder = 'http://www.example.com';
+		o.depends('auth_server_mode', 'local');
+
+		o = s.taboption('basic', form.Flag, 'disable_portal_auth', _('Disable Portal Authentication'),
+			_('When enabled, users can access the internet without portal authentication. Firewall redirect rules will not be created. Use this mode for pure traffic statistics without captive portal.'));
+		o.rmempty = false;
+		o.default = '0';
+
+		o = s.taboption('basic', form.ListValue, 'log_level', _('Log Level'),
+			_('The log level of the apfree-wifidog.'));
+		o.value(7, _('Debug'));
+		o.value(6, _('Info'));
+		o.value(5, _('Notice'));
+		o.value(4, _('Warning'));
+		o.value(3, _('Error'));
+		o.value(2, _('Critical'));
+		o.value(1, _('Alert'));
+		o.value(0, _('Emergency'));
+		o.default = 0;
+		o.optional = false;
+
+		// gateway settings
+		o = s.taboption('gateway', form.SectionValue, '_gateway', form.GridSection, 'gateway');
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.nodescriptions = true;
+
+		o = ss.option(form.Flag, 'gateway_auth_enabled', _('Auth Enabled'),
+			_('Enable the authentication of the gateway.'));
+		o.rmempty = false;
+		o.default = '1';
+
+		o = ss.option(widgets.DeviceSelect, 'gateway_name', _('Gateway Name'));
+		o.rmempty = false;
+		o.nocreate = true;
+		o.allowany = true;
+		o.default = 'lan';
+
+		o = ss.option(form.Value, 'gateway_channel', _('Gateway Channel'),
+			_('The channel of the gateway.'));
+		o.datatype = 'string';
+		o.rmempty = false;
+		o.optional = false;
+
+		o = ss.option(form.Value, 'gateway_id', _('Gateway ID'),
+			_('The ID of the gateway.'));
+		o.datatype = 'string';
+		o.rmempty = false;
+		o.optional = true;
+
+		o = ss.option(form.Value, 'gateway_subnetv4', _('Gateway Subnetv4'),
+			_('The ipv4 subnet of the gateway.'));
+		o.datatype = 'cidr4';
+		o.rmempty = false;
+		o.optional = false;
+		o.placeholder = '192.168.80.0/24';
+
+		// advanced settings
+		o = s.taboption('advanced', form.Value, 'check_interval', _('Check Interval'),
+			_('The interval of the check(s).'));
+		o.datatype = 'uinteger';
+		o.rmempty = false;
+		o.optional = false;
+		o.default = 60;
+
+		o = s.taboption('advanced', form.Value, 'client_timeout', _('Client Timeout'),
+			_('The timeout of the client.'));
+		o.datatype = 'uinteger';
+		o.rmempty = false;
+		o.optional = false;
+		o.default = 5;
+
+		o = s.taboption('advanced', form.Flag, 'wired_passed', _('Wired Passed'),
+			_('Wired users do not need to authenticate to access the internet.'));
+		o.rmempty = false;
+
+		o = s.taboption('advanced', form.Flag, 'apple_cna', _('Apple CNA'),
+			_('Enable Apple Captive Network Assistant.'));
+		o.rmempty = false;
+		o.default = '0';
+
+		o = s.taboption('advanced', form.Flag, 'js_filter', _('JS Filter'),
+			_('Enable JS redirect.'));
+		o.rmempty = false;
+		o.default = '1';
+
+		o = s.taboption('advanced', form.Flag, 'enable_anti_nat', _('Enable Anti NAT'),
+			_('Enable Anti NAT devices.'));
+		o.rmempty = false;
+		o.default = '0';
+
+		o = s.taboption('advanced', form.Value, 'privileged_ops_secret', _('Privileged Ops Secret'),
+			_('Local secret required for AWAS cloud platform to dynamically authorize remote OTA, reboot and system changes.'));
+		o.password = true;
+		o.rmempty = false;
+		o.optional = false;
+
+		o = s.taboption('advanced', form.Value, 'ttl_value', _('TTL Value'),
+			_('The TTL value of the gateway support.'));
+		o.datatype = 'string';
+		o.rmempty = false;
+		o.default = '64,128';
+		o.depends('enable_anti_nat', '1');
+
+		o = s.taboption('advanced', form.Value, 'anti_nat_permit_macs', _('Anti NAT Permit MAC'),
+			_('The MAC address of the Anti NAT permit.'));
+		o.datatype = 'macaddr';
+		o.rmempty = true;
+		o.depends('enable_anti_nat', '1');
+
+		// Auth Server Settings
+		o = s.taboption('auth', form.SectionValue, '_auth', form.GridSection, 'auth');
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.nodescriptions = true;
+
+		ss.handleAdd = function (ev, name) {
+			var self = this, i, longconnSections, authSections;
+			if (name) {
+				longconnSections = uci.sections('wifidogx', 'longconn');
+				for (i = 0; i < longconnSections.length; i++) {
+					if (longconnSections[i]['.name'] === name) {
+						ui.addNotification(null, E('p', _('The name "%s" already exists in Long Connection profiles. Please choose a different name.').format(name)), 'error');
+						return Promise.resolve();
+					}
+				}
+				authSections = uci.sections('wifidogx', 'auth');
+				for (i = 0; i < authSections.length; i++) {
+					if (authSections[i]['.name'] === name) {
+						ui.addNotification(null, E('p', _('The name "%s" already exists in Auth Server profiles. Please choose a different name.').format(name)), 'error');
+						return Promise.resolve();
+					}
+				}
+			}
+			return this.super('handleAdd', [ev, name]);
+		};
+
+		ss.handleRename = function (section_id, ev) {
+			var self = this;
+			var oldName = section_id;
+			var nameEl = E('input', {
+				'type': 'text',
+				'class': 'cbi-input-text',
+				'id': 'auth-rename-input',
+				'value': oldName,
+				'style': 'width: 100%;'
+			});
+			ui.showModal(_('Rename Authentication Server'), [
+				E('div', { 'class': 'cbi-section' }, [
+					E('div', { 'class': 'cbi-section-descr' }, _('Enter a new unique name for this authentication server profile.')),
+					E('div', { 'class': 'cbi-section-table' }, [
+						E('div', { 'class': 'tr' }, [
+							E('div', { 'class': 'td' }, _('Name')),
+							E('div', { 'class': 'td' }, [nameEl])
+						])
+					])
+				]),
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': function () { ui.hideModal(); } }, _('Cancel')),
+					E('button', { 'class': 'btn cbi-button cbi-button-positive', 'click': function () {
+						var newName = nameEl.value.trim(), i, longconnSections, authSections;
+						if (!newName) {
+							ui.addNotification(null, E('p', _('Please enter a name.')), 'error');
+							return;
+						}
+						if (newName === oldName) {
+							ui.hideModal();
+							return;
+						}
+						longconnSections = uci.sections('wifidogx', 'longconn');
+						for (i = 0; i < longconnSections.length; i++) {
+							if (longconnSections[i]['.name'] === newName) {
+								ui.addNotification(null, E('p', _('The name "%s" already exists in Long Connection profiles. Please choose a different name.').format(newName)), 'error');
+								return;
+							}
+						}
+						authSections = uci.sections('wifidogx', 'auth');
+						for (i = 0; i < authSections.length; i++) {
+							if (authSections[i]['.name'] === newName && authSections[i]['.name'] !== oldName) {
+								ui.addNotification(null, E('p', _('The name "%s" already exists in Auth Server profiles. Please choose a different name.').format(newName)), 'error');
+								return;
+							}
+						}
+						ui.hideModal();
+						uci.rename('wifidogx', section_id, newName);
+						self.map.save(null, true);
+					}}, _('Rename'))
+				])
+			]);
+		};
+
+		o = ss.option(form.Value, 'auth_server_hostname', _('Auth Server Hostname'),
+			_('The domain or IP address of the authentication server.'));
+		o.rmempty = false;
+		o.datatype = 'or(host,ip4addr)';
+		o.optional = false;
+
+
+		o = ss.option(form.Value, 'auth_server_port', _('Auth Server Port'),
+			_('The port of the authentication server.'));
+		o.rmempty = false;
+		o.datatype = 'port';
+		o.optional = false;
+		o.default = '443';
+
+
+		o = ss.option(form.Value, 'auth_server_path', _('Auth Server URI path'),
+			_('The URI path of the authentication server.'));
+		o.rmempty = false;
+		o.datatype = 'string';
+		o.optional = false;
+		o.default = '/wifidog/';
+
+		// Authentication Location Settings
+		// Add auto-fill button
+		o = s.taboption('location', form.Button, '_auto_fill', _('Auto Fill All Fields'),
+			_('Automatically fill AP MAC address, Device ID, Location ID, Longitude, and Latitude'));
+		o.inputtitle = _('Auto Fill All Fields');
+		o.inputstyle = 'apply';
+		o.onclick = function () {
+			showAutoFillModal();
+
+			var results = {
+				macAddress: null,
+				deviceId: null,
+				locationId: null,
+				longitude: null,
+				latitude: null
+			};
+
+			var promises = [
+				getMacAddressPromise(results),
+				getLocationPromise(results)
+			];
+
+			Promise.all(promises).then(function () {
+				fillFormFields(results);
+			});
+		};
+
+		// Helper function to show the auto-fill modal
+		function showAutoFillModal() {
+			ui.showModal(_('Auto Fill'), [
+				E('div', { 'class': 'cbi-section' }, [
+					E('div', { 'class': 'cbi-section-descr' }, _('Getting device information and location data, please wait...')),
+					E('div', { 'id': 'auto-fill-progress' }, [
+						E('ul', { 'style': 'margin: 10px 0;' }, [
+							E('li', { 'id': 'mac-status' }, _('Getting WAN MAC address...')),
+							E('li', { 'id': 'device-id-status' }, _('Generating Device ID...')),
+							E('li', { 'id': 'location-id-status' }, _('Generating Location ID...')),
+							E('li', { 'id': 'location-status' }, _('Getting location coordinates...'))
+						])
+					])
+				])
+			]);
+		}
+
+		// Helper function to get MAC address
+		function getMacAddressPromise(results) {
+			return callGetWanMac().then(function (response) {
+				if (response && response.status === 'success') {
+					var macAddr = response.mac.toUpperCase().replace(/:/g, '-');
+					results.macAddress = macAddr;
+					document.getElementById('mac-status').innerHTML = _('✓ WAN MAC address obtained: ') + macAddr + ' (interface: ' + response.interface + ')';
+
+					results.deviceId = generateDeviceId(macAddr);
+					document.getElementById('device-id-status').innerHTML = _('✓ Device ID generated: ') + results.deviceId;
+
+					results.locationId = generateLocationId();
+					document.getElementById('location-id-status').innerHTML = _('✓ Location ID generated: ') + results.locationId;
+				} else {
+					var errorMsg = (response && response.message) ? response.message : _('Unknown error');
+					document.getElementById('mac-status').innerHTML = _('✗ Failed to get WAN MAC address: ') + errorMsg;
+					document.getElementById('device-id-status').innerHTML = _('✗ Cannot generate Device ID without MAC address');
+				}
+			}).catch(function (error) {
+				document.getElementById('mac-status').innerHTML = _('✗ Error getting WAN MAC address: ') + error.message;
+				document.getElementById('device-id-status').innerHTML = _('✗ Cannot generate Device ID due to MAC error');
+			});
+		}
+
+		// Helper function to get location
+		function getLocationPromise(results) {
+			return callGetLocation().then(function (response) {
+				if (response && response.status === 'success') {
+					var lat = parseFloat(response.lat).toFixed(6);
+					var lon = parseFloat(response.lon).toFixed(6);
+
+					formatAndSetCoordinates(results, lat, lon);
+					document.getElementById('location-status').innerHTML = _('✓ Location obtained: ') + results.latitude + ', ' + results.longitude;
+				} else {
+					var errorMsg = (response && response.message) ? response.message : _('Location services unavailable');
+					document.getElementById('location-status').innerHTML = _('✗ Failed to get location: ') + errorMsg;
+				}
+			}).catch(function (error) {
+				document.getElementById('location-status').innerHTML = _('✗ Error getting location: ') + error.message;
+			});
+		}
+
+		// Helper function to format coordinates
+		function formatAndSetCoordinates(results, lat, lon) {
+			// Pad coordinates to required format
+			if (lat >= 0) {
+				lat = lat.padStart(10, '0');
+			} else {
+				lat = '-' + Math.abs(lat).toFixed(6).padStart(9, '0');
+			}
+
+			if (lon >= 0) {
+				lon = lon.padStart(10, '0');
+			} else {
+				lon = '-' + Math.abs(lon).toFixed(6).padStart(9, '0');
+			}
+
+			results.longitude = lon;
+			results.latitude = lat;
+		}
+
+		// Helper function to fill form fields
+		function fillFormFields(results) {
+			var successCount = 0;
+			var totalFields = 0;
+			var messages = [];
+
+			var fieldMappings = [
+				{ key: 'macAddress', selectors: ['input[data-name="ap_mac_address"]', 'input[name*="ap_mac_address"]', 'input[id*="ap_mac_address"]', '#cbid\\.wifidogx\\.default\\.ap_mac_address'], label: _('MAC Address: ') },
+				{ key: 'deviceId', selectors: ['input[data-name="ap_device_id"]', 'input[name*="ap_device_id"]', 'input[id*="ap_device_id"]', '#cbid\\.wifidogx\\.default\\.ap_device_id'], label: _('Device ID: ') },
+				{ key: 'locationId', selectors: ['input[data-name="location_id"]', 'input[name*="location_id"]', 'input[id*="location_id"]', '#cbid\\.wifidogx\\.default\\.location_id'], label: _('Location ID: ') },
+				{ key: 'longitude', selectors: ['input[data-name="ap_longitude"]', 'input[name*="ap_longitude"]', 'input[id*="ap_longitude"]', '#cbid\\.wifidogx\\.default\\.ap_longitude'], label: _('Longitude: ') },
+				{ key: 'latitude', selectors: ['input[data-name="ap_latitude"]', 'input[name*="ap_latitude"]', 'input[id*="ap_latitude"]', '#cbid\\.wifidogx\\.default\\.ap_latitude'], label: _('Latitude: ') }
+			];
+
+			fieldMappings.forEach(function (mapping) {
+				if (results[mapping.key]) {
+					var field = null;
+					for (var i = 0; i < mapping.selectors.length; i++) {
+						field = document.querySelector(mapping.selectors[i]);
+						if (field) break;
+					}
+
+					if (field) {
+						field.value = results[mapping.key];
+						field.dispatchEvent(new Event('input', { bubbles: true }));
+						field.dispatchEvent(new Event('change', { bubbles: true }));
+						successCount++;
+						messages.push(mapping.label + results[mapping.key]);
+					}
+					totalFields++;
+				}
+			});
+
+			showAutoFillResult(successCount, totalFields, messages);
+		}
+
+		// Helper function to show auto-fill results
+		function showAutoFillResult(successCount, totalFields, messages) {
+			ui.hideModal();
+
+			if (successCount === totalFields && totalFields > 0) {
+				ui.addNotification(null, E('p', _('Auto fill completed successfully! All fields have been filled.') + '<br>' + messages.join('<br>')), 'info');
+			} else if (successCount > 0) {
+				ui.addNotification(null, E('p', _('Auto fill partially completed.') + ' ' + successCount + '/' + totalFields + ' ' + _('fields filled successfully.') + '<br>' + messages.join('<br>')), 'warning');
+			} else {
+				ui.addNotification(null, E('p', _('Auto fill failed. No fields could be filled. Please check your network connection and try again.')), 'error');
+			}
+		}
+
+		// Location ID field
+		o = s.taboption('location', form.Value, 'location_id', _('Location ID'), _('The unique identifier of the internet service location.'));
+		o.rmempty = false;
+		o.datatype = 'string';
+		o.optional = false;
+		o.placeholder = '11010110012345';
+		o.validate = function (section_id, value) {
+			if (!value || value === '')
+				return _('Location ID is required');
+
+			// Check total length
+			if (value.length !== 14) {
+				return _('Location ID must be exactly 14 digits long');
+			}
+
+			// Check if all characters are digits
+			if (!/^\d{14}$/.test(value)) {
+				return _('Location ID must contain only digits (0-9)');
+			}
+
+			// Validate administrative division code (first 6 digits)
+			var adminCode = value.substring(0, 6);
+			if (!/^\d{6}$/.test(adminCode)) {
+				return _('First 6 digits must be valid administrative division code (GB/T 2260)');
+			}
+
+			// Validate service type code (7-9 digits)
+			var serviceType = value.substring(6, 9);
+			var firstDigit = serviceType.charAt(0);
+			if (serviceType !== '100' && firstDigit !== '2' && firstDigit !== '3') {
+				return _('Service type code (7-9 digits) must be "100" for commercial internet service locations, "2XX" for non-commercial locations, or "3XX" for WiFi wireless collection terminals');
+			}
+
+			// Validate sequence number (10-14 digits)
+			var sequenceNum = value.substring(9);
+			if (!/^\d{5}$/.test(sequenceNum)) {
+				return _('Last 5 digits must be sequence number (00000-99999)');
+			}
+
+			return true;
+		};
+
+		o = s.taboption('location', form.Value, 'ap_device_id', _('AP Device ID'),
+			_('The unique identifier of the AP device. Must be 21 characters: 9-character vendor code + 12-character MAC address (uppercase).'));
+		o.rmempty = true;
+		o.optional = true;
+		o.validate = function (section_id, value) {
+			if (!value || value === '')
+				return true; // Optional field, empty is allowed
+
+			// Check total length
+			if (value.length !== 21) {
+				return _('AP Device ID must be exactly 21 characters long');
+			}
+
+			// Check if all characters are alphanumeric (letters and digits)
+			if (!/^[A-Z0-9]+$/.test(value)) {
+				return _('AP Device ID must contain only uppercase letters and digits');
+			}
+
+			// Extract MAC address part (last 12 characters)
+			var macPart = value.substring(9);
+
+			// Validate MAC address format (12 hexadecimal characters)
+			if (!/^[A-F0-9]{12}$/.test(macPart)) {
+				return _('Last 12 characters must be a valid MAC address in uppercase hexadecimal format (e.g., 00E04C3B7D2F)');
+			}
+
+			return true;
+		};
+		o.placeholder = 'AW123456700E04C3B7D2F';
+
+		o = s.taboption('location', form.Value, 'ap_mac_address', _('AP MAC Address'),
+			_('The MAC address of the AP device. Must be 17 characters in format XX-XX-XX-XX-XX-XX (uppercase, separated by hyphens).'));
+		o.rmempty = true;
+		o.optional = true;
+		o.placeholder = '00-E0-4C-3B-7D-2F';
+		o.validate = function (section_id, value) {
+			if (!value || value === '')
+				return true; // Optional field, empty is allowed
+
+			// Check total length
+			if (value.length !== 17) {
+				return _('MAC address must be exactly 17 characters long');
+			}
+
+			// Check format: XX-XX-XX-XX-XX-XX where X is uppercase hex digit
+			if (!/^[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}$/.test(value)) {
+				return _('MAC address must be in format XX-XX-XX-XX-XX-XX (uppercase hexadecimal separated by hyphens)');
+			}
+
+			// Get the AP Device ID to check consistency
+			var deviceId = uci.get('wifidogx', section_id, 'ap_device_id');
+			if (deviceId && deviceId.length === 21) {
+				var deviceMacPart = deviceId.substring(9);
+				var normalizedMac = value.replace(/-/g, '');
+
+				if (normalizedMac !== deviceMacPart) {
+					return _('MAC address should match the MAC address part (last 12 characters) in AP Device ID');
+				}
+			}
+
+			return true;
+		};
+
+		o = s.taboption('location', form.Value, 'ap_longitude', _('Mobile AP Longitude'),
+			_('The longitude coordinate using format: ±XXX.XXXXXX (3 integer digits + 6 decimal digits). Positive for East, negative for West.'));
+		o.rmempty = true;
+		o.optional = true;
+		o.placeholder = '123.230000';
+		o.validate = function (section_id, value) {
+			if (!value || value === '')
+				return true; // Optional field, empty is allowed
+
+			// Allow more flexible input, then validate and suggest correct format
+			var numValue = parseFloat(value);
+			if (isNaN(numValue)) {
+				return _('Longitude must be a valid number');
+			}
+
+			if (numValue < -180 || numValue > 180) {
+				return _('Longitude must be between -180.000000 and 180.000000');
+			}
+
+			// Check if the input matches the strict format requirement
+			if (!/^[+-]?\d{3}\.\d{6}$/.test(value)) {
+				// Format the number to the required format and suggest it
+				var formatted = numValue.toFixed(6);
+				if (formatted.indexOf('.') > 0) {
+					var parts = formatted.split('.');
+					var intPart = parts[0];
+					var decPart = parts[1];
+
+					// Pad integer part to 3 digits
+					if (intPart.startsWith('-')) {
+						intPart = '-' + intPart.substring(1).padStart(3, '0');
+					} else {
+						intPart = intPart.padStart(3, '0');
+					}
+
+					formatted = intPart + '.' + decPart;
+				}
+				return _('Longitude must be in format ±XXX.XXXXXX (3 integer digits + 6 decimal digits, e.g., 123.230000 or -133.000000). Suggested format: ') + formatted;
+			}
+
+			return true;
+		};
+
+		o = s.taboption('location', form.Value, 'ap_latitude', _('Mobile AP Latitude'),
+			_('The latitude coordinate using format: ±XXX.XXXXXX (3 integer digits + 6 decimal digits). Positive for North, negative for South.'));
+		o.rmempty = true;
+		o.optional = true;
+		o.placeholder = '39.900000';
+		o.validate = function (section_id, value) {
+			if (!value || value === '')
+				return true; // Optional field, empty is allowed
+
+			// Allow more flexible input, then validate and suggest correct format
+			var numValue = parseFloat(value);
+			if (isNaN(numValue)) {
+				return _('Latitude must be a valid number');
+			}
+
+			if (numValue < -90 || numValue > 90) {
+				return _('Latitude must be between -90.000000 and 90.000000');
+			}
+
+			// Check if the input matches the strict format requirement
+			if (!/^[+-]?\d{3}\.\d{6}$/.test(value)) {
+				// Format the number to the required format and suggest it
+				var formatted = numValue.toFixed(6);
+				if (formatted.indexOf('.') > 0) {
+					var parts = formatted.split('.');
+					var intPart = parts[0];
+					var decPart = parts[1];
+
+					// Pad integer part to 3 digits
+					if (intPart.startsWith('-')) {
+						intPart = '-' + intPart.substring(1).padStart(3, '0');
+					} else {
+						intPart = intPart.padStart(3, '0');
+					}
+
+					formatted = intPart + '.' + decPart;
+				}
+				return _('Latitude must be in format ±XXX.XXXXXX (3 integer digits + 6 decimal digits, e.g., 39.900000 or -33.000000). Suggested format: ') + formatted;
+			}
+
+			return true;
+		};
+
+		// Long Connection Settings
+		o = s.taboption('longconn', form.SectionValue, '_longconn', form.GridSection, 'longconn',
+			_('Persistent Connection Profiles'),
+			_('Create one or more long connection profiles for cloud authentication and OpenClaw intelligent control channels.'));
+		ss = o.subsection;
+		ss.addremove = true;
+		ss.nodescriptions = true;
+
+		ss.handleAdd = function (ev, name) {
+			var self = this, i, authSections, longconnSections;
+			if (name) {
+				authSections = uci.sections('wifidogx', 'auth');
+				for (i = 0; i < authSections.length; i++) {
+					if (authSections[i]['.name'] === name) {
+						ui.addNotification(null, E('p', _('The name "%s" already exists in Auth Server profiles. Please choose a different name.').format(name)), 'error');
+						return Promise.resolve();
+					}
+				}
+				longconnSections = uci.sections('wifidogx', 'longconn');
+				for (i = 0; i < longconnSections.length; i++) {
+					if (longconnSections[i]['.name'] === name) {
+						ui.addNotification(null, E('p', _('The name "%s" already exists in Long Connection profiles. Please choose a different name.').format(name)), 'error');
+						return Promise.resolve();
+					}
+				}
+			}
+			return this.super('handleAdd', [ev, name]);
+		};
+
+		ss.handleRename = function (section_id, ev) {
+			var self = this;
+			var oldName = section_id;
+			var nameEl = E('input', {
+				'type': 'text',
+				'class': 'cbi-input-text',
+				'id': 'longconn-rename-input',
+				'value': oldName,
+				'style': 'width: 100%;'
+			});
+			ui.showModal(_('Rename Long Connection Profile'), [
+				E('div', { 'class': 'cbi-section' }, [
+					E('div', { 'class': 'cbi-section-descr' }, _('Enter a new unique name for this long connection profile.')),
+					E('div', { 'class': 'cbi-section-table' }, [
+						E('div', { 'class': 'tr' }, [
+							E('div', { 'class': 'td' }, _('Name')),
+							E('div', { 'class': 'td' }, [nameEl])
+						])
+					])
+				]),
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': function () { ui.hideModal(); } }, _('Cancel')),
+					E('button', { 'class': 'btn cbi-button cbi-button-positive', 'click': function () {
+						var newName = nameEl.value.trim(), i, authSections, longconnSections;
+						if (!newName) {
+							ui.addNotification(null, E('p', _('Please enter a name.')), 'error');
+							return;
+						}
+						if (newName === oldName) {
+							ui.hideModal();
+							return;
+						}
+						authSections = uci.sections('wifidogx', 'auth');
+						for (i = 0; i < authSections.length; i++) {
+							if (authSections[i]['.name'] === newName) {
+								ui.addNotification(null, E('p', _('The name "%s" already exists in Auth Server profiles. Please choose a different name.').format(newName)), 'error');
+								return;
+							}
+						}
+						longconnSections = uci.sections('wifidogx', 'longconn');
+						for (i = 0; i < longconnSections.length; i++) {
+							if (longconnSections[i]['.name'] === newName && longconnSections[i]['.name'] !== oldName) {
+								ui.addNotification(null, E('p', _('The name "%s" already exists in Long Connection profiles. Please choose a different name.').format(newName)), 'error');
+								return;
+							}
+						}
+						ui.hideModal();
+						uci.rename('wifidogx', section_id, newName);
+						self.map.save(null, true);
+					}}, _('Rename'))
+				])
+			]);
+		};
+
+		o = ss.option(form.ListValue, 'long_conn_mode', _('Connection Mode'),
+			_('The type of persistent connection to the remote management server.'));
+		o.value('ws', _('WebSocket (ws://)'));
+		o.value('wss', _('WebSocket Secure (wss://)'));
+		o.value('mqtt', _('MQTT'));
+		o.value('mqtts', _('MQTT Secure'));
+		o.default = 'ws';
+		o.rmempty = false;
+
+		o = ss.option(form.Value, 'ws_server_hostname', _('WebSocket Hostname'),
+			_('The hostname or IP address of the WebSocket server.'));
+		o.datatype = 'or(host,ip4addr)';
+		o.rmempty = true;
+		o.depends('long_conn_mode', 'ws');
+		o.depends('long_conn_mode', 'wss');
+		o.placeholder = 'ws.example.com';
+		o.modalonly = true;
+
+		o = ss.option(form.Value, 'ws_server_port', _('WebSocket Port'),
+			_('The port of the WebSocket server.'));
+		o.datatype = 'port';
+		o.rmempty = true;
+		o.default = '443';
+		o.depends('long_conn_mode', 'ws');
+		o.depends('long_conn_mode', 'wss');
+		o.modalonly = true;
+
+		o = ss.option(form.Value, 'ws_server_path', _('WebSocket Path'),
+			_('The URI path for the WebSocket connection.'));
+		o.datatype = 'string';
+		o.rmempty = true;
+		o.default = '/ws/wifidogx';
+		o.depends('long_conn_mode', 'ws');
+		o.depends('long_conn_mode', 'wss');
+		o.modalonly = true;
+
+		o = ss.option(form.Value, 'mqtt_server_hostname', _('MQTT Hostname'),
+			_('The hostname or IP address of the MQTT broker.'));
+		o.datatype = 'or(host,ip4addr)';
+		o.rmempty = true;
+		o.depends('long_conn_mode', 'mqtt');
+		o.depends('long_conn_mode', 'mqtts');
+		o.placeholder = 'mqtt.example.com';
+		o.modalonly = true;
+
+		o = ss.option(form.Value, 'mqtt_server_port', _('MQTT Port'),
+			_('The port of the MQTT broker.'));
+		o.datatype = 'port';
+		o.rmempty = true;
+		o.default = '1883';
+		o.depends('long_conn_mode', 'mqtt');
+		o.depends('long_conn_mode', 'mqtts');
+		o.modalonly = true;
+
+		o = ss.option(form.Value, 'mqtt_username', _('MQTT Username'),
+			_('The username for MQTT authentication.'));
+		o.datatype = 'string';
+		o.rmempty = true;
+		o.optional = true;
+		o.depends('long_conn_mode', 'mqtt');
+		o.depends('long_conn_mode', 'mqtts');
+		o.modalonly = true;
+
+		o = ss.option(form.Value, 'mqtt_password', _('MQTT Password'),
+			_('The password for MQTT authentication.'));
+		o.datatype = 'string';
+		o.rmempty = true;
+		o.optional = true;
+		o.password = true;
+		o.depends('long_conn_mode', 'mqtt');
+		o.depends('long_conn_mode', 'mqtts');
+		o.modalonly = true;
+
+		// rule settings
+		o = s.taboption('rule', form.DynamicList, 'trusted_wildcard_domains', _('Trusted Wildcard Domains'),
+			_('Requires aw-bpf DNS XDP (dns_ringbuf_portal). Patterns like .example.com; resolved IPs are added to the captive portal firewall (inet wifidogx), not inet awbpf.'));
+		o.rmempty = true;
+		o.optional = true;
+		o.datatype = 'string';
+		o.placeholder = '.example.com';
+
+		o = s.taboption('rule', form.DynamicList, 'trusted_domains', _('Trusted Domains'),
+			_('The trusted domains of the gateway'));
+		o.rmempty = true;
+		o.optional = true;
+		o.datatype = 'hostname';
+		o.placeholder = 'www.example.com';
+
+		o = s.taboption('rule', form.DynamicList, 'trusted_macs', _('Trusted MACs'),
+			_('The trusted MAC addresses of the gateway.'));
+		o.rmempty = true;
+		o.optional = true;
+		o.datatype = 'macaddr';
+		o.placeholder = 'A0:B1:C2:D3:44:55';
+
+		o = s.taboption('rule', CBIWifidogxGroupSelect, 'app_white_list', _('App White List'),
+			_('The app white list of the gateway.'));
+		o.rmempty = true;
+		o.multiple = true;
+		o.nocreate = true;
+
+		o = s.taboption('rule', CBIWifidogxGroupSelect, 'mac_white_list', _('MAC White List'),
+			_('The MAC white list of the gateway.'));
+		o.rmempty = true;
+		o.multiple = true;
+		o.nocreate = true;
+		o.setGroupType('mac');
+
+		o = s.taboption('rule', CBIWifidogxGroupSelect, 'wildcard_white_list', _('Wildcard White List'),
+			_('The wildcard domain white list of the gateway.'));
+		o.rmempty = true;
+		o.multiple = true;
+		o.nocreate = true;
+		o.setGroupType('wildcard');
+
+		s = m.section(form.GridSection, 'group', _('Group Define'));
+		s.addremove = true;
+		s.anonymous = false;
+		s.nodescriptions = true;
+
+		s.handleRemove = function (section_id, ev) {
+			// according section_id to check whether it is used by app_white_list, wildcard_white_list or mac_white_list
+			var gtype = uci.get('wifidogx', section_id, 'g_type');
+			var group = (gtype === '1') ? 'app_white_list' : (gtype === '3') ? 'wildcard_white_list' : 'mac_white_list';
+			var groupList = uci.get('wifidogx', 'common', group);
+			if (groupList) {
+				for (var i = 0; i < groupList.length; i++) {
+					if (groupList[i] === section_id) {
+						ui.addNotification(null, E('p', [
+							_('The group is used by '), E('strong', group), _(' please remove it from '), E('strong', group), _(' first.')
+						]), 'warning');
+						return false;
+					}
+				}
+			}
+
+			return this.super('handleRemove', [section_id, ev]);
+		};
+
+		o = s.option(form.ListValue, 'g_type', _('Group Type'), _('The type of the group.'));
+		o.value('1', _('Domain Group'));
+		o.value('2', _('MAC Group'));
+		o.value('3', _('Wildcard Domain Group'));
+		o.default = '1';
+
+		o = s.option(form.DynamicList, 'domain_name', _('Domain Name'), _('The domain name of the group.'));
+		o.depends('g_type', '1');
+		o.datatype = 'hostname';
+		o.rmempty = false;
+		o.optional = false;
+		o.placeholder = 'www.example.com';
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'mac_address', _('MAC Address'), _('The MAC address of the group.'));
+		o.depends('g_type', '2');
+		o.datatype = 'macaddr';
+		o.rmempty = false;
+		o.optional = false;
+		o.placeholder = 'A0:B1:C2:D3:44:55';
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'wildcard_domain', _('Wildcard Domain'), _('The wildcard domain of the group.'));
+		o.depends('g_type', '3');
+		o.datatype = 'string';
+		o.rmempty = false;
+		o.optional = false;
+		o.placeholder = '.example.com';
+		o.modalonly = true;
+
+		o = s.option(form.Value, 'g_desc', _('Group Description'), _('The description of the group.'));
+		o.datatype = 'string';
+		o.optional = true;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js
+++ b/applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js
@@ -1,0 +1,283 @@
+'use strict';
+'require view';
+'require fs';
+'require poll';
+'require ui';
+
+return view.extend({
+	render: function(data) {
+		// Create container for status
+		var container = E('div', { id: 'wifidogx-status' }, [
+			E('h2', {}, _('apfree-wifidog Status'))
+		]);
+
+		// Function to update the status information
+		function updateStatus() {
+			// Get all status information in parallel
+			var promises = [
+				fs.exec('wdctlx', ['status', 'wifidogx']),
+				fs.exec('wdctlx', ['status', 'client']),
+				fs.exec('wdctlx', ['status', 'auth'])
+			];
+
+			return Promise.all(promises).then(function(results) {
+				var wifidogxRes = results[0];
+				var clientRes = results[1];
+				var authRes = results[2];
+				
+				// Clear container
+				container.innerHTML = '';
+				container.appendChild(E('h2', {}, _('apfree-wifidog Status')));
+
+				// Parse wifidogx status
+				var wifidogxData = null;
+				var clientData = null;
+				var authData = null;
+
+				try {
+					if (wifidogxRes.code === 0 && wifidogxRes.stdout) {
+						wifidogxData = JSON.parse(wifidogxRes.stdout);
+					}
+				} catch (e) {
+					console.error('Error parsing wifidogx status:', e);
+				}
+
+				try {
+					if (clientRes.code === 0 && clientRes.stdout) {
+						clientData = JSON.parse(clientRes.stdout);
+					}
+				} catch (e) {
+					console.error('Error parsing client status:', e);
+				}
+
+				try {
+					if (authRes.code === 0 && authRes.stdout) {
+						authData = JSON.parse(authRes.stdout);
+					}
+				} catch (e) {
+					console.error('Error parsing auth status:', e);
+				}
+
+				// Display wifidogx information
+				if (wifidogxData) {
+					createWifidogxStatusTable(wifidogxData);
+				} else {
+					container.appendChild(E('p', {}, _('Failed to get wifidogx status')));
+				}
+
+				// Display client information
+				if (clientData) {
+					createClientStatusTable(clientData);
+				} else {
+					container.appendChild(E('p', {}, _('Failed to get client status')));
+				}
+
+				// Display auth server information
+				if (authData) {
+					createAuthStatusTable(authData);
+				} else {
+					container.appendChild(E('p', {}, _('Failed to get auth server status')));
+				}
+			}).catch(function(error) {
+				container.innerHTML = '';
+				container.appendChild(E('h2', {}, _('apfree-wifidog Status')));
+				container.appendChild(E('p', {}, _('Error getting status information: ') + error.message));
+			});
+		}
+
+		// Function to create wifidogx status table
+		function createWifidogxStatusTable(data) {
+			container.appendChild(E('h3', {}, _('apfree-wifidog Status')));
+			
+			var table = E('table', { 'class': 'table' });
+			
+			var uptime = formatUptime(data.uptime || 0);
+			var authModeText = getAuthModeText(data.auth_server_mode);
+			
+			var rows = [
+				[_('Version'), data.wifidogx_version || '-'],
+				[_('Uptime'), uptime],
+				[_('Internet Connected'), data.is_internet_connected ? _('Yes') : _('No')],
+				[_('Auth Server Connected'), data.is_auth_server_connected ? _('Yes') : _('No')],
+				[_('MQTT Connected'), data.is_mqtt_connected ? _('Yes') : _('No')],
+				[_('WebSocket Connected'), data.is_websocket_connected ? _('Yes') : _('No')],
+				[_('Auth Server Mode'), authModeText]
+			];
+
+			rows.forEach(function(row) {
+				table.appendChild(E('tr', {}, [
+					E('td', { 'class': 'td left', 'width': '30%' }, [ row[0] ]),
+					E('td', { 'class': 'td left' }, [ row[1] ])
+				]));
+			});
+
+			container.appendChild(table);
+		}
+
+		// Function to create client status table
+		function createClientStatusTable(data) {
+			container.appendChild(E('h3', {}, _('Client Status')));
+			
+			var summaryTable = E('table', { 'class': 'table' });
+			var summaryRows = [
+				[_('Online Clients'), data.online_client_count || 0],
+				[_('Active Clients'), data.active_client_count || 0]
+			];
+
+			summaryRows.forEach(function(row) {
+				summaryTable.appendChild(E('tr', {}, [
+					E('td', { 'class': 'td left', 'width': '30%' }, [ row[0] ]),
+					E('td', { 'class': 'td left' }, [ row[1] ])
+				]));
+			});
+
+			container.appendChild(summaryTable);
+
+			// Display client details if available
+			if (data.clients && data.clients.length > 0) {
+				container.appendChild(E('h4', {}, _('Connected Clients')));
+				
+				var clientTable = E('table', { 'class': 'table' });
+				
+				// Add header row
+				clientTable.appendChild(E('tr', { 'class': 'tr table-titles' }, [
+					E('th', { 'class': 'th' }, _('IP Address')),
+					E('th', { 'class': 'th' }, _('MAC Address')),
+					E('th', { 'class': 'th' }, _('Name')),
+					E('th', { 'class': 'th' }, _('Online Time')),
+					E('th', { 'class': 'th' }, _('Connection Type')),
+					E('th', { 'class': 'th' }, _('Gateway ID')),
+					E('th', { 'class': 'th' }, _('Download Rate')),
+					E('th', { 'class': 'th' }, _('Upload Rate'))
+				]));
+
+				data.clients.forEach(function(client) {
+					var onlineTime = formatOnlineTime(client.online_time || 0);
+					var connectionType = client.wired ? _('Wired') : _('Wireless');
+					
+					// compute combined v4+v6 rates if present
+					var dl_rate = 0;
+					var ul_rate = 0;
+					if (client.traffic) {
+						dl_rate = (client.traffic.incoming_rate || 0) + (client.traffic.incoming_rate_v6 || 0);
+						ul_rate = (client.traffic.outgoing_rate || 0) + (client.traffic.outgoing_rate_v6 || 0);
+					}
+
+					clientTable.appendChild(E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td' }, client.ip || '-'),
+						E('td', { 'class': 'td' }, client.mac || '-'),
+						E('td', { 'class': 'td' }, client.name || '-'),
+						E('td', { 'class': 'td' }, onlineTime),
+						E('td', { 'class': 'td' }, connectionType),
+						E('td', { 'class': 'td' }, client.gw_id || '-'),
+						E('td', { 'class': 'td' }, formatRate(dl_rate)),
+						E('td', { 'class': 'td' }, formatRate(ul_rate))
+					]));
+				});
+
+				container.appendChild(clientTable);
+			}
+		}
+
+		// Function to create auth server status table
+		function createAuthStatusTable(data) {
+			container.appendChild(E('h3', {}, _('Authentication Server Status')));
+			
+			var table = E('table', { 'class': 'table' });
+			
+			var rows = [
+				[_('Auth Server Online'), data.auth_online ? _('Yes') : _('No')]
+			];
+
+			rows.forEach(function(row) {
+				table.appendChild(E('tr', {}, [
+					E('td', { 'class': 'td left', 'width': '30%' }, [ row[0] ]),
+					E('td', { 'class': 'td left' }, [ row[1] ])
+				]));
+			});
+
+			// Add auth servers if available
+			if (data.auth_servers && data.auth_servers.length > 0) {
+				table.appendChild(E('tr', {}, [
+					E('td', { 'class': 'td left', 'width': '30%' }, [ _('Authentication Servers') ]),
+					E('td', { 'class': 'td left' }, [
+						E('ul', { 'class': 'clean-list' }, 
+							data.auth_servers.map(function(srv) {
+								return E('li', {}, srv.host + ' (' + srv.ip + ')');
+							})
+						)
+					])
+				]));
+			}
+
+			container.appendChild(table);
+		}
+
+		// Helper function to format uptime
+		function formatUptime(seconds) {
+			var days = Math.floor(seconds / 86400);
+			var hours = Math.floor((seconds % 86400) / 3600);
+			var minutes = Math.floor((seconds % 3600) / 60);
+			var secs = seconds % 60;
+			
+			var parts = [];
+			if (days > 0) parts.push(days + _('d'));
+			if (hours > 0) parts.push(hours + _('h'));
+			if (minutes > 0) parts.push(minutes + _('m'));
+			if (secs > 0 || parts.length === 0) parts.push(secs + _('s'));
+			
+			return parts.join(' ');
+		}
+
+		// Helper function to format online time
+		function formatOnlineTime(seconds) {
+			var hours = Math.floor(seconds / 3600);
+			var minutes = Math.floor((seconds % 3600) / 60);
+			var secs = seconds % 60;
+			
+			var parts = [];
+			if (hours > 0) parts.push(hours + _('h'));
+			if (minutes > 0) parts.push(minutes + _('m'));
+			if (secs > 0 || parts.length === 0) parts.push(secs + _('s'));
+			
+			return parts.join(' ');
+		}
+
+		// Helper to format byte-per-second rates into human readable strings
+		function formatRate(bps) {
+			if (!bps || bps === 0) return '-';
+			var units = ['B/s','KB/s','MB/s','GB/s'];
+			var idx = 0;
+			var value = bps;
+			while (value >= 1024 && idx < units.length - 1) {
+				value = value / 1024;
+				idx++;
+			}
+			return value.toFixed(value < 10 ? 2 : (value < 100 ? 1 : 0)) + ' ' + units[idx];
+		}
+
+		// Helper function to get auth mode text
+		function getAuthModeText(mode) {
+			switch(mode) {
+				case 0: return _('Cloud Auth');
+				case 1: return _('Local Auth');
+				case 2: return _('Bypass Auth');
+				default: return _('Unknown');
+			}
+		}
+
+		// Initial update
+		updateStatus();
+
+		// Poll status every 5 seconds
+		L.Poll.add(function() {
+			return updateStatus();
+		}, 5);
+
+		return container;
+	},
+
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null
+});

--- a/applications/luci-app-apfree-wifidog/po/templates/apfree-wifidog.pot
+++ b/applications/luci-app-apfree-wifidog/po/templates/apfree-wifidog.pot
@@ -1,0 +1,1004 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:622
+msgid "AP Device ID"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:632
+msgid "AP Device ID must be exactly 21 characters long"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:637
+msgid "AP Device ID must contain only uppercase letters and digits"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:652
+msgid "AP MAC Address"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:124
+msgid "Active Clients"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:134
+msgid "Advanced Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:229
+msgid "Alert"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:317
+msgid "Anti NAT Permit MAC"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:121
+msgid "ApFree-WiFiDog"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:949
+msgid "App White List"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:289
+msgid "Apple CNA"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:240
+msgid "Auth Enabled"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:101
+msgid "Auth Server Connected"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:404
+msgid "Auth Server Hostname"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:142
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:104
+msgid "Auth Server Mode"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:189
+msgid "Auth Server Online"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:411
+msgid "Auth Server Port"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:132
+msgid "Auth Server Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:419
+msgid "Auth Server URI path"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:136
+msgid "Authentication Location Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:151
+msgid "Authentication Server"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:184
+msgid "Authentication Server Status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:202
+msgid "Authentication Servers"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:455
+msgid "Auto Fill"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:428
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:430
+msgid "Auto Fill All Fields"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:572
+msgid "Auto fill completed successfully! All fields have been filled."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:576
+msgid ""
+"Auto fill failed. No fields could be filled. Please check your network "
+"connection and try again."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:574
+msgid "Auto fill partially completed."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:429
+msgid ""
+"Automatically fill AP MAC address, Device ID, Location ID, Longitude, and "
+"Latitude"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:130
+msgid "Basic Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:146
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:264
+msgid "Bypass Auth"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:371
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:821
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:271
+msgid "Check Interval"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:119
+msgid "Client Status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:278
+msgid "Client Timeout"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:144
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:262
+msgid "Cloud Auth"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:126
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:138
+msgid "Connected Clients"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:854
+msgid "Connection Mode"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:148
+msgid "Connection Type"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:774
+msgid ""
+"Create one or more long connection profiles for cloud authentication and "
+"OpenClaw intelligent control channels."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:228
+msgid "Critical"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:223
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:203
+msgid "Device ID"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:539
+msgid "Device ID:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:216
+msgid "Disable Portal Authentication"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:994
+msgid "Domain Group"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:999
+msgid "Domain Name"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:150
+msgid "Download Rate"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:230
+msgid "Emergency"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:139
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:299
+msgid "Enable Anti NAT"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:300
+msgid "Enable Anti NAT devices."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:290
+msgid "Enable Apple Captive Network Assistant."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:295
+msgid "Enable JS redirect."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:139
+msgid "Enable apfree-wifidog service."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:241
+msgid "Enable the authentication of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:362
+msgid "Enter a new unique name for this authentication server profile."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:812
+msgid "Enter a new unique name for this long connection profile."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:227
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:84
+msgid "Error getting status information:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:196
+msgid "External Interface"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:79
+msgid "Failed to get auth server status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:72
+msgid "Failed to get client status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:65
+msgid "Failed to get wifidogx status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:603
+msgid "First 6 digits must be valid administrative division code (GB/T 2260)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:251
+msgid "Gateway Channel"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:257
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:149
+msgid "Gateway ID"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:245
+msgid "Gateway Name"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:133
+msgid "Gateway Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:263
+msgid "Gateway Subnetv4"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:461
+msgid "Generating Device ID..."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:462
+msgid "Generating Location ID..."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:460
+msgid "Getting WAN MAC address..."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:457
+msgid "Getting device information and location data, please wait..."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:463
+msgid "Getting location coordinates..."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:123
+msgid "GitHub project page"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/rpcd/acl.d/luci-app-apfree-wifidog.json:3
+msgid "Grant access to LuCI app apfree-wifidog"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:969
+msgid "Group Define"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1023
+msgid "Group Description"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:993
+msgid "Group Type"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:144
+msgid "IP Address"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:224
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:100
+msgid "Internet Connected"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:294
+msgid "JS Filter"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:645
+msgid ""
+"Last 12 characters must be a valid MAC address in uppercase hexadecimal "
+"format (e.g., 00E04C3B7D2F)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:616
+msgid "Last 5 digits must be sequence number (00000-99999)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:740
+msgid "Latitude must be a valid number"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:744
+msgid "Latitude must be between -90.000000 and 90.000000"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:765
+msgid ""
+"Latitude must be in format ±XXX.XXXXXX (3 integer digits + 6 decimal digits, "
+"e.g., 39.900000 or -33.000000). Suggested format:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:542
+msgid "Latitude:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:145
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:263
+msgid "Local Auth"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:208
+msgid "Local Portal"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:305
+msgid ""
+"Local secret required for AWAS cloud platform to dynamically authorize "
+"remote OTA, reboot and system changes."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:581
+msgid "Location ID"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:588
+msgid "Location ID is required"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:592
+msgid "Location ID must be exactly 14 digits long"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:597
+msgid "Location ID must contain only digits (0-9)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:540
+msgid "Location ID:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:504
+msgid "Location services unavailable"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:221
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:174
+msgid "Long Connection Profile"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:131
+msgid "Long Connection Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:697
+msgid "Longitude must be a valid number"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:701
+msgid "Longitude must be between -180.000000 and 180.000000"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:722
+msgid ""
+"Longitude must be in format ±XXX.XXXXXX (3 integer digits + 6 decimal "
+"digits, e.g., 123.230000 or -133.000000). Suggested format:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:541
+msgid "Longitude:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1007
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:145
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:538
+msgid "MAC Address:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:995
+msgid "MAC Group"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:955
+msgid "MAC White List"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:663
+msgid "MAC address must be exactly 17 characters long"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:668
+msgid ""
+"MAC address must be in format XX-XX-XX-XX-XX-XX (uppercase hexadecimal "
+"separated by hyphens)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:678
+msgid ""
+"MAC address should match the MAC address part (last 12 characters) in AP "
+"Device ID"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:858
+msgid "MQTT"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:102
+msgid "MQTT Connected"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:890
+msgid "MQTT Hostname"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:917
+msgid "MQTT Password"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:899
+msgid "MQTT Port"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:859
+msgid "MQTT Secure"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:908
+msgid "MQTT Username"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:728
+msgid "Mobile AP Latitude"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:685
+msgid "Mobile AP Longitude"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:365
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:815
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:146
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:100
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:101
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:102
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:103
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:189
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:225
+msgid "Notice"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:123
+msgid "Online Clients"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:147
+msgid "Online Time"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:773
+msgid "Persistent Connection Profiles"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:184
+msgid "Please create a long connection profile first"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:162
+msgid "Please create an authentication server first"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:375
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:825
+msgid "Please enter a name."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:304
+msgid "Privileged Ops Secret"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:399
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:849
+msgid "Rename"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:360
+msgid "Rename Authentication Server"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:810
+msgid "Rename Long Connection Profile"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:929
+msgid ""
+"Requires aw-bpf DNS XDP (dns_ringbuf_portal). Patterns like .example.com; "
+"resolved IPs are added to the captive portal firewall (inet wifidogx), not "
+"inet awbpf."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:135
+msgid "Rule Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:152
+msgid "Select the authentication server to use for cloud authentication."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:175
+msgid ""
+"Select which long connection configuration to use. This option is always "
+"available regardless of authentication mode."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:610
+msgid ""
+"Service type code (7-9 digits) must be \"100\" for commercial internet "
+"service locations, \"2XX\" for non-commercial locations, or \"3XX\" for WiFi "
+"wireless collection terminals"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json:14
+msgid "Settings"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json:22
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:310
+msgid "TTL Value"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:203
+msgid "The ID of the device."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:258
+msgid "The ID of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:653
+msgid ""
+"The MAC address of the AP device. Must be 17 characters in format XX-XX-XX-"
+"XX-XX-XX (uppercase, separated by hyphens)."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:318
+msgid "The MAC address of the Anti NAT permit."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1007
+msgid "The MAC address of the group."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:956
+msgid "The MAC white list of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:311
+msgid "The TTL value of the gateway support."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:882
+msgid "The URI path for the WebSocket connection."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:420
+msgid "The URI path of the authentication server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:950
+msgid "The app white list of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:252
+msgid "The channel of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1023
+msgid "The description of the group."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:999
+msgid "The domain name of the group."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:405
+msgid "The domain or IP address of the authentication server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:197
+msgid "The external interface of the device, if bypass mode, do not choose."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:983
+msgid "The group is used by"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:891
+msgid "The hostname or IP address of the MQTT broker."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:864
+msgid "The hostname or IP address of the WebSocket server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:272
+msgid "The interval of the check(s)."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:264
+msgid "The ipv4 subnet of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:729
+msgid ""
+"The latitude coordinate using format: ±XXX.XXXXXX (3 integer digits + 6 "
+"decimal digits). Positive for North, negative for South."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:209
+msgid "The local portal url."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:222
+msgid "The log level of the apfree-wifidog."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:686
+msgid ""
+"The longitude coordinate using format: ±XXX.XXXXXX (3 integer digits + 6 "
+"decimal digits). Positive for East, negative for West."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:143
+msgid "The mode of the authentication server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:342
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:392
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:785
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:835
+msgid ""
+"The name \"%s\" already exists in Auth Server profiles. Please choose a "
+"different name."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:335
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:385
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:792
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:842
+msgid ""
+"The name \"%s\" already exists in Long Connection profiles. Please choose a "
+"different name."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:918
+msgid "The password for MQTT authentication."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:900
+msgid "The port of the MQTT broker."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:873
+msgid "The port of the WebSocket server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:412
+msgid "The port of the authentication server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:279
+msgid "The timeout of the client."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:943
+msgid "The trusted MAC addresses of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:936
+msgid "The trusted domains of the gateway"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:855
+msgid "The type of persistent connection to the remote management server."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:993
+msgid "The type of the group."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:623
+msgid ""
+"The unique identifier of the AP device. Must be 21 characters: 9-character "
+"vendor code + 12-character MAC address (uppercase)."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:581
+msgid "The unique identifier of the internet service location."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:909
+msgid "The username for MQTT authentication."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1015
+msgid "The wildcard domain of the group."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:963
+msgid "The wildcard domain white list of the gateway."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:935
+msgid "Trusted Domains"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:942
+msgid "Trusted MACs"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:928
+msgid "Trusted Wildcard Domains"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:166
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:188
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:265
+msgid "Unknown"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:484
+msgid "Unknown error"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:151
+msgid "Upload Rate"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:99
+msgid "Uptime"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:98
+msgid "Version"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:226
+msgid "Warning"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:856
+msgid "WebSocket (ws://)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:103
+msgid "WebSocket Connected"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:863
+msgid "WebSocket Hostname"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:881
+msgid "WebSocket Path"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:872
+msgid "WebSocket Port"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:857
+msgid "WebSocket Secure (wss://)"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:217
+msgid ""
+"When enabled, users can access the internet without portal authentication. "
+"Firewall redirect rules will not be created. Use this mode for pure traffic "
+"statistics without captive portal."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1015
+msgid "Wildcard Domain"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:996
+msgid "Wildcard Domain Group"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:962
+msgid "Wildcard White List"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:156
+msgid "Wired"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:285
+msgid "Wired Passed"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:286
+msgid "Wired users do not need to authenticate to access the internet."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:156
+msgid "Wireless"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:100
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:101
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:102
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:103
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:189
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json:3
+msgid "apfree-wifidog"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:11
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:30
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:83
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:90
+msgid "apfree-wifidog Status"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:122
+msgid ""
+"apfree-wifidog offers a stable and secure captive portal solution. For more "
+"details, see the %s."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:75
+msgid "create"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:224
+msgid "d"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:574
+msgid "fields filled successfully."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:983
+msgid "first."
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:225
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:239
+msgid "h"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:226
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:240
+msgid "m"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:983
+msgid "please remove it from"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:227
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:241
+msgid "s"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:50
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:67
+msgid "unspecified"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:479
+msgid "✓ Device ID generated:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:482
+msgid "✓ Location ID generated:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:502
+msgid "✓ Location obtained:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:476
+msgid "✓ WAN MAC address obtained:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:490
+msgid "✗ Cannot generate Device ID due to MAC error"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:486
+msgid "✗ Cannot generate Device ID without MAC address"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:489
+msgid "✗ Error getting WAN MAC address:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:508
+msgid "✗ Error getting location:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:485
+msgid "✗ Failed to get WAN MAC address:"
+msgstr ""
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:505
+msgid "✗ Failed to get location:"
+msgstr ""

--- a/applications/luci-app-apfree-wifidog/po/zh_Hans/apfree-wifidog.po
+++ b/applications/luci-app-apfree-wifidog/po/zh_Hans/apfree-wifidog.po
@@ -1,0 +1,1038 @@
+# Translations for LuCI
+# Copyright (C) 2022 Jo-Philipp Wich <jo@mein.io>
+# This file is distributed under the Apache License, Version 2.0.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: apfree-wifidog 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-03-16 00:00+0000\n"
+"PO-Revision-Date: 2025-03-16 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Chinese (Simplified)\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:622
+msgid "AP Device ID"
+msgstr "AP设备ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:632
+msgid "AP Device ID must be exactly 21 characters long"
+msgstr "AP设备ID必须是21个字符长"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:637
+msgid "AP Device ID must contain only uppercase letters and digits"
+msgstr "AP设备ID只能包含大写字母和数字"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:652
+msgid "AP MAC Address"
+msgstr "AP MAC地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:124
+msgid "Active Clients"
+msgstr "活跃客户端"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:134
+msgid "Advanced Settings"
+msgstr "高级设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:229
+msgid "Alert"
+msgstr "警报"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:317
+msgid "Anti NAT Permit MAC"
+msgstr "防NAT允许的MAC"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:121
+msgid "ApFree-WiFiDog"
+msgstr "门户认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:949
+msgid "App White List"
+msgstr "应用白名单"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:289
+msgid "Apple CNA"
+msgstr "苹果CNA"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:240
+msgid "Auth Enabled"
+msgstr "启用认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:101
+msgid "Auth Server Connected"
+msgstr "认证服务器连接"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:404
+msgid "Auth Server Hostname"
+msgstr "认证服务器主机名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:142
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:104
+msgid "Auth Server Mode"
+msgstr "认证服务器模式"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:189
+msgid "Auth Server Online"
+msgstr "认证服务器在线"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:411
+msgid "Auth Server Port"
+msgstr "认证服务器端口"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:132
+msgid "Auth Server Settings"
+msgstr "认证服务器设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:419
+msgid "Auth Server URI path"
+msgstr "认证服务器URI路径"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:136
+msgid "Authentication Location Settings"
+msgstr "认证位置设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:151
+msgid "Authentication Server"
+msgstr "认证服务器"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:184
+msgid "Authentication Server Status"
+msgstr "认证服务器状态"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:202
+msgid "Authentication Servers"
+msgstr "认证服务器列表"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:455
+msgid "Auto Fill"
+msgstr "自动填充"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:428
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:430
+msgid "Auto Fill All Fields"
+msgstr "自动填充所有字段"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:572
+msgid "Auto fill completed successfully! All fields have been filled."
+msgstr "自动填充成功！所有字段已填写。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:576
+msgid ""
+"Auto fill failed. No fields could be filled. Please check your network "
+"connection and try again."
+msgstr "自动填充失败。无法填写任何字段。请检查您的网络连接并重试。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:574
+msgid "Auto fill partially completed."
+msgstr "自动填充部分完成。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:429
+msgid ""
+"Automatically fill AP MAC address, Device ID, Location ID, Longitude, and "
+"Latitude"
+msgstr "自动填充 AP MAC地址、设备ID、位置ID、经度和纬度"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:130
+msgid "Basic Settings"
+msgstr "基本设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:146
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:264
+msgid "Bypass Auth"
+msgstr "旁认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:371
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:821
+msgid "Cancel"
+msgstr "取消"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:271
+msgid "Check Interval"
+msgstr "检查间隔"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:119
+msgid "Client Status"
+msgstr "客户端状态"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:278
+msgid "Client Timeout"
+msgstr "客户端超时"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:144
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:262
+msgid "Cloud Auth"
+msgstr "云认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:126
+msgid "Configuration"
+msgstr "配置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:138
+msgid "Connected Clients"
+msgstr "已连接客户端"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:854
+msgid "Connection Mode"
+msgstr "连接模式"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:148
+msgid "Connection Type"
+msgstr "连接类型"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:774
+msgid ""
+"Create one or more long connection profiles for cloud authentication and "
+"OpenClaw intelligent control channels."
+msgstr "创建长连接配置用于云认证和OpenClaw（龙虾）智能管控通道"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:228
+msgid "Critical"
+msgstr "严重"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:223
+msgid "Debug"
+msgstr "调试"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:203
+msgid "Device ID"
+msgstr "设备ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:539
+msgid "Device ID:"
+msgstr "设备ID："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:216
+msgid "Disable Portal Authentication"
+msgstr "禁用Portal认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:994
+msgid "Domain Group"
+msgstr "域名组"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:999
+msgid "Domain Name"
+msgstr "域名"
+
+# Client status UI additions
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:150
+msgid "Download Rate"
+msgstr "下载速率"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:230
+msgid "Emergency"
+msgstr "紧急"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:139
+msgid "Enable"
+msgstr "启用"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:299
+msgid "Enable Anti NAT"
+msgstr "启用防NAT"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:300
+msgid "Enable Anti NAT devices."
+msgstr "启用防NAT设备"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:290
+msgid "Enable Apple Captive Network Assistant."
+msgstr "启用苹果强制网络门户助手"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:295
+msgid "Enable JS redirect."
+msgstr "启用JS重定向"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:139
+msgid "Enable apfree-wifidog service."
+msgstr "启用apfree-wifidog门户认证服务"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:241
+msgid "Enable the authentication of the gateway."
+msgstr "启用网关的认证功能"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:362
+msgid "Enter a new unique name for this authentication server profile."
+msgstr "请输入认证服务器配置文件的新名称。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:812
+msgid "Enter a new unique name for this long connection profile."
+msgstr "请输入长连接配置文件的新名称。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:227
+msgid "Error"
+msgstr "错误"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:84
+msgid "Error getting status information:"
+msgstr "获取状态信息时出错："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:196
+msgid "External Interface"
+msgstr "外部接口"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:79
+msgid "Failed to get auth server status"
+msgstr "获取认证服务器状态失败"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:72
+msgid "Failed to get client status"
+msgstr "获取客户端状态失败"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:65
+msgid "Failed to get wifidogx status"
+msgstr "获取wifidogx状态失败"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:603
+msgid "First 6 digits must be valid administrative division code (GB/T 2260)"
+msgstr "前6位必须是有效的行政区划代码 (GB/T 2260)"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:251
+msgid "Gateway Channel"
+msgstr "网关通道"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:257
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:149
+msgid "Gateway ID"
+msgstr "网关 ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:245
+msgid "Gateway Name"
+msgstr "网关名称"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:133
+msgid "Gateway Settings"
+msgstr "网关设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:263
+msgid "Gateway Subnetv4"
+msgstr "网关IPv4子网"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:461
+msgid "Generating Device ID..."
+msgstr "生成设备ID..."
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:462
+msgid "Generating Location ID..."
+msgstr "生成位置ID..."
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:460
+msgid "Getting WAN MAC address..."
+msgstr "正在获取 WAN MAC 地址..."
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:457
+msgid "Getting device information and location data, please wait..."
+msgstr "正在获取设备信息和位置数据，请稍候..."
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:463
+msgid "Getting location coordinates..."
+msgstr "正在获取位置坐标..."
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:123
+msgid "GitHub project page"
+msgstr "GitHub 项目主页"
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/rpcd/acl.d/luci-app-apfree-wifidog.json:3
+msgid "Grant access to LuCI app apfree-wifidog"
+msgstr "授予访问 LuCI 应用 apfree-wifidog 的权限"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:969
+msgid "Group Define"
+msgstr "组定义"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1023
+msgid "Group Description"
+msgstr "组描述"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:993
+msgid "Group Type"
+msgstr "组类型"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:144
+msgid "IP Address"
+msgstr "IP地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:224
+msgid "Info"
+msgstr "信息"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:100
+msgid "Internet Connected"
+msgstr "互联网连接"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:294
+msgid "JS Filter"
+msgstr "JS过滤"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:645
+msgid ""
+"Last 12 characters must be a valid MAC address in uppercase hexadecimal "
+"format (e.g., 00E04C3B7D2F)"
+msgstr "最后12个字符必须是大写十六进制格式的有效MAC地址（例如：00E04C3B7D2F）"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:616
+msgid "Last 5 digits must be sequence number (00000-99999)"
+msgstr "最后5位必须是序列号 (00000-99999)"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:740
+msgid "Latitude must be a valid number"
+msgstr "纬度必须是一个有效的数字"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:744
+msgid "Latitude must be between -90.000000 and 90.000000"
+msgstr "纬度必须在 -90.000000 到 90.000000 之间"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:765
+msgid ""
+"Latitude must be in format ±XXX.XXXXXX (3 integer digits + 6 decimal digits, "
+"e.g., 39.900000 or -33.000000). Suggested format:"
+msgstr ""
+"纬度格式必须为 ±XXX.XXXXXX（3位整数 + 6位小数，例如：39.900000 或 "
+"-33.000000）。建议格式："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:542
+msgid "Latitude:"
+msgstr "纬度："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:145
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:263
+msgid "Local Auth"
+msgstr "本地认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:208
+msgid "Local Portal"
+msgstr "本地门户"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:305
+msgid ""
+"Local secret required for AWAS cloud platform to dynamically authorize "
+"remote OTA, reboot and system changes."
+msgstr ""
+"AWAS云端管理平台动态授权远程OTA升级、重启及系统配置变更所需的本地安全秘钥。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:581
+msgid "Location ID"
+msgstr "位置ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:588
+msgid "Location ID is required"
+msgstr "必须填写位置ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:592
+msgid "Location ID must be exactly 14 digits long"
+msgstr "位置ID必须是14位数字"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:597
+msgid "Location ID must contain only digits (0-9)"
+msgstr "位置ID只能包含数字 (0-9)"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:540
+msgid "Location ID:"
+msgstr "位置ID："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:504
+msgid "Location services unavailable"
+msgstr "定位服务不可用"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:221
+msgid "Log Level"
+msgstr "日志级别"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:174
+msgid "Long Connection Profile"
+msgstr "长连接配置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:131
+msgid "Long Connection Settings"
+msgstr "长连接设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:697
+msgid "Longitude must be a valid number"
+msgstr "经度必须是一个有效的数字"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:701
+msgid "Longitude must be between -180.000000 and 180.000000"
+msgstr "经度必须在 -180.000000 到 180.000000 之间"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:722
+msgid ""
+"Longitude must be in format ±XXX.XXXXXX (3 integer digits + 6 decimal "
+"digits, e.g., 123.230000 or -133.000000). Suggested format:"
+msgstr ""
+"经度格式必须为 ±XXX.XXXXXX（3位整数 + 6位小数，例如：123.230000 或 "
+"-133.000000）。建议格式："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:541
+msgid "Longitude:"
+msgstr "经度："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1007
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:145
+msgid "MAC Address"
+msgstr "MAC地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:538
+msgid "MAC Address:"
+msgstr "MAC地址："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:995
+msgid "MAC Group"
+msgstr "MAC地址组"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:955
+msgid "MAC White List"
+msgstr "MAC白名单"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:663
+msgid "MAC address must be exactly 17 characters long"
+msgstr "MAC地址必须是17个字符长"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:668
+msgid ""
+"MAC address must be in format XX-XX-XX-XX-XX-XX (uppercase hexadecimal "
+"separated by hyphens)"
+msgstr "MAC地址格式必须为 XX-XX-XX-XX-XX-XX（大写十六进制，由连字符分隔）"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:678
+msgid ""
+"MAC address should match the MAC address part (last 12 characters) in AP "
+"Device ID"
+msgstr "MAC地址应与 AP设备ID 中的 MAC地址部分（最后12个字符）匹配"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:858
+msgid "MQTT"
+msgstr "MQTT"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:102
+msgid "MQTT Connected"
+msgstr "MQTT 连接"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:890
+msgid "MQTT Hostname"
+msgstr "MQTT主机名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:917
+msgid "MQTT Password"
+msgstr "MQTT密码"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:899
+msgid "MQTT Port"
+msgstr "MQTT端口"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:859
+msgid "MQTT Secure"
+msgstr "MQTT安全"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:908
+msgid "MQTT Username"
+msgstr "MQTT用户名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:728
+msgid "Mobile AP Latitude"
+msgstr "移动AP纬度"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:685
+msgid "Mobile AP Longitude"
+msgstr "移动AP经度"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:365
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:815
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:146
+msgid "Name"
+msgstr "名称"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:100
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:101
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:102
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:103
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:189
+msgid "No"
+msgstr "否"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:225
+msgid "Notice"
+msgstr "通知"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:123
+msgid "Online Clients"
+msgstr "在线客户端"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:147
+msgid "Online Time"
+msgstr "在线时间"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:773
+msgid "Persistent Connection Profiles"
+msgstr "持久连接配置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:184
+msgid "Please create a long connection profile first"
+msgstr "请先创建一个长连接配置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:162
+msgid "Please create an authentication server first"
+msgstr "请先创建认证服务器"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:375
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:825
+msgid "Please enter a name."
+msgstr "请输入名称。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:304
+msgid "Privileged Ops Secret"
+msgstr "特权管控秘钥"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:399
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:849
+msgid "Rename"
+msgstr "重命名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:360
+msgid "Rename Authentication Server"
+msgstr "重命名认证服务器"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:810
+msgid "Rename Long Connection Profile"
+msgstr "重命名长连接配置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:929
+msgid ""
+"Requires aw-bpf DNS XDP (dns_ringbuf_portal). Patterns like .example.com; "
+"resolved IPs are added to the captive portal firewall (inet wifidogx), not "
+"inet awbpf."
+msgstr ""
+"依赖 aw-bpf 的 DNS XDP（dns_ringbuf_portal）。格式如 .example.com；解析到的 "
+"IP 写入门户防火墙 inet wifidogx，不会写入 inet awbpf。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:135
+msgid "Rule Settings"
+msgstr "规则设置"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:152
+msgid "Select the authentication server to use for cloud authentication."
+msgstr "选择用于云认证的认证服务器"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:175
+msgid ""
+"Select which long connection configuration to use. This option is always "
+"available regardless of authentication mode."
+msgstr "选择使用的长连接配置。该选项在所有认证模式下都可用。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:610
+msgid ""
+"Service type code (7-9 digits) must be \"100\" for commercial internet "
+"service locations, \"2XX\" for non-commercial locations, or \"3XX\" for WiFi "
+"wireless collection terminals"
+msgstr ""
+"服务类型代码（第7-9位）必须是：商业上网场所为\"100\"，非商业场所为\"2XX\"，或"
+"WiFi无线采集终端为\"3XX\""
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json:14
+msgid "Settings"
+msgstr "设置"
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json:22
+msgid "Status"
+msgstr "状态"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:310
+msgid "TTL Value"
+msgstr "TTL值"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:203
+msgid "The ID of the device."
+msgstr "设备的ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:258
+msgid "The ID of the gateway."
+msgstr "网关的ID（一般为设备的MAC地址）"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:653
+msgid ""
+"The MAC address of the AP device. Must be 17 characters in format XX-XX-XX-"
+"XX-XX-XX (uppercase, separated by hyphens)."
+msgstr ""
+"AP设备的MAC地址。必须为17个字符，格式为 XX-XX-XX-XX-XX-XX（大写，由连字符分"
+"隔）。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:318
+msgid "The MAC address of the Anti NAT permit."
+msgstr "防NAT允许的MAC地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1007
+msgid "The MAC address of the group."
+msgstr "组的MAC地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:956
+msgid "The MAC white list of the gateway."
+msgstr "网关的MAC白名单"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:311
+msgid "The TTL value of the gateway support."
+msgstr "网关支持的TTL值"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:882
+msgid "The URI path for the WebSocket connection."
+msgstr "WebSocket连接的URI路径。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:420
+msgid "The URI path of the authentication server."
+msgstr "认证服务器的URI路径"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:950
+msgid "The app white list of the gateway."
+msgstr "网关的应用白名单"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:252
+msgid "The channel of the gateway."
+msgstr "网关的通道"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1023
+msgid "The description of the group."
+msgstr "组的描述"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:999
+msgid "The domain name of the group."
+msgstr "组的域名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:405
+msgid "The domain or IP address of the authentication server."
+msgstr "认证服务器的域名或 IP 地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:197
+msgid "The external interface of the device, if bypass mode, do not choose."
+msgstr "设备的外部接口，如果是旁路模式，请不要选择"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:983
+msgid "The group is used by"
+msgstr "该组正被以下项使用："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:891
+msgid "The hostname or IP address of the MQTT broker."
+msgstr "MQTT代理的主机名或IP地址。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:864
+msgid "The hostname or IP address of the WebSocket server."
+msgstr "WebSocket服务器的主机名或IP地址。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:272
+msgid "The interval of the check(s)."
+msgstr "检查的时间间隔（秒）"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:264
+msgid "The ipv4 subnet of the gateway."
+msgstr "网关的IPv4子网"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:729
+msgid ""
+"The latitude coordinate using format: ±XXX.XXXXXX (3 integer digits + 6 "
+"decimal digits). Positive for North, negative for South."
+msgstr ""
+"纬度坐标，使用格式：±XXX.XXXXXX（3位整数 + 6位小数）。北纬为正，南纬为负。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:209
+msgid "The local portal url."
+msgstr "本地门户网址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:222
+msgid "The log level of the apfree-wifidog."
+msgstr "apfree-wifidog的日志级别"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:686
+msgid ""
+"The longitude coordinate using format: ±XXX.XXXXXX (3 integer digits + 6 "
+"decimal digits). Positive for East, negative for West."
+msgstr ""
+"经度坐标，使用格式：±XXX.XXXXXX（3位整数 + 6位小数）。东经为正，西经为负。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:143
+msgid "The mode of the authentication server."
+msgstr "认证服务器的模式。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:342
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:392
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:785
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:835
+msgid ""
+"The name \"%s\" already exists in Auth Server profiles. Please choose a "
+"different name."
+msgstr "名称\"%s\"已存在于认证服务器配置中，请选择其他名称。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:335
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:385
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:792
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:842
+msgid ""
+"The name \"%s\" already exists in Long Connection profiles. Please choose a "
+"different name."
+msgstr "名称\"%s\"已存在于长连接配置中，请选择其他名称。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:918
+msgid "The password for MQTT authentication."
+msgstr "MQTT认证的密码。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:900
+msgid "The port of the MQTT broker."
+msgstr "MQTT代理的端口。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:873
+msgid "The port of the WebSocket server."
+msgstr "WebSocket服务器的端口。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:412
+msgid "The port of the authentication server."
+msgstr "认证服务器的端口"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:279
+msgid "The timeout of the client."
+msgstr "客户端的超时时间"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:943
+msgid "The trusted MAC addresses of the gateway."
+msgstr "网关的信任MAC地址列表。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:936
+msgid "The trusted domains of the gateway"
+msgstr "网关的信任域名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:855
+msgid "The type of persistent connection to the remote management server."
+msgstr "到远程管理服务器的持久连接类型。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:993
+msgid "The type of the group."
+msgstr "组的类型"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:623
+msgid ""
+"The unique identifier of the AP device. Must be 21 characters: 9-character "
+"vendor code + 12-character MAC address (uppercase)."
+msgstr ""
+"AP设备的唯一标识符。必须是21个字符：9位厂商代码 + 12位MAC地址（大写）。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:581
+msgid "The unique identifier of the internet service location."
+msgstr "上网服务场所的唯一标识符。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:909
+msgid "The username for MQTT authentication."
+msgstr "MQTT认证的用户名。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1015
+msgid "The wildcard domain of the group."
+msgstr "组的通配符域名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:963
+msgid "The wildcard domain white list of the gateway."
+msgstr "网关的通配符域名白名单"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:935
+msgid "Trusted Domains"
+msgstr "信任的域名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:942
+msgid "Trusted MACs"
+msgstr "信任的MAC地址"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:928
+msgid "Trusted Wildcard Domains"
+msgstr "信任的通配符域名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:166
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:188
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:265
+msgid "Unknown"
+msgstr "未知"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:484
+msgid "Unknown error"
+msgstr "未知错误"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:151
+msgid "Upload Rate"
+msgstr "上传速率"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:99
+msgid "Uptime"
+msgstr "运行时间"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:98
+msgid "Version"
+msgstr "版本"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:226
+msgid "Warning"
+msgstr "警告"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:856
+msgid "WebSocket (ws://)"
+msgstr "WebSocket (ws://)"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:103
+msgid "WebSocket Connected"
+msgstr "WebSocket 连接"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:863
+msgid "WebSocket Hostname"
+msgstr "WebSocket主机名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:881
+msgid "WebSocket Path"
+msgstr "WebSocket路径"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:872
+msgid "WebSocket Port"
+msgstr "WebSocket端口"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:857
+msgid "WebSocket Secure (wss://)"
+msgstr "WebSocket加密 (wss://)"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:217
+msgid ""
+"When enabled, users can access the internet without portal authentication. "
+"Firewall redirect rules will not be created. Use this mode for pure traffic "
+"statistics without captive portal."
+msgstr ""
+"启用后，用户无需Portal认证即可上网。不会创建防火墙重定向规则。适用于纯流量统"
+"计场景，不需要强制Portal认证页面。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:1015
+msgid "Wildcard Domain"
+msgstr "通配符域名"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:996
+msgid "Wildcard Domain Group"
+msgstr "通配符域名组"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:962
+msgid "Wildcard White List"
+msgstr "通配符白名单"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:156
+msgid "Wired"
+msgstr "有线"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:285
+msgid "Wired Passed"
+msgstr "有线免认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:286
+msgid "Wired users do not need to authenticate to access the internet."
+msgstr "有线用户无需认证即可访问互联网"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:156
+msgid "Wireless"
+msgstr "无线"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:100
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:101
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:102
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:103
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:189
+msgid "Yes"
+msgstr "是"
+
+#: applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json:3
+msgid "apfree-wifidog"
+msgstr "门户认证"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:11
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:30
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:83
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:90
+msgid "apfree-wifidog Status"
+msgstr "apfree-wifidog 状态"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:122
+msgid ""
+"apfree-wifidog offers a stable and secure captive portal solution. For more "
+"details, see the %s."
+msgstr "apfree-wifidog 提供了一个稳定安全的门户认证解决方案。更多详情请参阅 %s。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:75
+msgid "create"
+msgstr "创建"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:224
+msgid "d"
+msgstr "天"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:574
+msgid "fields filled successfully."
+msgstr "个字段已填充。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:983
+msgid "first."
+msgstr "。"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:225
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:239
+msgid "h"
+msgstr "小时"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:226
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:240
+msgid "m"
+msgstr "分钟"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:983
+msgid "please remove it from"
+msgstr "，请先从以下项中移除："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:227
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx/status.js:241
+msgid "s"
+msgstr "秒"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:50
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:67
+msgid "unspecified"
+msgstr "未指定"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:479
+msgid "✓ Device ID generated:"
+msgstr "✓ 设备ID已生成："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:482
+msgid "✓ Location ID generated:"
+msgstr "✓ 位置ID已生成："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:502
+msgid "✓ Location obtained:"
+msgstr "✓ 已获取位置："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:476
+msgid "✓ WAN MAC address obtained:"
+msgstr "✓ 已获取 WAN MAC 地址："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:490
+msgid "✗ Cannot generate Device ID due to MAC error"
+msgstr "✗ 由于 MAC 错误，无法生成设备 ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:486
+msgid "✗ Cannot generate Device ID without MAC address"
+msgstr "✗ 没有 MAC 地址，无法生成设备 ID"
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:489
+msgid "✗ Error getting WAN MAC address:"
+msgstr "✗ 获取 WAN MAC 地址错误："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:508
+msgid "✗ Error getting location:"
+msgstr "✗ 获取位置错误："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:485
+msgid "✗ Failed to get WAN MAC address:"
+msgstr "✗ 获取 WAN MAC 地址失败："
+
+#: applications/luci-app-apfree-wifidog/htdocs/luci-static/resources/view/wifidogx.js:505
+msgid "✗ Failed to get location:"
+msgstr "✗ 获取位置失败："
+
+#~ msgid "apfree-wifidog offers a stable and secure captive portal solution."
+#~ msgstr "apfree-wifidog 提供了一个稳定安全的门户认证解决方案"

--- a/applications/luci-app-apfree-wifidog/root/usr/libexec/rpcd/luci.wifidogx
+++ b/applications/luci-app-apfree-wifidog/root/usr/libexec/rpcd/luci.wifidogx
@@ -1,0 +1,144 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+fetch_url() {
+	local url="$1"
+	if command -v uclient-fetch >/dev/null 2>&1; then
+		uclient-fetch -q --timeout=10 -O - "$url" 2>/dev/null
+	elif command -v curl >/dev/null 2>&1; then
+		curl -s --connect-timeout 10 --max-time 30 "$url" 2>/dev/null
+	elif command -v wget >/dev/null 2>&1; then
+		wget -q -T 10 -O - "$url" 2>/dev/null
+	fi
+}
+
+case "$1" in
+	list)
+		json_init
+		json_add_object "get_location"
+		json_close_object
+		json_add_object "get_wan_mac"
+		json_close_object
+		json_dump
+		;;
+	call)
+		case "$2" in
+			get_wan_mac)
+				# Method 1: Try to get WAN interface device name from UCI (newer OpenWrt)
+				wan_device=$(uci get network.wan.device 2>/dev/null)
+				
+				# Method 2: Try legacy ifname (older OpenWrt)
+				if [ -z "$wan_device" ]; then
+					wan_device=$(uci get network.wan.ifname 2>/dev/null)
+				fi
+				
+				# Method 3: Try to resolve logical interface to physical interface
+				if [ -z "$wan_device" ]; then
+					# Get the physical interface for logical wan interface
+					wan_device=$(ubus call network.interface.wan status 2>/dev/null | jsonfilter -e '@.l3_device' 2>/dev/null)
+					if [ -z "$wan_device" ]; then
+						wan_device=$(ubus call network.interface.wan status 2>/dev/null | jsonfilter -e '@.device' 2>/dev/null)
+					fi
+				fi
+				
+				# Method 4: Try to find WAN interface from routing table
+				if [ -z "$wan_device" ]; then
+					wan_device=$(ip route | grep default | awk '{print $5}' | head -n1)
+				fi
+				
+				# Method 5: Try common WAN interface names
+				if [ -z "$wan_device" ]; then
+					for iface in eth0 eth1 eth0.2 pppoe-wan; do
+						if [ -e "/sys/class/net/$iface" ]; then
+							wan_device="$iface"
+							break
+						fi
+					done
+				fi
+				
+				if [ -n "$wan_device" ] && [ -e "/sys/class/net/$wan_device" ]; then
+					# Get MAC address from the interface
+					mac_addr=$(cat "/sys/class/net/$wan_device/address" 2>/dev/null)
+					
+					if [ -n "$mac_addr" ] && [ "$mac_addr" != "00:00:00:00:00:00" ]; then
+						json_init
+						json_add_object "result"
+						json_add_string "status" "success"
+						json_add_string "mac" "$mac_addr"
+						json_add_string "interface" "$wan_device"
+						json_close_object
+						json_dump
+					else
+						json_init
+						json_add_object "result"
+						json_add_string "status" "fail"
+						json_add_string "message" "Failed to read valid MAC address from interface $wan_device"
+						json_close_object
+						json_dump
+					fi
+				else
+					json_init
+					json_add_object "result"
+					json_add_string "status" "fail"
+					json_add_string "message" "WAN interface not found"
+					json_close_object
+					json_dump
+				fi
+				;;
+			get_location)
+				# Try multiple location APIs for better reliability
+				
+				# First try ipapi.co (HTTPS, more reliable)
+				result=$(fetch_url "https://ipapi.co/json")
+				
+				if [ $? -eq 0 ] && [ -n "$result" ]; then
+					# Check if we got valid latitude/longitude
+					lat=$(echo "$result" | jsonfilter -e '@.latitude' 2>/dev/null)
+					lon=$(echo "$result" | jsonfilter -e '@.longitude' 2>/dev/null)
+					
+					if [ -n "$lat" ] && [ -n "$lon" ] && [ "$lat" != "null" ] && [ "$lon" != "null" ]; then
+						json_init
+						json_add_object "result"
+						json_add_string "status" "success"
+						json_add_string "lat" "$lat"
+						json_add_string "lon" "$lon"
+						json_close_object
+						json_dump
+						exit 0
+					fi
+				fi
+				
+				# If first API failed, try ipinfo.io as backup
+				result=$(fetch_url "https://ipinfo.io/json")
+				
+				if [ $? -eq 0 ] && [ -n "$result" ]; then
+					# Extract lat,lon from loc field (format: "lat,lon")
+					loc=$(echo "$result" | jsonfilter -e '@.loc' 2>/dev/null)
+					if [ -n "$loc" ] && [ "$loc" != "null" ]; then
+						lat=$(echo "$loc" | cut -d',' -f1)
+						lon=$(echo "$loc" | cut -d',' -f2)
+						
+						# Format response to match expected format
+						json_init
+						json_add_object "result"
+						json_add_string "status" "success"
+						json_add_string "lat" "$lat"
+						json_add_string "lon" "$lon"
+						json_close_object
+						json_dump
+						exit 0
+					fi
+				fi
+				
+				# If both APIs failed, return error instead of fallback
+				json_init
+				json_add_object "result"
+				json_add_string "status" "fail"
+				json_add_string "message" "Location services unavailable - please check network connection"
+				json_close_object
+				json_dump
+				;;
+		esac
+		;;
+esac

--- a/applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json
+++ b/applications/luci-app-apfree-wifidog/root/usr/share/luci/menu.d/luci-app-apfree-wifidog.json
@@ -1,0 +1,29 @@
+{
+	"admin/services/wifidogx": {
+		"title": "apfree-wifidog",
+		"order": 1,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		},
+		"depends": {
+			"acl": [ "luci-app-apfree-wifidog" ]
+		}
+	},
+	"admin/services/wifidogx/config": {
+		"title": "Settings",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "wifidogx"
+		}
+	},
+	"admin/services/wifidogx/status": {
+		"title": "Status",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "wifidogx/status"
+		}
+	}
+}

--- a/applications/luci-app-apfree-wifidog/root/usr/share/rpcd/acl.d/luci-app-apfree-wifidog.json
+++ b/applications/luci-app-apfree-wifidog/root/usr/share/rpcd/acl.d/luci-app-apfree-wifidog.json
@@ -1,0 +1,17 @@
+{
+	"luci-app-apfree-wifidog": {
+		"description": "Grant access to LuCI app apfree-wifidog",
+		"read": {
+			"ubus": {
+				"luci.wifidogx": [ "get_location", "get_wan_mac" ]
+			},
+			"file": {
+				"/usr/bin/wdctlx": [ "exec" ]
+			},
+			"uci": [ "wifidogx", "network" ]
+		},
+		"write": {
+			"uci": [ "wifidogx" ]
+		}
+	}
+}


### PR DESCRIPTION
Add LuCI web interface for apfree-wifidog captive portal gateway.

### Description
This package provides the LuCI web interface (`luci-app-apfree-wifidog`) for configuring and monitoring `apfree-wifidog`.

Features include:
- Configuration for auth server modes (cloud, local, bypass)
- Multi-server auth fallback and long connection configuration
- Gateway settings and interface binding
- Rule settings (domain, MAC, and wildcard whitelist groups)
- Real-time status monitoring view via wdctlx rpcd backend

Signed-off-by: Dengfeng Liu <liudf0716@gmail.com>
