### PR TITLE
luci-app-frp: avoid saving the same form twice

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -184,7 +184,7 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
+			return E('div', {},
 				E('fieldset', { class: 'cbi-section'}, [
 					E('p', { id: 'service_status' },
 						_('Collecting data ...'))

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -139,7 +139,7 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
+			return E('div', {},
 				E('fieldset', { class: 'cbi-section'}, [
 					E('p', { id: 'service_status' },
 						_('Collecting data ...'))


### PR DESCRIPTION
The frpc and frps status sections render a nested `cbi-map` without a bound form instance. LuCI resolves it to the enclosing map, so save and reset invoke that map twice. Concurrent saves can submit duplicate UCI delete requests and report resource not found.

## Pull request details

### Description

Remove the form marker from both status wrappers while retaining their fieldsets and polling. This addresses the duplicate-save cause of issue #7679 for both luci-app-frpc and luci-app-frps on `openwrt-25.12`.

### Screenshot or video of changes (if applicable)

Related to #7679. 

### Maintainer (preferred)

No maintainer is listed in either package Makefile. Feedback from @ysc3839 would be appreciated.

## Tested on

Original reported FRPS reproduction environment (OpenWrt downstream):

- **OpenWrt version:** ImmortalWrt 25.12.1
- **LuCI version:** ImmortalWrt branch `openwrt-25.12`, `26.187.07797~ed7692c`
- **Web browser:** Edge 152.0.4191.53

## Checklist
<!-- Place an x inside each [ ] and remove the empty space to check each item off the list. 
They should look like this: [x], otherwise leave them as is. -->
- [ ] _(Nice to have)_ Includes what Issue it closes (e.g. openwrt/luci#issue-number).
- [ ] _(Nice to have)_ Includes what it depends on (e.g. openwrt/packages#pr-number in sister repo).
